### PR TITLE
bump up clickhouse operator version

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for ClickHouse
 type: application
-version: 23.3.1
+version: 23.3.2
 appVersion: "22.4.5"
 icon: https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/website/images/logo-400x240.png
 dependencies:

--- a/charts/clickhouse/crds/clickhouse-operator-install.yaml
+++ b/charts/clickhouse/crds/clickhouse-operator-install.yaml
@@ -14,7 +14,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallations.clickhouse.altinity.com
   labels:
-    clickhouse.altinity.com/chop: 0.18.4
+    clickhouse.altinity.com/chop: 0.19.0
 spec:
   group: clickhouse.altinity.com
   scope: Namespaced
@@ -123,6 +123,9 @@ spec:
                 chop-date:
                   type: string
                   description: "ClickHouse operator build date"
+                chop-ip:
+                  type: string
+                  description: "IP address of the operator's pod which managed this CHI"
                 clusters:
                   type: integer
                   minimum: 0
@@ -190,6 +193,11 @@ spec:
                 pods:
                   type: array
                   description: "Pods"
+                  items:
+                    type: string
+                pod-ips:
+                  type: array
+                  description: "Pod IPs"
                   items:
                     type: string
                 fqdns:
@@ -661,6 +669,26 @@ spec:
                               volumeClaimTemplate:
                                 type: string
                                 description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                          schemaPolicy:
+                            type: object
+                            description: |
+                              describes how schema is propagated within replicas and shards
+                            properties:
+                              replica:
+                                type: string
+                                description: "how schema is propagated within a replica"
+                                enum:
+                                  # List SchemaPolicyReplicaXXX constants from model
+                                  - "None"
+                                  - "All"
+                              shard:
+                                type: string
+                                description: "how schema is propagated between shards"
+                                enum:
+                                  # List SchemaPolicyShardXXX constants from model
+                                  - "None"
+                                  - "All"
+                                  - "DistributedTablesOnly"
                           layout:
                             type: object
                             description: |
@@ -1348,7 +1376,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallationtemplates.clickhouse.altinity.com
   labels:
-    clickhouse.altinity.com/chop: 0.18.4
+    clickhouse.altinity.com/chop: 0.19.0
 spec:
   group: clickhouse.altinity.com
   scope: Namespaced
@@ -1457,6 +1485,9 @@ spec:
                 chop-date:
                   type: string
                   description: "ClickHouse operator build date"
+                chop-ip:
+                  type: string
+                  description: "IP address of the operator's pod which managed this CHI"
                 clusters:
                   type: integer
                   minimum: 0
@@ -1524,6 +1555,11 @@ spec:
                 pods:
                   type: array
                   description: "Pods"
+                  items:
+                    type: string
+                pod-ips:
+                  type: array
+                  description: "Pod IPs"
                   items:
                     type: string
                 fqdns:
@@ -1995,6 +2031,26 @@ spec:
                               volumeClaimTemplate:
                                 type: string
                                 description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                          schemaPolicy:
+                            type: object
+                            description: |
+                              describes how schema is propagated within replicas and shards
+                            properties:
+                              replica:
+                                type: string
+                                description: "how schema is propagated within a replica"
+                                enum:
+                                  # List SchemaPolicyReplicaXXX constants from model
+                                  - "None"
+                                  - "All"
+                              shard:
+                                type: string
+                                description: "how schema is propagated between shards"
+                                enum:
+                                  # List SchemaPolicyShardXXX constants from model
+                                  - "None"
+                                  - "All"
+                                  - "DistributedTablesOnly"
                           layout:
                             type: object
                             description: |
@@ -2679,7 +2735,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clickhouseoperatorconfigurations.clickhouse.altinity.com
   labels:
-    clickhouse.altinity.com/chop: 0.18.4
+    clickhouse.altinity.com/chop: 0.19.0
 spec:
   group: clickhouse.altinity.com
   scope: Namespaced
@@ -2788,6 +2844,9 @@ spec:
                         password:
                           type: string
                           description: "ClickHouse password to be used by operator to connect to ClickHouse instances, deprecated, use chCredentialsSecretName"
+                        rootCA:
+                          type: string
+                          description: "Root certificate authority that clients use when verifying server certificates. Used for https connection to ClickHouse"
                         secret:
                           type: object
                           properties:
