### PR TITLE
storage class related improvements and other changes

### DIFF
--- a/charts/clickhouse/templates/_helper.tpl
+++ b/charts/clickhouse/templates/_helper.tpl
@@ -49,7 +49,7 @@ Set zookeeper port
 Return the proper clickhouse image name
 */}}
 {{- define "clickhouse.image" -}}
-{{- $registryName := .Values.image.registry -}}
+{{- $registryName := default .Values.image.registry .Values.global.image.registry -}}
 {{- $repositoryName := .Values.image.repository -}}
 {{- $tag := .Values.image.tag | toString -}}
 {{- if $registryName -}}

--- a/charts/clickhouse/templates/clickhouse-instance.yaml
+++ b/charts/clickhouse/templates/clickhouse-instance.yaml
@@ -185,12 +185,17 @@ spec:
     volumeClaimTemplates:
       - name: data-volumeclaim-template
         spec:
-          {{- if .Values.persistence.storageClass }}
-          storageClassName: {{ .Values.persistence.storageClass }}
-          {{- end }}
           accessModes:
-            - ReadWriteOnce
+            {{- toYaml .Values.persistence.accessModes | nindent 10 }}
           resources:
             requests:
-              storage: {{ .Values.persistence.size | quote }}
+              storage: {{ .Values.persistence.size }}
+        {{- $storageClass := default .Values.persistence.storageClass .Values.global.storageClass -}}
+        {{- if $storageClass -}}
+        {{- if (eq "-" $storageClass) }}
+          storageClassName: ""
+        {{- else }}
+          storageClassName: {{ $storageClass }}
+        {{- end -}}
+        {{- end }}
     {{- end }}

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -1,5 +1,8 @@
 ---
 global:
+  image:
+    # -- Overrides the Docker registry globally for all images
+    registry: null
   # -- Overrides the storage class for all PVC with persistence enabled.
   storageClass: &GLOBAL_SC null
 

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -1,3 +1,8 @@
+---
+global:
+  # -- Overrides the storage class for all PVC with persistence enabled.
+  storageClass: &GLOBAL_SC null
+
 # -- Cloud service being deployed on (example: `aws`, `azure`, `gcp`, `hcloud`, `other`).
 # Based on the cloud, storage class for the persistent volume is selected.
 # When set to 'aws' or 'gcp', new expandible storage class is created.
@@ -41,6 +46,35 @@ zookeeper:
 
   # -- replica count for zookeeper
   replicaCount: 1
+
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    # -- Enable ZooKeeper data persistence using PVC. If false, use emptyDir
+    #
+    enabled: true
+    # -- Name of an existing PVC to use (only when deploying a single replica)
+    #
+    existingClaim: ""
+    # -- PVC Storage Class for ZooKeeper data volume
+    # If defined, storageClassName: <storageClass>
+    # If set to "-", storageClassName: "", which disables dynamic provisioning
+    # If undefined (the default) or set to null, no storageClassName spec is
+    #   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    #   GKE, AWS & OpenStack)
+    #
+    storageClass: *GLOBAL_SC
+
+    # -- PVC Access modes
+    accessModes:
+      - ReadWriteOnce
+
+    # -- PVC Storage Request for ZooKeeper data volume
+    size: 8Gi
+
+    # -- Annotations for the PVC
+    annotations: {}
 
 ###
 ###
@@ -148,11 +182,15 @@ persistence:
 
   # -- Persistent Volume Storage Class to use.
   # If defined, `storageClassName: <storageClass>`.
-  # If set to `storageClassName: ""`, disables dynamic provisioning.
+  # If set to "-", `storageClassName: ""`, which disables dynamic provisioning
   # If undefined (the default) or set to `null`, no storageClassName spec is
   # set, choosing the default provisioner.
   #
   storageClass: null
+
+  # -- Access Modes for persistent volume
+  accessModes:
+    - ReadWriteOnce
 
   # -- Persistent Volume size
   size: 20Gi

--- a/charts/signoz/templates/_helpers.tpl
+++ b/charts/signoz/templates/_helpers.tpl
@@ -90,7 +90,7 @@ Return the initContainers image name
 Return the proper queryService image name
 */}}
 {{- define "queryService.image" -}}
