### PR TITLE
add nodePort feature to _helpers.tpl

### DIFF
--- a/charts/signoz/templates/_helpers.tpl
+++ b/charts/signoz/templates/_helpers.tpl
@@ -468,6 +468,9 @@ nodePort: null
   {{ include "service.ifClusterIP" $serviceType }}
   targetPort: {{ $key }}
   protocol: {{ $port.protocol }}
+  {{- if $serviceType := "nodePort" }}
+  nodePort: {{ $port.nodePort }}
+  {{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -554,12 +554,6 @@ frontend:
     #    hosts:
     #      - frontend.domain.com
 
-  # -- Nginx congifmap customize for new parameters
-  customConfig: false
-  # customConfig: true
-  # data: |
-  #   large_client_header_buffers 4 256k;
-
   # adjust the resource requests and limit as necessary
   resources:
     requests:

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -554,6 +554,12 @@ frontend:
     #    hosts:
     #      - frontend.domain.com
 
+  # -- Nginx congifmap customize for new parameters
+  customConfig: false
+  # customConfig: true
+  # data: |
+  #   large_client_header_buffers 4 256k;
+
   # adjust the resource requests and limit as necessary
   resources:
     requests:

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -861,6 +861,8 @@ otelCollector:
       servicePort: 4317
       # -- Host port for OTLP gRPC
       hostPort: 4317
+      # -- Node port for OTLP gRPC
+      nodePort: ""
       # -- Protocol to use for OTLP gRPC
       protocol: TCP
     otlp-http:
@@ -872,6 +874,8 @@ otelCollector:
       servicePort: 4318
       # -- Host port for OTLP HTTP
       hostPort: 4318
+      # -- Node port for OTLP HTTP
+      nodePort: ""
       # -- Protocol to use for OTLP HTTP
       protocol: TCP
     jaeger-compact:
@@ -883,6 +887,8 @@ otelCollector:
       servicePort: 6831
       # -- Host port for Jaeger Compact
       hostPort: 6831
+      # -- Node port for Jaeger Compact
+      nodePort: ""
       # -- Protocol to use for Jaeger Compact
       protocol: UDP
     jaeger-thrift:
@@ -894,6 +900,8 @@ otelCollector:
       servicePort: 14268
       # -- Host port for Jaeger Thrift
       hostPort: 14268
+      # -- Node port for Jaeger Thrift
+      nodePort: ""
       # -- Protocol to use for Jaeger Thrift
       protocol: TCP
     jaeger-grpc:
@@ -905,6 +913,8 @@ otelCollector:
       servicePort: 14250
       # -- Host port for Jaeger gRPC
       hostPort: 14250
+      # -- Node port for Jaeger gRPC
+      nodePort: ""
       # -- Protocol to use for Jaeger gRPC
       protocol: TCP
     zipkin:
@@ -916,6 +926,8 @@ otelCollector:
       servicePort: 9411
       # -- Host port for Zipkin
       hostPort: 9411
+      # -- Node port for Zipkin
+      nodePort: ""
       # -- Protocol to use for Zipkin
       protocol: TCP
     prometheus-metrics:
@@ -927,6 +939,8 @@ otelCollector:
       servicePort: 8889
       # -- Host port for SigNoz exported prometheus metrics
       hostPort: 8889
+      # -- Node port for SigNoz exported prometheus metrics
+      nodePort: ""
       # -- Protocol to use for SigNoz exported prometheus metrics
       protocol: TCP
     metrics:
@@ -938,6 +952,8 @@ otelCollector:
       servicePort: 8888
       # -- Host port for internal metrics
       hostPort: 8888
+      # -- Node port for internal metrics
+      nodePort: ""
       # -- Protocol to use for internal metrics
       protocol: TCP
     zpages:
@@ -949,6 +965,8 @@ otelCollector:
       servicePort: 55679
       # -- Host port for Zpages
       hostPort: 55679
+      # -- Node port for Zpages
+      nodePort: ""
       # -- Protocol to use for Zpages
       protocol: TCP
 


### PR DESCRIPTION
Hi,

We were facing issue when we defined otelCollector's service type as NodePort. We were desiring to add nodePort statically but it was assigned to ports dynamically. So I added feature with @canerturkaslan to the _helper.tpl as you can see from our commit. 

For example if you want to assign static nodePort you can give values.yaml like below:

```yaml
otelCollector:
  service:
    type: NodePort
  ports:
    otlp:
      nodePort: 30900
      targetPort: otlp
      protocol: TCP
```