@@ -2976,7 +3035,7 @@ metadata:
   name: clickhouse-operator
   namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.4
+    clickhouse.altinity.com/chop: 0.19.0
 ---
 # Template Parameters:
 #
@@ -2993,7 +3052,7 @@ metadata:
   name: clickhouse-operator-kube-system
   #namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.4
+    clickhouse.altinity.com/chop: 0.19.0
 rules:
 - apiGroups:
     - ""
@@ -3150,7 +3209,7 @@ metadata:
   name: clickhouse-operator-kube-system
   #namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.4
+    clickhouse.altinity.com/chop: 0.19.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -3172,13 +3231,16 @@ metadata:
   name: etc-clickhouse-operator-files
   namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.4
+    clickhouse.altinity.com/chop: 0.19.0
     app: clickhouse-operator
 data:
   config.yaml: |
     # IMPORTANT
-    # This file is auto-generated from deploy/builder/templates-config.
-    # It will be overwritten upon next sources build.
+    # This file is auto-generated
+    # Do not edit this file - all changes would be lost
+    # Edit appropriate template in the following folder:
+    # deploy/builder/templates-config
+    # IMPORTANT
     #
     # Template parameters available:
     #   watchNamespaces
@@ -3403,7 +3465,7 @@ metadata:
   name: etc-clickhouse-operator-confd-files
   namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.4
+    clickhouse.altinity.com/chop: 0.19.0
     app: clickhouse-operator
 data:
 ---
@@ -3419,10 +3481,16 @@ metadata:
   name: etc-clickhouse-operator-configd-files
   namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.4
+    clickhouse.altinity.com/chop: 0.19.0
     app: clickhouse-operator
 data:
   01-clickhouse-01-listen.xml: |
+    <!-- IMPORTANT -->
+    <!-- This file is auto-generated -->
+    <!-- Do not edit this file - all changes would be lost -->
+    <!-- Edit appropriate template in the following folder: -->
+    <!-- deploy/builder/templates-config -->
+    <!-- IMPORTANT -->
     <yandex>
         <!-- Listen wildcard address to allow accepting connections from other containers and host network. -->
         <listen_host>::</listen_host>
@@ -3431,6 +3499,12 @@ data:
     </yandex>
 
   01-clickhouse-02-logger.xml: |
+    <!-- IMPORTANT -->
+    <!-- This file is auto-generated -->
+    <!-- Do not edit this file - all changes would be lost -->
+    <!-- Edit appropriate template in the following folder: -->
+    <!-- deploy/builder/templates-config -->
+    <!-- IMPORTANT -->
     <yandex>
         <logger>
             <!-- Possible levels: https://github.com/pocoproject/poco/blob/develop/Foundation/include/Poco/Logger.h#L105 -->
@@ -3445,6 +3519,12 @@ data:
     </yandex>
 
   01-clickhouse-03-query_log.xml: |
+    <!-- IMPORTANT -->
+    <!-- This file is auto-generated -->
+    <!-- Do not edit this file - all changes would be lost -->
+    <!-- Edit appropriate template in the following folder: -->
+    <!-- deploy/builder/templates-config -->
+    <!-- IMPORTANT -->
     <yandex>
         <query_log replace="1">
             <database>system</database>
@@ -3456,6 +3536,12 @@ data:
     </yandex>
 
   01-clickhouse-04-part_log.xml: |
+    <!-- IMPORTANT -->
+    <!-- This file is auto-generated -->
+    <!-- Do not edit this file - all changes would be lost -->
+    <!-- Edit appropriate template in the following folder: -->
+    <!-- deploy/builder/templates-config -->
+    <!-- IMPORTANT -->
     <yandex>
         <part_log replace="1">
             <database>system</database>
@@ -3478,7 +3564,7 @@ metadata:
   name: etc-clickhouse-operator-templatesd-files
   namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.4
+    clickhouse.altinity.com/chop: 0.19.0
     app: clickhouse-operator
 data:
   001-templates.json.example: |
@@ -3578,17 +3664,21 @@ metadata:
   name: etc-clickhouse-operator-usersd-files
   namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.4
+    clickhouse.altinity.com/chop: 0.19.0
     app: clickhouse-operator
 data:
   01-clickhouse-user.xml: |