-{{- $registryName := .Values.queryService.image.registry -}}
+{{- $registryName := default .Values.queryService.image.registry .Values.global.image.registry -}}
 {{- $repositoryName := .Values.queryService.image.repository -}}
 {{- $tag := .Values.queryService.image.tag | toString -}}
 {{- if $registryName -}}
@@ -173,7 +173,7 @@ Create the name of the service account to use
 Return the proper frontend image name
 */}}
 {{- define "frontend.image" -}}
-{{- $registryName := .Values.frontend.image.registry -}}
+{{- $registryName := default .Values.frontend.image.registry .Values.global.image.registry -}}
 {{- $repositoryName := .Values.frontend.image.repository -}}
 {{- $tag := .Values.frontend.image.tag | toString -}}
 {{- if $registryName -}}
@@ -263,7 +263,7 @@ Return the initContainers image name
 Return the proper otelCollector image name
 */}}
 {{- define "alertmanager.image" -}}
-{{- $registryName := .Values.alertmanager.image.registry -}}
+{{- $registryName := default .Values.alertmanager.image.registry .Values.global.image.registry -}}
 {{- $repositoryName := .Values.alertmanager.image.repository -}}
 {{- $tag := .Values.alertmanager.image.tag | toString -}}
 {{- if $registryName -}}
@@ -339,7 +339,7 @@ Return the initContainers image name
 Return the proper otelCollector image name
 */}}
 {{- define "otelCollector.image" -}}
-{{- $registryName := .Values.otelCollector.image.registry -}}
+{{- $registryName := default .Values.otelCollector.image.registry .Values.global.image.registry -}}
 {{- $repositoryName := .Values.otelCollector.image.repository -}}
 {{- $tag := .Values.otelCollector.image.tag | toString -}}
 {{- if $registryName -}}
@@ -408,7 +408,7 @@ Return the initContainers image name
 Return the proper otelCollectorMetrics image name
 */}}
 {{- define "otelCollectorMetrics.image" -}}
-{{- $registryName := .Values.otelCollectorMetrics.image.registry -}}
+{{- $registryName := default .Values.otelCollectorMetrics.image.registry .Values.global.image.registry -}}
 {{- $repositoryName := .Values.otelCollectorMetrics.image.repository -}}
 {{- $tag := .Values.otelCollectorMetrics.image.tag | toString -}}
 {{- if $registryName -}}

--- a/charts/signoz/templates/alertmanager/statefulset.yaml
+++ b/charts/signoz/templates/alertmanager/statefulset.yaml
@@ -151,13 +151,14 @@ spec:
         resources:
           requests:
             storage: {{ .Values.alertmanager.persistence.size }}
-      {{- if .Values.alertmanager.persistence.storageClass }}
-      {{- if (eq "-" .Values.alertmanager.persistence.storageClass) }}
+      {{- $storageClass := default .Values.alertmanager.persistence.storageClass .Values.global.storageClass -}}
+      {{- if $storageClass -}}
+      {{- if (eq "-" $storageClass) }}
         storageClassName: ""
       {{- else }}
-        storageClassName: {{ .Values.alertmanager.persistence.storageClass }}
+        storageClassName: {{ $storageClass }}
+      {{- end -}}
       {{- end }}
-  {{- end }}
   {{- else }}
         - name: storage
           emptyDir: {}

--- a/charts/signoz/templates/query-service/statefulset.yaml
+++ b/charts/signoz/templates/query-service/statefulset.yaml
@@ -98,11 +98,22 @@ spec:
       - name: dashboards
         emptyDir: {}
 
+{{- if .Values.queryService.persistence.enabled }}
   volumeClaimTemplates:
