### PR TITLE
Migrate to stable Ingress API

### DIFF
--- a/charts/signoz/templates/frontend/ingress.yaml
+++ b/charts/signoz/templates/frontend/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.frontend.ingress.enabled -}}
 {{- $fullName := include "frontend.fullname" . -}}
 {{- $svcPort := .Values.frontend.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1

--- a/charts/signoz/templates/frontend/ingress.yaml
+++ b/charts/signoz/templates/frontend/ingress.yaml
@@ -36,8 +36,15 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+              {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
networking.k8s.io/v1beta1 API versions of Ingress is no longer served as of v1.22

Migrate manifests and API clients to use the networking.k8s.io/v1 API version, available since v1.19.
