### PR TITLE
Frontend nginx cm customize feature

### DIFF
--- a/charts/signoz/templates/_helpers.tpl
+++ b/charts/signoz/templates/_helpers.tpl
@@ -468,6 +468,9 @@ nodePort: null
   {{ include "service.ifClusterIP" $serviceType }}
   targetPort: {{ $key }}
   protocol: {{ $port.protocol }}
+  {{- if $serviceType := "nodePort" }}
+  nodePort: {{ $port.nodePort }}
+  {{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/signoz/templates/frontend/config.yaml
+++ b/charts/signoz/templates/frontend/config.yaml
@@ -9,7 +9,9 @@ data:
     server {
       listen       {{ .Values.frontend.service.port }};
       server_name  _;
-
+{{- if .Values.frontend.customConfig }}      
+      {{ .Values.frontend.data | nindent 6 }}
+{{- end }}
       gzip on;
       gzip_static on;    
       gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;

--- a/charts/signoz/templates/frontend/config.yaml
+++ b/charts/signoz/templates/frontend/config.yaml
@@ -9,9 +9,9 @@ data:
     server {
       listen       {{ .Values.frontend.service.port }};
       server_name  _;
-{{- if .Values.frontend.customConfig }}      
-      {{ .Values.frontend.data | nindent 6 }}
-{{- end }}
+    {{- with .Values.frontend.nginxExtraConfig }}
+      {{ . | trim | nindent 6 }}
+    {{- end }}
       gzip on;
       gzip_static on;    
       gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -554,11 +554,10 @@ frontend:
     #    hosts:
     #      - frontend.domain.com
 
-  # -- Nginx congifmap customize for new parameters
-  customConfig: false
-  # customConfig: true
-  # data: |
-  #   large_client_header_buffers 4 256k;
+  # -- Frontend Nginx extra configurations
+  nginxExtraConfig: |
+      client_max_body_size 24M;
+      large_client_header_buffers 8 16k;
 
   # adjust the resource requests and limit as necessary
   resources:

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -554,6 +554,12 @@ frontend:
     #    hosts:
     #      - frontend.domain.com
 
+  # -- Nginx congifmap customize for new parameters
+  customConfig: false
+  # customConfig: true
+  # data: |
+  #   large_client_header_buffers 4 256k;
+
   # adjust the resource requests and limit as necessary
   resources:
     requests:


### PR DESCRIPTION
Hi,

During our load tests to the signoz we faced with a serious problem which is inaccessibility of the frontend service. We troubleshooted it and saw that we were getting errors from frontend's nginx. So we added some parameters to the signoz-frontend configMap and solved the issue. Because of that we made it configurable.

Also @canerturkaslan added this values example to the values.yaml