-  - metadata:
-      name: signoz-db
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: 1Gi
+    - metadata:
+        name: signoz-db
+      spec:
+        accessModes:
+          {{- toYaml .Values.queryService.persistence.accessModes | nindent 10 }}
+        resources:
+          requests:
+            storage: {{ .Values.queryService.persistence.size }}
+      {{- $storageClass := default .Values.queryService.persistence.storageClass .Values.global.storageClass -}}
+      {{- if $storageClass -}}
+      {{- if (eq "-" $storageClass) }}
+        storageClassName: ""
+      {{- else }}
+        storageClassName: {{ $storageClass }}
+      {{- end -}}
+      {{- end -}}
+{{- end }}

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1,3 +1,8 @@
+---
+global:
+  # -- Overrides the storage class for all PVC with persistence enabled.
+  storageClass: null
+
 # -- SigNoz chart full name override
 fullnameOverride: ""
 
@@ -110,7 +115,7 @@ clickhouse:
     - "192.168.0.0/16"
 
   persistence:
-    # -- Enable data persistence using PVC.
+    # -- Enable data persistence using PVC for ClickHouseDB data.
     enabled: true
 
     # -- Use a manually managed Persistent Volume and Claim.
@@ -120,11 +125,15 @@ clickhouse:
 
     # -- Persistent Volume Storage Class to use.
     # If defined, `storageClassName: <storageClass>`.
-    # If set to `storageClassName: ""`, disables dynamic provisioning.
+    # If set to "-", `storageClassName: ""`, which disables dynamic provisioning
     # If undefined (the default) or set to `null`, no storageClassName spec is
-    # set, choosing the default provisioneralertmanager
+    # set, choosing the default provisioner.
     #
     storageClass: null
+
+    # -- Access Modes for persistent volume
+    accessModes:
+      - ReadWriteOnce
 
     # -- Persistent Volume size
     size: 20Gi
@@ -321,6 +330,26 @@ queryService:
   tolerations: []
 
   affinity: {}
+
+  persistence:
+    # -- Enable data persistence using PVC for SQLiteDB data.
+    enabled: true
+
+    # -- Persistent Volume Storage Class to use.
+    # If defined, `storageClassName: <storageClass>`.
+    # If set to "-", `storageClassName: ""`, which disables dynamic provisioning
+    # If undefined (the default) or set to `null`, no storageClassName spec is
+    # set, choosing the default provisioner.
+    #
+    storageClass: null
+
+    # -- Access Modes for persistent volume
+    accessModes:
+      - ReadWriteOnce
+
+    # -- Persistent Volume size
+    size: 1Gi
+
 
 # Default values for frontend
 frontend:
@@ -563,16 +592,22 @@ alertmanager:
     # minAvailable: 1
 
   persistence:
+    # -- Enable data persistence using PVC for Alertmanager data.
     enabled: true
-    ## Persistent Volume Storage Class
-    ## If defined, storageClassName: <storageClass>
-    ## If set to "-", storageClassName: "", which disables dynamic provisioning
-    ## If undefined (the default) or set to null, no storageClassName spec is
-    ## set, choosing the default provisioner.
-    ##
-    # storageClass: "-"
+
+    # -- Persistent Volume Storage Class to use.
+    # If defined, `storageClassName: <storageClass>`.
+    # If set to "-", `storageClassName: ""`, which disables dynamic provisioning
+    # If undefined (the default) or set to `null`, no storageClassName spec is
+    # set, choosing the default provisioner.
+    #
+    storageClass: null
+
+    # -- Access Modes for persistent volume
     accessModes:
       - ReadWriteOnce
+
+    # -- Persistent Volume size
     size: 100Mi
 
   ## Using the config, alertmanager.yml file is created.

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1,5 +1,8 @@
 ---
 global:
+  image:
+    # -- Overrides the Docker registry globally for all images
+    registry: null
   # -- Overrides the storage class for all PVC with persistence enabled.
   storageClass: null
 


### PR DESCRIPTION
This PR resolves the issue which was observered when users tried to install SigNoz on K8s cluster without a default storage class.

- storage class global value which applies to all PVC
- add global value for image registry

**Example**

```bash
$ kubectl get storageclass
NAME       PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
standard   rancher.io/local-path   Delete          WaitForFirstConsumer   false                  48m
```

As we can see above, we do not have any default storage class.
So, we will use the following `override-values.yaml`:

```yaml
global:
  storageClass: standard

clickhouse:
  cloud: others
```

Signed-off-by: Prashant Shahi <prashant@signoz.io>
