### PR TITLE
fix(frontend): change HTTP proxy protocol from 1.0 to 1.1 to stop 426 error

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.1.3
+version: 0.1.4
 appVersion: "0.9.2"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/templates/frontend/config.yaml
+++ b/charts/signoz/templates/frontend/config.yaml
@@ -30,10 +30,12 @@ data:
 
       location /api/alertmanager {
         proxy_pass http://{{ include "alertmanager.url" . }}/api/v2;
+        proxy_http_version 1.1;
       }
 
       location /api {
         proxy_pass http://{{ include "queryService.url" . }}/api;
+        proxy_http_version 1.1;
       }
 
       # redirect server error pages to the static page /50x.html


### PR DESCRIPTION
Default nginx proxy HTTP protocol is 1.0, which causes 426 Upgrade Errors when communicating with the query-service in an Istio environment.

Closes https://github.com/SigNoz/charts/issues/53

Signed-off-by: Nick Burrett <nick@sqrt.co.uk>