### PR TITLE
Allow Ingress Class Name frontend/query service

### DIFF
--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -92,6 +92,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `queryService.service.port`              | Query Service service port                                              | `8080`                            |
 | `queryService.service.internalPort`      | Query Service service internal port                                     | `8085`                            |
 | `queryService.ingress.enabled`           | Query Service ingress resource enabled                                  | `false`                           |
+| `queryService.ingress.className`         | Query Service ingress class name                                        | `""`                              |
 | `queryService.ingress.hosts`             | Query Service ingress virtual hosts                                     | See `values.yaml` for defaults    |
 | `queryService.ingress.annotations`       | Query Service ingress annotations                                       | `{}`                              |
 | `queryService.ingress.tls`               | Query Service ingress TLS settings                                      | `[]`                              |
@@ -120,6 +121,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `frontend.service.type`                  | Frontend service type                                                   | `ClusterIP`                       |
 | `frontend.service.port`                  | Frontend service port                                                   | `3301`                            |
 | `frontend.ingress.enabled`               | Frontend ingress resource enabled                                       | `false`                           |
+| `frontend.ingress.className`             | Frontend ingress class name                                             | `""`                              |
 | `frontend.ingress.hosts`                 | Frontend ingress virtual hosts                                          | See `values.yaml` for defaults    |
 | `frontend.ingress.annotations`           | Frontend ingress annotations                                            | `{}`                              |
 | `frontend.ingress.tls`                   | Frontend ingress TLS settings                                           | `[]`                              |
@@ -147,7 +149,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `alertmanager.securityContext`           | Security context for alertmanager node                                  | See `values.yaml` for defaults    |
 | `alertmanager.additionalPeers`           | Additional Peers for alertmanager                                       | `[]`                              |
 | `alertmanager.ingress.enabled`           | Alertmanager ingress resource enabled                                   | `false`                           |
-| `alertmanager.ingress.ingressClassName`  | Alertmanager ingress class name                                         | `""`                              |
+| `alertmanager.ingress.className`         | Alertmanager ingress class name                                         | `""`                              |
 | `alertmanager.ingress.hosts`             | Alertmanager ingress virtual hosts                                      | See `values.yaml` for defaults    |
 | `alertmanager.ingress.annotations`       | Alertmanager ingress annotations                                        | `{}`                              |
 | `alertmanager.ingress.tls`               | Alertmanager ingress TLS settings                                       | `[]`                              |

--- a/charts/signoz/templates/frontend/ingress.yaml
+++ b/charts/signoz/templates/frontend/ingress.yaml
@@ -18,6 +18,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: {{ .Values.frontend.ingress.classname }}
 {{- if .Values.frontend.ingress.tls }}
   tls:
   {{- range .Values.frontend.ingress.tls }}

--- a/charts/signoz/templates/query-service/ingress.yaml
+++ b/charts/signoz/templates/query-service/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: {{ .Values.frontend.ingress.classname }}
+  ingressClassName: {{ .Values.queryService.ingress.classname }}
 {{- if .Values.queryService.ingress.tls }}
   tls:
   {{- range .Values.queryService.ingress.tls }}

--- a/charts/signoz/templates/query-service/ingress.yaml
+++ b/charts/signoz/templates/query-service/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: {{ .Values.frontend.ingress.classname }}
 {{- if .Values.queryService.ingress.tls }}
   tls:
   {{- range .Values.queryService.ingress.tls }}

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -249,6 +249,7 @@ queryService:
 
   ingress:
     enabled: false
+    className: ""
     annotations:
       {}
       # kubernetes.io/ingress.class: nginx
@@ -332,6 +333,7 @@ frontend:
 
   ingress:
     enabled: false
+    className: ""
     annotations:
       {}
       # kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
I was deploying Signoz via Helm Chart however not being able to define ingress classname on the frontend/query service made it so that external DNS was unable to process that DNS. Allowing this would be super helpful :) 

