### PR TITLE
chore: 🔧 add service account and service type template for SigNoz charts

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -9,3 +9,6 @@ dependencies:
   - name: zookeeper
     repository: "https://charts.bitnami.com/bitnami"
     version: 6.0.0
+maintainers:
+  - name: signoz
+    email: hello@signoz.io

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -1,5 +1,6 @@
 # zookeeper auto purge interval prevents full disk space error
 zookeeper:
+  fullnameOverride: signoz-zookeeper
   autopurge:
     purgeInterval: 1
 

--- a/charts/signoz/templates/frontend/deployment.yaml
+++ b/charts/signoz/templates/frontend/deployment.yaml
@@ -14,10 +14,11 @@ spec:
       labels:
         {{- include "frontend.selectorLabels" . | nindent 8 }}
     spec:
-    {{- with .Values.frontend.imagePullSecrets }}
+      serviceAccountName: {{ include "frontend.serviceAccountName" . }}
+      {{- with .Values.frontend.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.frontend.podSecurityContext | nindent 8 }}
       volumes:

--- a/charts/signoz/templates/otel-collector-metrics/deployment.yaml
+++ b/charts/signoz/templates/otel-collector-metrics/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         {{- include "otelCollectorMetrics.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "otelCollectorMetrics.serviceAccountName" . }}
       initContainers:
         {{- if .Values.otelCollectorMetrics.initContainers.init.enabled }}
         - name: {{ include "otelCollectorMetrics.fullname" . }}-init

--- a/charts/signoz/templates/otel-collector-metrics/service.yaml
+++ b/charts/signoz/templates/otel-collector-metrics/service.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "otelCollectorMetrics.labels" . | nindent 4 }}
 spec:
+  type: {{ .Values.otelCollectorMetrics.serviceType }}
   ports:
   - name: otlp
     port: {{ .Values.otelCollectorMetrics.ports.openTelemetryReceiver }}

--- a/charts/signoz/templates/otel-collector-metrics/serviceaccount.yaml
+++ b/charts/signoz/templates/otel-collector-metrics/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.otelCollectorMetrics.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "otelCollectorMetrics.serviceAccountName" . }}
+  labels:
+    {{- include "otelCollectorMetrics.labels" . | nindent 4 }}
+  {{- with .Values.otelCollectorMetrics.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/signoz/templates/otel-collector/deployment.yaml
+++ b/charts/signoz/templates/otel-collector/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         {{- include "otelCollector.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "otelCollector.serviceAccountName" . }}
       initContainers:
         {{- if .Values.otelCollector.initContainers.init.enabled }}
         - name: {{ include "otelCollector.fullname" . }}-init

--- a/charts/signoz/templates/otel-collector/service.yaml
+++ b/charts/signoz/templates/otel-collector/service.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "otelCollector.labels" . | nindent 4 }}
 spec:
+  type: {{ .Values.otelCollector.serviceType }}
   ports:
   - name: otlp
     port: {{ .Values.otelCollector.ports.openTelemetryReceiver }}

--- a/charts/signoz/templates/otel-collector/serviceaccount.yaml
+++ b/charts/signoz/templates/otel-collector/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.otelCollector.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "otelCollector.serviceAccountName" . }}
+  labels:
+    {{- include "otelCollector.labels" . | nindent 4 }}
+  {{- with .Values.otelCollector.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/signoz/templates/query-service/statefulset.yaml
+++ b/charts/signoz/templates/query-service/statefulset.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         {{- include "queryService.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "queryService.serviceAccountName" . }}
       {{- if .Values.queryService.initContainers.init.enabled }}
       initContainers:
         {{- if .Values.queryService.initContainers.init.enabled }}

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -59,7 +59,7 @@ queryService:
 
   serviceAccount:
     # Specifies whether a service account should be created
-    create: false
+    create: true
     # Annotations to add to the service account
     annotations: {}
     # The name of the service account to use.
@@ -129,7 +129,7 @@ frontend:
 
   serviceAccount:
     # Specifies whether a service account should be created
-    create: false
+    create: true
     # Annotations to add to the service account
     annotations: {}
     # The name of the service account to use.
@@ -224,7 +224,6 @@ otelCollector:
     tag: "0.5.0"
     pullPolicy: IfNotPresent
 
-  serviceType: "ClusterIP"
   minReadySeconds: 5
   progressDeadlineSeconds: 120
   replicas: 1
@@ -244,6 +243,16 @@ otelCollector:
         endpoint: ping
         waitMessage: "waiting for clickhouseDB"
         doneMessage: "clickhouse ready, starting otel collector now"
+
+  serviceType: "ClusterIP"
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name:
 
   # ports used by the container
   ports:
@@ -367,7 +376,6 @@ otelCollectorMetrics:
     tag: "0.5.0"
     pullPolicy: IfNotPresent
   
-  serviceType: "ClusterIP"
   minReadySeconds: 5
   progressDeadlineSeconds: 120
   replicas: 1
@@ -387,6 +395,16 @@ otelCollectorMetrics:
         endpoint: ping
         waitMessage: "waiting for clickhouseDB"
         doneMessage: "clickhouse ready, starting otel collector metrics now"
+
+  serviceType: "ClusterIP"
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name:
 
   # ports used by the container
   ports:

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -6,6 +6,8 @@ nameOverride: ""
 
 clickhouse:
   fullnameOverride: signoz-clickhouse
+  zookeeper:
+    fullnameOverride: signoz-zookeeper
 
   # Based on the cloud, storage class for the persistent volume is selected.
   # We can pass anyone of ['aws','gcp','hcloud'].
@@ -375,7 +377,7 @@ otelCollectorMetrics:
     repository: signoz/otelcontribcol
     tag: "0.5.0"
     pullPolicy: IfNotPresent
-  
+
   minReadySeconds: 5
   progressDeadlineSeconds: 120
   replicas: 1

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -224,6 +224,7 @@ otelCollector:
     tag: "0.5.0"
     pullPolicy: IfNotPresent
 
+  serviceType: "ClusterIP"
   minReadySeconds: 5
   progressDeadlineSeconds: 120
   replicas: 1
@@ -365,10 +366,13 @@ otelCollectorMetrics:
     repository: signoz/otelcontribcol
     tag: "0.5.0"
     pullPolicy: IfNotPresent
+  
+  serviceType: "ClusterIP"
   minReadySeconds: 5
   progressDeadlineSeconds: 120
   replicas: 1
   ballastSizeMib: 683
+
   initContainers:
     init:
       enabled: true


### PR DESCRIPTION
- use overrode full name for zookeeper for ClickHouse
- use a service account for SigNoz charts
- add service type template for Otel Collector and metrics

Signed-off-by: Prashant Shahi <prashant@signoz.io>