+    <!-- IMPORTANT -->
+    <!-- This file is auto-generated -->
+    <!-- Do not edit this file - all changes would be lost -->
+    <!-- Edit appropriate template in the following folder: -->
+    <!-- deploy/builder/templates-config -->
+    <!-- IMPORTANT -->
     <yandex>
         <users>
             <clickhouse_operator>
                 <networks>
                     <ip>127.0.0.1</ip>
-                    <ip>0.0.0.0/0</ip>
-                    <ip>::/0</ip>
                 </networks>
                 <password_sha256_hex>716b36073a90c6fe1d445ac1af85f4777c5b7a155cea359961826a030513e448</password_sha256_hex>
                 <profile>clickhouse_operator</profile>
@@ -3605,6 +3695,12 @@ data:
     </yandex>
 
   02-clickhouse-default-profile.xml: |
+    <!-- IMPORTANT -->
+    <!-- This file is auto-generated -->
+    <!-- Do not edit this file - all changes would be lost -->
+    <!-- Edit appropriate template in the following folder: -->
+    <!-- deploy/builder/templates-config -->
+    <!-- IMPORTANT -->
     <yandex>
       <profiles>
         <default>
@@ -3616,6 +3712,12 @@ data:
       </profiles>
     </yandex>
   03-database-ordinary.xml: |
+    <!-- IMPORTANT -->
+    <!-- This file is auto-generated -->
+    <!-- Do not edit this file - all changes would be lost -->
+    <!-- Edit appropriate template in the following folder: -->
+    <!-- deploy/builder/templates-config -->
+    <!-- IMPORTANT -->
     <!--  Remove it for ClickHouse versions before 20.4 -->
     <yandex>
         <profiles>
@@ -3629,8 +3731,10 @@ data:
 #
 # NAMESPACE=kube-system
 # COMMENT=
-# OPERATOR_IMAGE=altinity/clickhouse-operator:0.18.4
-# METRICS_EXPORTER_IMAGE=altinity/metrics-exporter:0.18.4
+# OPERATOR_IMAGE=altinity/clickhouse-operator:0.19.0
+# OPERATOR_IMAGE_PULL_POLICY=Always
+# METRICS_EXPORTER_IMAGE=altinity/metrics-exporter:0.19.0
+# METRICS_EXPORTER_IMAGE_PULL_POLICY=Always
 #
 # Setup Deployment for clickhouse-operator
 # Deployment would be created in kubectl-specified namespace
@@ -3640,7 +3744,7 @@ metadata:
   name: clickhouse-operator
   namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.4
+    clickhouse.altinity.com/chop: 0.19.0
     app: clickhouse-operator
 spec:
   replicas: 1
@@ -3652,8 +3756,8 @@ spec:
       labels:
         app: clickhouse-operator
       annotations:
-        prometheus.io/port: '8888'
-        prometheus.io/scrape: 'true'
+        signoz.io/port: '8888'
+        signoz.io/scrape: 'true'
     spec:
       serviceAccountName: clickhouse-operator
       volumes:
@@ -3674,7 +3778,7 @@ spec:
             name: etc-clickhouse-operator-usersd-files
       containers:
         - name: clickhouse-operator
-          image: altinity/clickhouse-operator:0.18.4
+          image: altinity/clickhouse-operator:0.19.0
           imagePullPolicy: Always
           volumeMounts:
             - name: etc-clickhouse-operator-folder
@@ -3739,7 +3843,7 @@ spec:
                   resource: limits.memory
 
         - name: metrics-exporter
-          image: altinity/metrics-exporter:0.18.4
+          image: altinity/metrics-exporter:0.19.0
           imagePullPolicy: Always
           volumeMounts:
             - name: etc-clickhouse-operator-folder
@@ -3772,7 +3876,7 @@ metadata:
   name: clickhouse-operator-metrics
   namespace: kube-system
   labels:
-    clickhouse.altinity.com/chop: 0.18.4
+    clickhouse.altinity.com/chop: 0.19.0
     app: clickhouse-operator
 spec:
   ports:


### PR DESCRIPTION
- upgrade clickhouse operator to 0.19.0
- use `signoz.io/*` annotations for scraping operator metrics

Signed-off-by: Prashant Shahi <prashant@signoz.io>
