### PR TITLE
feat: ✨ introduce k8s-infra chart

### DIFF
--- a/charts/k8s-infra/.helmignore
+++ b/charts/k8s-infra/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: k8s-infra
+description: Helm chart for collecting metrics and logs in K8s
+type: application
+version: 0.1.0
+appVersion: "0.55.0"
+home: https://signoz.io
+icon: https://signoz.io/img/SigNozLogo-orange.svg
+keywords:
+  - SigNoz
+  - OpenTelemetry
+  - apm
+  - monitoring
+  - logs
+sources:
+  - https://github.com/signoz/charts
+  - https://github.com/open-telemetry/opentelemetry-collector-contrib
+maintainers:
+  - name: SigNoz
+    email: hello@signoz.io
+    url: https://signoz.io
+  - name: prashant-shahi
+    email: prashant@signoz.io
+    url: https://prashantshahi.dev

--- a/charts/k8s-infra/templates/NOTES.txt
+++ b/charts/k8s-infra/templates/NOTES.txt
@@ -1,0 +1,7 @@
+{{- if not .Values.otelAgent.configMap.create }}
+[WARNING] "configMap" wil not be created and "config" will not take effect.
+{{ end }}
+
+{{- if not .Values.otelDeployment.configMap.create }}
+[WARNING] "configMap" wil not be created and "config" will not take effect.
+{{ end }}

--- a/charts/k8s-infra/templates/_helpers.tpl
+++ b/charts/k8s-infra/templates/_helpers.tpl
@@ -1,0 +1,261 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "k8s-infra.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "k8s-infra.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "k8s-infra.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Return namespace of the release
+*/}}
+{{- define "k8s-infra.namespace" -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name for the agent.
+*/}}
+{{- define "otelAgent.fullname" -}}
+{{- printf "%s-%s" (include "k8s-infra.fullname" .) .Values.otelAgent.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels for agent.
+*/}}
+{{- define "otelAgent.labels" -}}
+helm.sh/chart: {{ include "k8s-infra.chart" . }}
+{{ include "otelAgent.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels for agent.
+*/}}
+{{- define "otelAgent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "k8s-infra.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: {{ include "otelAgent.name" . }}
+{{- end }}
+
+{{/*
+Name of the component agent.
+*/}}
+{{- define "otelAgent.name" -}}
+{{ default "otel-agent" .Values.otelAgent.name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use for agent.
+*/}}
+{{- define "otelAgent.serviceAccountName" -}}
+{{- if .Values.otelAgent.serviceAccount.create }}
+{{- default (include "otelAgent.fullname" .) .Values.otelAgent.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.otelAgent.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the proper image name of agent.
+*/}}
+{{- define "otelAgent.image" -}}
+{{- $registryName := default .Values.otelAgent.image.registry .Values.global.image.registry -}}
+{{- $repositoryName := .Values.otelAgent.image.repository -}}
+{{- $tag := default .Chart.AppVersion .Values.otelAgent.image.tag | toString -}}
+{{- if $registryName -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- else -}}
+    {{- printf "%s:%s" $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the clusterRole to use for agent.
+*/}}
+{{- define "otelAgent.clusterRoleName" -}}
+{{- if .Values.otelAgent.clusterRole.create }}
+{{- $clusterRole := printf "%s-%s" (include "otelAgent.fullname" .) (include "k8s-infra.namespace" .) }}
+{{- default $clusterRole .Values.otelAgent.clusterRole.name }}
+{{- else }}
+{{- default "default" .Values.otelAgent.clusterRole.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the clusterRoleBinding to use for agent.
+*/}}
+{{- define "otelAgent.clusterRoleBindingName" -}}
+{{- if .Values.otelAgent.clusterRole.create }}
+{{- $clusterRole := printf "%s-%s" (include "otelAgent.fullname" .) (include "k8s-infra.namespace" .) }}
+{{- default $clusterRole .Values.otelAgent.clusterRole.clusterRoleBinding.name }}
+{{- else }}
+{{- default "default" .Values.otelAgent.clusterRole.clusterRoleBinding.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name for the deployment.
+*/}}
+{{- define "otelDeployment.fullname" -}}
+{{- printf "%s-%s" (include "k8s-infra.fullname" .) .Values.otelDeployment.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels for deployment.
+*/}}
+{{- define "otelDeployment.labels" -}}
+helm.sh/chart: {{ include "k8s-infra.chart" . }}
+{{ include "otelDeployment.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels for deployment.
+*/}}
+{{- define "otelDeployment.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "k8s-infra.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: {{ include "otelDeployment.name" . }}
+{{- end }}
+
+{{/*
+Name of the component deployment.
+*/}}
+{{- define "otelDeployment.name" -}}
+{{ default "otel-deployment" .Values.otelDeployment.name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use for deployment.
+*/}}
+{{- define "otelDeployment.serviceAccountName" -}}
+{{- if .Values.otelDeployment.serviceAccount.create }}
+{{- default (include "otelDeployment.fullname" .) .Values.otelDeployment.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.otelDeployment.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the proper image name of deployment.
+*/}}
+{{- define "otelDeployment.image" -}}
+{{- $registryName := default .Values.otelDeployment.image.registry .Values.global.image.registry }}
+{{- $repositoryName := .Values.otelDeployment.image.repository }}
+{{- $tag := default .Chart.AppVersion .Values.otelDeployment.image.tag | toString }}
+{{- if $registryName }}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag }}
+{{- else }}
+    {{- printf "%s:%s" $repositoryName $tag }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the clusterRole to use for deployment.
+*/}}
+{{- define "otelDeployment.clusterRoleName" -}}
+{{- if .Values.otelDeployment.clusterRole.create }}
+{{- $clusterRole := printf "%s-%s" (include "otelDeployment.fullname" .) (include "k8s-infra.namespace" .) }}
+{{- default $clusterRole .Values.otelDeployment.clusterRole.name }}
+{{- else }}
+{{- default "default" .Values.otelDeployment.clusterRole.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the clusterRoleBinding to use for deployment.
+*/}}
+{{- define "otelDeployment.clusterRoleBindingName" -}}
+{{- if .Values.otelDeployment.clusterRole.create }}
+{{- $clusterRole := printf "%s-%s" (include "otelDeployment.fullname" .) (include "k8s-infra.namespace" .) }}
+{{- default $clusterRole .Values.otelDeployment.clusterRole.clusterRoleBinding.name }}
+{{- else }}
+{{- default "default" .Values.otelDeployment.clusterRole.clusterRoleBinding.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return endpoint of OtelCollector.
+*/}}
+{{- define "otel.endpoint" -}}
+{{- default "my-release-signoz-otel-collector.platform.svc.cluster.local:4317" .Values.otelCollectorEndpoint }}
+{{- end }}
+
+{{/*
+Return structured list of ports config for Service.
+*/}}
+{{- define "otel.portsConfig" -}}
+{{- $serviceType := deepCopy .service.type }}
+{{- $ports := deepCopy .ports }}
+{{- range $key, $port := $ports }}
+{{- if $port.enabled }}
+- name: {{ $key }}
+  port: {{ $port.servicePort }}
+  targetPort: {{ $key }}
+  protocol: {{ $port.protocol }}
+  {{- if (eq $serviceType "ClusterIP") }}
+  nodePort: null
+  {{- else if (eq $serviceType "NodePort") }}
+  nodePort: {{ $port.nodePort }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return if ingress supports pathType.
+*/}}
+{{- define "ingress.supportsPathType" -}}
+  {{- or (eq (include "ingress.isStable" .) "true") (and (eq (include "ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
+{{- end -}}
+
+{{/*
+Return if ingress is stable.
+*/}}
+{{- define "ingress.isStable" -}}
+  {{- eq (include "ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}

--- a/charts/k8s-infra/templates/otel-agent/clusterrole.yaml
+++ b/charts/k8s-infra/templates/otel-agent/clusterrole.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.otelAgent.clusterRole.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "otelAgent.clusterRoleName" . }}
+  namespace: {{ include "k8s-infra.namespace" . }}
+  {{- with .Values.otelAgent.clusterRole.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  {{ toYaml .Values.otelAgent.clusterRole.rules | nindent 2 -}}
+{{- end }}

--- a/charts/k8s-infra/templates/otel-agent/clusterrolebinding.yaml
+++ b/charts/k8s-infra/templates/otel-agent/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.otelAgent.clusterRole.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "otelAgent.clusterRoleBindingName" . }}
+  namespace: {{ include "k8s-infra.namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "otelAgent.clusterRoleName" . }}
+subjects:
+  - name: {{ include "otelAgent.serviceAccountName" . }}
+    kind: ServiceAccount
+    namespace: {{ include "k8s-infra.namespace" . }}
+{{- end }}

--- a/charts/k8s-infra/templates/otel-agent/configmap.yaml
+++ b/charts/k8s-infra/templates/otel-agent/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "otelAgent.fullname" . }}
+  labels:
+    {{- include "otelAgent.labels" . | nindent 4 }}
+data:
+  otel-agent-config.yaml: |-
+    {{- toYaml .Values.otelAgent.config | nindent 4 }}

--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -1,0 +1,146 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "otelAgent.fullname" . }}
+  labels:
+    {{- include "otelAgent.labels" . | nindent 4 }}
+  {{- if .Values.otelAgent.annotations }}
+  annotations:
+    {{ toYaml .Values.otelAgent.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "otelAgent.selectorLabels" . | nindent 6 }}
+  minReadySeconds: {{ .Values.otelAgent.minReadySeconds }}
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.otelAgent.podAnnotations }}
+          {{- toYaml .Values.otelAgent.podAnnotations | nindent 8 }}
+        {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/otel-agent/configmap.yaml") . | sha256sum }}
+      labels:
+        {{- include "otelAgent.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "otelAgent.serviceAccountName" . }}
+      containers:
+        - name: {{ include "otelAgent.fullname" . }}
+          image: {{ include "otelAgent.image" . }}
+          imagePullPolicy: {{ .Values.otelAgent.image.pullPolicy }}
+          ports:
+          {{- range $key, $port := .Values.otelAgent.ports }}
+            {{- if $port.enabled }}
+            - name: {{ $key }}
+              containerPort: {{ $port.containerPort }}
+              protocol: {{ $port.protocol }}
+              {{- if $port.hostPort }}
+              hostPort: {{ $port.hostPort }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.otelDeployment.command.name }}
+          command:
+            - {{ . | quote }}
+          {{- end }}
+          args:
+            {{- if .Values.otelDeployment.configMap.create }}
+            - "--config=/conf/otel-agent-config.yaml"
+            {{- end }}
+            {{- range .Values.otelDeployment.command.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
+          env:
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: K8S_NAMESPACE
+              valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: host.name=$(K8S_NODE_NAME)
+            - name: OTEL_COLLECTOR_ENDPOINT
+              value: {{ include "otel.endpoint" . }}
+          volumeMounts:
+            - name: otel-agent-config-vol
+              mountPath: /conf
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            # - name: otel-agent-secrets
+            #   mountPath: /secrets
+          {{- if .Values.otelAgent.livenessProbe.enabled }}
+          livenessProbe:
+            {{- with .Values.otelDeployment.livenessProbe }}
+            httpGet:
+              port: {{ .port }}
+              path: {{ .path }}
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            timeoutSeconds: {{ .timeoutSeconds }}
+            successThreshold: {{ .successThreshold }}
+            failureThreshold: {{ .failureThreshold }}
+            {{- end }}
+          {{- else if .Values.otelAgent.customLivenessProbe }}
+          livenessProbe: {{- toYaml .Values.otelAgent.customLivenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.otelAgent.readinessProbe.enabled }}
+          readinessProbe:
+            {{- with .Values.otelDeployment.readinessProbe }}
+            httpGet:
+              port: {{ .port }}
+              path: {{ .path }}
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            timeoutSeconds: {{ .timeoutSeconds }}
+            successThreshold: {{ .successThreshold }}
+            failureThreshold: {{ .failureThreshold }}
+            {{- end }}
+          {{- else if .Values.otelAgent.customReadinessProbe }}
+          readinessProbe: {{- toYaml .Values.otelAgent.customReadinessProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.otelAgent.resources | nindent 12 }}
+      {{- with .Values.otelAgent.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.otelAgent.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.otelAgent.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: otel-agent-config-vol
+          configMap:
+            name: {{ include "otelAgent.fullname" . }}
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+#        - secret:
+#            name: otel-agent-secrets
+#            items:
+#              - key: cert.pem
+#                path: cert.pem
+#              - key: key.pem
+#                path: key.pem

--- a/charts/k8s-infra/templates/otel-agent/service.yaml
+++ b/charts/k8s-infra/templates/otel-agent/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "otelAgent.fullname" . }}
+  labels:
+    {{- include "otelAgent.labels" . | nindent 4 }}
+{{- with .Values.otelAgent }}
+  {{- if .service.annotations }}
+  annotations:
+    {{- toYaml .service.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .service.type }}
+  ports:
+    {{- include "otel.portsConfig" . | nindent 4 }}
+
+  selector:
+    {{- include "otelAgent.selectorLabels" $ | nindent 4 }}
+{{- end }}

--- a/charts/k8s-infra/templates/otel-agent/serviceaccount.yaml
+++ b/charts/k8s-infra/templates/otel-agent/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "otelAgent.serviceAccountName" . }}
+  labels:
+    {{- include "otelAgent.labels" . | nindent 4 }}
+  {{- with .Values.otelAgent.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/k8s-infra/templates/otel-agent/tests/test-connection.yaml
+++ b/charts/k8s-infra/templates/otel-agent/tests/test-connection.yaml
@@ -1,0 +1,16 @@
+{{- $healthCheckPort := index .Values.otelAgent.ports "health-check" -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "otelAgent.fullname" . }}-test-connection"
+  labels:
+    {{- include "otelAgent.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "otelAgent.fullname" . }}:{{ $healthCheckPort.servicePort }}']
+  restartPolicy: Never

--- a/charts/k8s-infra/templates/otel-deployment/clusterrole.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/clusterrole.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.otelDeployment.clusterRole.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "otelDeployment.clusterRoleName" . }}
+  namespace: {{ include "k8s-infra.namespace" . }}
+  {{- with .Values.otelDeployment.clusterRole.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  {{ toYaml .Values.otelDeployment.clusterRole.rules | nindent 2 -}}
+{{- end }}

--- a/charts/k8s-infra/templates/otel-deployment/clusterrolebinding.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.otelDeployment.clusterRole.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "otelDeployment.clusterRoleBindingName" . }}
+  namespace: {{ include "k8s-infra.namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "otelDeployment.clusterRoleName" . }}
+subjects:
+  - name: {{ include "otelDeployment.serviceAccountName" . }}
+    kind: ServiceAccount
+    namespace: {{ include "k8s-infra.namespace" . }}
+{{- end }}

--- a/charts/k8s-infra/templates/otel-deployment/configmap.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "otelDeployment.fullname" . }}
+  labels:
+    {{- include "otelDeployment.labels" . | nindent 4 }}
+data:
+  otel-deployment-config.yaml: |-
+    {{- toYaml .Values.otelDeployment.config | nindent 4 }}

--- a/charts/k8s-infra/templates/otel-deployment/deployment.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/deployment.yaml
@@ -1,0 +1,125 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "otelDeployment.fullname" . }}
+  labels:
+    {{- include "otelDeployment.labels" . | nindent 4 }}
+  {{- if .Values.otelDeployment.annotations }}
+  annotations:
+    {{ toYaml .Values.otelDeployment.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "otelDeployment.selectorLabels" . | nindent 6 }}
+  minReadySeconds: {{ .Values.otelDeployment.minReadySeconds }}
+  progressDeadlineSeconds: {{ .Values.otelDeployment.progressDeadlineSeconds }}
+  replicas: {{ .Values.otelDeployment.replicaCount }}
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.otelDeployment.podAnnotations }}
+          {{- toYaml .Values.otelDeployment.podAnnotations | nindent 8 }}
+        {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/otel-deployment/configmap.yaml") . | sha256sum }}
+      labels:
+        {{- include "otelDeployment.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "otelDeployment.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.otelDeployment.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ template "otelDeployment.fullname" . }}
+          image: {{ template "otelDeployment.image" . }}
+          imagePullPolicy: {{ .Values.otelDeployment.image.pullPolicy }}
+          ports:
+            {{- range $key, $port := .Values.otelDeployment.ports }}
+            {{- if $port.enabled }}
+            - name: {{ $key }}
+              containerPort: {{ $port.containerPort }}
+              protocol: {{ $port.protocol }}
+            {{- end }}
+            {{- end }}
+          {{- with .Values.otelDeployment.command.name }}
+          command:
+            - {{ . | quote }}
+          {{- end }}
+          args:
+            {{- if .Values.otelDeployment.configMap.create }}
+            - "--config=/conf/otel-deployment-config.yaml"
+            {{- end }}
+            {{- range .Values.otelDeployment.command.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
+          securityContext:
+            {{- toYaml .Values.otelDeployment.securityContext | nindent 12 }}
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: OTEL_COLLECTOR_ENDPOINT
+              value: {{ include "otel.endpoint" . }}
+          volumeMounts:
+            - name: otel-deployment-config-vol
+              mountPath: /conf
+            # - name: otel-collector-secrets
+            #   mountPath: /secrets
+          {{- if .Values.otelDeployment.livenessProbe.enabled }}
+          livenessProbe:
+            {{- with .Values.otelDeployment.livenessProbe }}
+            httpGet:
+              port: {{ .port }}
+              path: {{ .path }}
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            timeoutSeconds: {{ .timeoutSeconds }}
+            successThreshold: {{ .successThreshold }}
+            failureThreshold: {{ .failureThreshold }}
+            {{- end }}
+          {{- else if .Values.otelDeployment.customLivenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.otelDeployment.customLivenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.otelDeployment.readinessProbe.enabled }}
+          readinessProbe:
+            {{- with .Values.otelDeployment.readinessProbe }}
+            httpGet:
+              port: {{ .port }}
+              path: {{ .path }}
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            timeoutSeconds: {{ .timeoutSeconds }}
+            successThreshold: {{ .successThreshold }}
+            failureThreshold: {{ .failureThreshold }}
+            {{- end }}
+          {{- else if .Values.otelDeployment.customReadinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.otelDeployment.customReadinessProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.otelDeployment.resources | nindent 12 }}
+      {{- with .Values.otelDeployment.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.otelDeployment.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.otelDeployment.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: otel-deployment-config-vol
+          configMap:
+            name: {{ include "otelDeployment.fullname" . }}
+#        - secret:
+#            name: otel-deployment-secrets
+#            items:
+#              - key: cert.pem
+#                path: cert.pem
+#              - key: key.pem
+#                path: key.pem

--- a/charts/k8s-infra/templates/otel-deployment/ingress.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/ingress.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.otelDeployment.ingress.enabled -}}
+{{- $fullName := include "otelDeployment.fullname" . -}}
+{{- $ingressApiIsStable := eq (include "ingress.isStable" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
+{{- $ingressSupportsClassName := and .Values.otelDeployment.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) -}}
+apiVersion: {{ include "ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "otelDeployment.labels" . | nindent 4 }}
+  {{- with .Values.otelDeployment.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if $ingressSupportsClassName }}
+  ingressClassName: {{ .Values.otelDeployment.ingress.className }}
+  {{- end }}
+  {{- if .Values.otelDeployment.ingress.tls }}
+  tls:
+    {{- range .Values.otelDeployment.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.otelDeployment.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if $ingressSupportsPathType }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if $ingressApiIsStable }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ .port }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ .port }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/k8s-infra/templates/otel-deployment/service.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "otelDeployment.fullname" . }}
+  labels:
+    {{- include "otelDeployment.labels" . | nindent 4 }}
+{{- with .Values.otelAgent }}
+  {{- if .service.annotations }}
+  annotations:
+    {{- toYaml .service.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .service.type }}
+  ports:
+    {{- include "otel.portsConfig" . | nindent 4 }}
+  selector:
+    {{- include "otelDeployment.selectorLabels" $ | nindent 4 }}
+{{- end }}
+
+

--- a/charts/k8s-infra/templates/otel-deployment/serviceaccount.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.otelDeployment.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "otelDeployment.serviceAccountName" . }}
+  labels:
+    {{- include "otelDeployment.labels" . | nindent 4 }}
+  {{- with .Values.otelDeployment.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/k8s-infra/templates/otel-deployment/tests/test-connection.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "otelDeployment.fullname" . }}-test-connection"
+  labels:
+    {{- include "otelDeployment.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "otelDeployment.fullname" . }}:{{ .Values.otelDeployment.service.port }}']
+  restartPolicy: Never

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -253,16 +253,16 @@ otelAgent:
     #      - otel-agent.domain.com
 
   # -- Configure resource requests and limits. Update according to your own use
-  # case as these values might be too low for a typical deployment.
+  # case as these values might not be suitable for your workload.
   # ref: http://kubernetes.io/docs/user-guide/compute-resources/
   # @default -- See `values.yaml` for defaults
   resources:
     requests:
       cpu: 200m
-      memory: 400Mi
+      memory: 200Mi
     limits:
       cpu: 1000m
-      memory: 2Gi
+      memory: 1Gi
 
   # -- OtelAgent node selector
   nodeSelector: {}
@@ -606,16 +606,16 @@ otelDeployment:
     #      - otel-deployment.domain.com
 
   # -- Configure resource requests and limits. Update according to your own use
-  # case as these values might be too low for a typical deployment.
+  # case as these values might not be suitable for your workload.
   # ref: http://kubernetes.io/docs/user-guide/compute-resources/
   # @default -- See `values.yaml` for defaults
   resources:
     requests:
       cpu: 200m
-      memory: 400Mi
+      memory: 200Mi
     limits:
       cpu: 1000m
-      memory: 2Gi
+      memory: 1Gi
 
   # -- OtelDeployment node selector
   nodeSelector: {}

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -1,0 +1,723 @@
+# Global override values
+global:
+  image:
+    # -- Overrides the Docker registry globally for all images
+    registry: null
+  # -- Overrides the storage class for all PVC with persistence enabled.
+  storageClass: null
+
+# -- SigNoz chart name override
+nameOverride: ""
+
+# -- SigNoz chart full name override
+fullnameOverride: ""
+
+# -- Endpoint/IP Address of the SigNoz or any other OpenTelemetry backend.
+otelCollectorEndpoint: my-release-signoz-otel-collector.platform.svc.cluster.local:4317
+
+# Default values for OtelAgent
+otelAgent:
+  name: "otel-agent"
+  image:
+    registry: docker.io
+    repository: otel/opentelemetry-collector-contrib
+    tag: 0.55.0
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+
+  # OpenTelemetry Collector executable
+  command:
+    # -- OtelAgent command name
+    name: /otelcol-contrib
+    # -- OtelAgent command extra arguments
+    extraArgs: []
+
+  configMap:
+    # -- Specifies whether a configMap should be created (true by default)
+    create: true
+
+  # OtelAgent service
+  service:
+    # -- Annotations to use by service associated to OtelAgent
+    annotations: {}
+    # -- Service Type: LoadBalancer (allows external access) or NodePort (more secure, no extra cost)
+    type: ClusterIP
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name:
+
+  # -- OtelColector Deployment annotation.
+  annotations: {}
+  # -- OtelColector pod(s) annotation.
+  podAnnotations:
+    signoz.io/scrape: 'true'
+    signoz.io/port: '8889'
+    signoz.io/path: /metrics
+
+  # -- Minimum number of seconds for which a newly created Pod should be ready
+  # without any of its containers crashing, for it to be considered available.
+  minReadySeconds: 5
+
+  # OtelAgent RBAC config
+  clusterRole:
+    # -- Specifies whether a clusterRole should be created
+    create: true
+    # -- Annotations to add to the clusterRole
+    annotations: {}
+    # -- The name of the clusterRole to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+    # -- A set of rules as documented here.
+    # ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+    rules:
+      - apiGroups: [""]
+        resources: ["pods", "nodes", "endpoints"]
+        verbs: ["list", "watch"]
+      - apiGroups: ["apps"]
+        resources: ["replicasets"]
+        verbs: ["list", "watch"]
+      - apiGroups: ["batch"]
+        resources: ["jobs"]
+        verbs: ["list", "watch"]
+      - apiGroups: [""]
+        resources: ["nodes/proxy"]
+        verbs: ["get"]
+      - apiGroups: [""]
+        resources: ["nodes/stats", "configmaps", "events"]
+        verbs: ["create", "get"]
+      - apiGroups: [""]
+        resources: ["configmaps"]
+        resourceNames: ["otel-container-insight-clusterleader"]
+        verbs: ["get", "update"]
+
+    # OtelAgent clusterRoleBinding
+    clusterRoleBinding:
+      # Annotations to add to the clusterRoleBinding
+      annotations: {}
+      # The name of the clusterRoleBinding to use.
+      # If not set and create is true, a name is generated using the fullname template
+      name: ""
+
+  # Configuration for ports
+  ports:
+    otlp:
+      # -- Whether to enable service port for OTLP gRPC
+      enabled: true
+      # -- Container port for OTLP gRPC
+      containerPort: 4317
+      # -- Service port for OTLP gRPC
+      servicePort: 4317
+      # -- Node port for OTLP gRPC
+      nodePort: ""
+      # -- Host port for OTLP gRPC
+      hostPort: 4317
+      # -- Protocol to use for OTLP gRPC
+      protocol: TCP
+    otlp-http:
+      # -- Whether to enable service port for OTLP HTTP
+      enabled: true
+      # -- Container port for OTLP HTTP
+      containerPort: 4318
+      # -- Service port for OTLP HTTP
+      servicePort: 4318
+      # -- Node port for OTLP HTTP
+      nodePort: ""
+      # -- Host port for OTLP HTTP
+      hostPort: 4318
+      # -- Protocol to use for OTLP HTTP
+      protocol: TCP
+    zipkin:
+      # -- Whether to enable service port for Zipkin
+      enabled: false
+      # -- Container port for Zipkin
+      containerPort: 9411
+      # -- Service port for Zipkin
+      servicePort: 9411
+      # -- Node port for Zipkin
+      nodePort: ""
+      # -- Host port for Zipkin
+      hostPort: 9411
+      # -- Protocol to use for Zipkin
+      protocol: TCP
+    metrics:
+      # -- Whether to enable service port for internal metrics
+      enabled: true
+      # -- Container port for internal metrics
+      containerPort: 8888
+      # -- Service port for internal metrics
+      servicePort: 8888
+      # -- Node port for internal metrics
+      nodePort: ""
+      # -- Host port for internal metrics
+      hostPort: 8888
+      # -- Protocol to use for internal metrics
+      protocol: TCP
+    zpages:
+      # -- Whether to enable service port for ZPages
+      enabled: false
+      # -- Container port for Zpages
+      containerPort: 55679
+      # -- Service port for Zpages
+      servicePort: 55679
+      # -- Node port for Zpages
+      nodePort: ""
+      # -- Host port for Zpages
+      hostPort: 55679
+      # -- Protocol to use for Zpages
+      protocol: TCP
+    health-check:
+      # -- Whether to enable service port for health check
+      enabled: true
+      # -- Container port for health check
+      containerPort: 13133
+      # -- Service port for health check
+      servicePort: 13133
+      # -- Node port for health check
+      nodePort: ""
+      # -- Host port for health check
+      hostPort: 13133
+      # -- Protocol to use for health check
+      protocol: TCP
+    pprof:
+      # -- Whether to enable service port for pprof
+      enabled: false
+      # -- Container port for pprof
+      containerPort: 1777
+      # -- Service port for pprof
+      servicePort: 1777
+      # -- Node port for pprof
+      nodePort: ""
+      # -- Host port for pprof
+      hostPort: 1777
+      # -- Protocol to use for pprof
+      protocol: TCP
+
+  # -- Configure liveness probe.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command
+  livenessProbe:
+    enabled: false
+    port: 13133
+    path: /
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
+  # -- Configure readiness probe.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes
+  readinessProbe:
+    enabled: false
+    port: 13133
+    path: /
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
+  # -- Custom liveness probe
+  customLivenessProbe: {}
+  # -- Custom readiness probe
+  customReadinessProbe: {}
+
+  ingress:
+    # -- Enable ingress for OtelAgent
+    enabled: false
+    # -- Ingress Class Name to be used to identify ingress controllers
+    className: ""
+    # -- Annotations to OtelAgent Ingress
+    annotations: {}
+      # cert-manager.io/cluster-issuer: letsencrypt-prod
+      # nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      # nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    # -- OtelAgent Ingress Host names with their path details
+    hosts:
+      - host: otel-agent.domain.com
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            port: 4317
+    # -- OtelAgent Ingress TLS
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - otel-agent.domain.com
+
+  # -- Configure resource requests and limits. Update according to your own use
+  # case as these values might be too low for a typical deployment.
+  # ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  # @default -- See `values.yaml` for defaults
+  resources:
+    requests:
+      cpu: 200m
+      memory: 400Mi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+
+  # -- OtelAgent node selector
+  nodeSelector: {}
+
+  # -- Toleration labels for OtelAgent pod assignment
+  tolerations: []
+
+  # -- Affinity settings for OtelAgent pod
+  affinity: {}
+
+  # -- Pod-level security configuration
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  # -- Container security configuration
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  # -- Configurations for OtelAgent
+  # @default -- See `values.yaml` for defaults
+  config:
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+      hostmetrics:
+        collection_interval: 30s
+        scrapers:
+          cpu: {}
+          load: {}
+          memory: {}
+          disk: {}
+          filesystem: {}
+          network: {}
+      filelog/k8s:
+        include:
+          - /var/log/pods/*/*/*.log
+        exclude:
+          # Exclude logs from all containers named otel-collector
+          - /var/log/pods/*/otel-collector/*.log
+        start_at: beginning
+        include_file_path: true
+        include_file_name: false
+        operators:
+        # Find out which format is used by kubernetes
+        - type: router
+          id: get-format
+          routes:
+            - output: parser-docker
+              expr: 'body matches "^\\{"'
+            - output: parser-crio
+              expr: 'body matches "^[^ Z]+ "'
+            - output: parser-containerd
+              expr: 'body matches "^[^ Z]+Z"'
+        # Parse CRI-O format
+        - type: regex_parser
+          id: parser-crio
+          regex: '^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$'
+          output: extract_metadata_from_filepath
+          timestamp:
+            parse_from: attributes.time
+            layout_type: gotime
+            layout: '2006-01-02T15:04:05.000000000-07:00'
+        # Parse CRI-Containerd format
+        - type: regex_parser
+          id: parser-containerd
+          regex: '^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$'
+          output: extract_metadata_from_filepath
+          timestamp:
+            parse_from: attributes.time
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+        # Parse Docker format
+        - type: json_parser
+          id: parser-docker
+          output: extract_metadata_from_filepath
+          timestamp:
+            parse_from: attributes.time
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+        # Extract metadata from file path
+        - type: regex_parser
+          id: extract_metadata_from_filepath
+          regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
+          parse_from: attributes["log.file.path"]
+        # Rename attributes
+        - type: move
+          from: attributes.stream
+          to: attributes["log.iostream"]
+        - type: move
+          from: attributes.container_name
+          to: attributes["k8s.container.name"]
+        - type: move
+          from: attributes.namespace
+          to: attributes["k8s.namespace.name"]
+        - type: move
+          from: attributes.pod_name
+          to: attributes["k8s.pod.name"]
+        - type: move
+          from: attributes.restart_count
+          to: attributes["k8s.container.restart_count"]
+        - type: move
+          from: attributes.uid
+          to: attributes["k8s.pod.uid"]
+        - type: move
+          from: attributes.log
+          to: body
+      prometheus:
+        config:
+          global:
+            scrape_interval: 60s
+          scrape_configs:
+            - job_name: otel-agent
+              static_configs:
+              - targets:
+                - ${MY_POD_IP}:8888
+    processors:
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
+      # Resource detection processor config.
+      # ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/README.md
+      resourcedetection:
+        detectors: [env, system]  # Include ec2/eks for AWS, gce/gke for GCP and azure/aks for Azure
+        # Using OTEL_RESOURCE_ATTRIBUTES envvar, env detector adds custom labels
+        timeout: 2s
+        override: false
+        system:
+          hostname_sources: [os]  # Alternatively, use [dns,os] for setting FQDN as host.name and os as fallback
+      # Memory Limiter processor config.
+      # If set to null, will be overridden with values based on k8s resource limits.
+      # ref: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor
+      memory_limiter: null
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+      zpages:
+        endpoint: localhost:55679
+      pprof:
+        endpoint: localhost:1777
+    exporters:
+      otlp:
+        endpoint: ${OTEL_COLLECTOR_ENDPOINT}
+        tls:
+          insecure: true
+    service:
+      telemetry:
+        metrics:
+          address: 0.0.0.0:8888
+      extensions: [health_check, zpages]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [otlp]
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [otlp]
+        metrics/generic:
+          receivers: [hostmetrics, prometheus]
+          processors: [resourcedetection, batch]
+          exporters: [otlp]
+        logs:
+          receivers: [filelog/k8s, otlp]
+          processors: [batch]
+          exporters: [otlp]
+
+# Default values for OtelDeployment
+otelDeployment:
+  name: "otel-deployment"
+  image:
+    registry: docker.io
+    repository: otel/opentelemetry-collector-contrib
+    tag: 0.55.0
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+
+  # OpenTelemetry Collector executable
+  command:
+    # -- OtelDeployment command name
+    name: /otelcol-contrib
+    # -- OtelDeployment command extra arguments
+    extraArgs: []
+
+  configMap:
+    # -- Specifies whether a configMap should be created (true by default)
+    create: true
+
+  # OtelDeployment service
+  service:
+    # -- Annotations to use by service associated to OtelDeployment
+    annotations: {}
+    # -- Service Type: LoadBalancer (allows external access) or NodePort (more secure, no extra cost)
+    type: ClusterIP
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name:
+
+  # -- OtelDeployment deployment annotation.
+  annotations: {}
+  # -- OtelDeployment pod(s) annotation.
+  podAnnotations:
+    signoz.io/scrape: 'true'
+    signoz.io/port: '8888'
+    signoz.io/path: /metrics
+
+  # -- Pod-level security configuration
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  # -- Container security configuration
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  # -- Minimum number of seconds for which a newly created Pod should be ready
+  # without any of its containers crashing, for it to be considered available.
+  minReadySeconds: 5
+
+  # -- Number of seconds to wait for the OtelDeployment to progress before the
+  # system reports back that the OtelDeployment has failed.
+  progressDeadlineSeconds: 120
+
+  # Configuration for ports
+  ports:
+    metrics:
+      # -- Whether to enable service port for internal metrics
+      enabled: false
+      # -- Container port for internal metrics
+      containerPort: 8888
+      # -- Service port for internal metrics
+      servicePort: 8888
+      # -- Node port for internal metrics
+      nodePort: ""
+      # -- Protocol to use for internal metrics
+      protocol: TCP
+    zpages:
+      # -- Whether to enable service port for ZPages
+      enabled: false
+      # -- Container port for Zpages
+      containerPort: 55679
+      # -- Service port for Zpages
+      servicePort: 55679
+      # -- Node port for Zpages
+      nodePort: ""
+      # -- Protocol to use for Zpages
+      protocol: TCP
+    health-check:
+      # -- Whether to enable service port for health check
+      enabled: true
+      # -- Container port for health check
+      containerPort: 13133
+      # -- Service port for health check
+      servicePort: 13133
+      # -- Node port for health check
+      nodePort: ""
+      # -- Protocol to use for health check
+      protocol: TCP
+    pprof:
+      # -- Whether to enable service port for pprof
+      enabled: false
+      # -- Container port for pprof
+      containerPort: 1777
+      # -- Service port for pprof
+      servicePort: 1777
+      # -- Node port for pprof
+      nodePort: ""
+      # -- Protocol to use for pprof
+      protocol: TCP
+
+  # -- Configure liveness probe.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command
+  livenessProbe:
+    enabled: false
+    port: 13133
+    path: /
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
+  # -- Configure readiness probe.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes
+  readinessProbe:
+    enabled: false
+    port: 13133
+    path: /
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
+  # -- Custom liveness probe
+  customLivenessProbe: {}
+
+  # -- Custom readiness probe
+  customReadinessProbe: {}
+
+  ingress:
+    # -- Enable ingress for OtelDeployment
+    enabled: false
+    # -- Ingress Class Name to be used to identify ingress controllers
+    className: ""
+    # -- Annotations to OtelDeployment Ingress
+    annotations: {}
+      # cert-manager.io/cluster-issuer: letsencrypt-prod
+      # nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      # nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    # -- OtelDeployment Ingress Host names with their path details
+    hosts:
+      - host: otel-deployment.domain.com
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            port: 13133
+    # -- OtelDeployment Ingress TLS
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - otel-deployment.domain.com
+
+  # -- Configure resource requests and limits. Update according to your own use
+  # case as these values might be too low for a typical deployment.
+  # ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  # @default -- See `values.yaml` for defaults
+  resources:
+    requests:
+      cpu: 200m
+      memory: 400Mi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+
+  # -- OtelDeployment node selector
+  nodeSelector: {}
+
+  # -- Toleration labels for OtelDeployment pod assignment
+  tolerations: []
+
+  # -- Affinity settings for OtelDeployment pod
+  affinity: {}
+
+  # OtelDeployment RBAC config
+  clusterRole:
+    # -- Specifies whether a clusterRole should be created
+    create: true
+    # -- Annotations to add to the clusterRole
+    annotations: {}
+    # -- The name of the clusterRole to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+    # -- A set of rules as documented here : https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+    # @default -- See `values.yaml` for defaults
+    rules:
+      - apiGroups: [""]
+        resources:
+          - events
+          - namespaces
+          - namespaces/status
+          - nodes
+          - nodes/spec
+          - pods
+          - pods/status
+          - replicationcontrollers
+          - replicationcontrollers/status
+          - resourcequotas
+          - services
+        verbs: ["get", "list", "watch"]
+      - apiGroups: ["apps"]
+        resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
+        verbs: ["get", "list", "watch"]
+      - apiGroups: ["extensions"]
+        resources: ["daemonsets", "deployments", "replicasets"]
+        verbs: ["get", "list", "watch"]
+      - apiGroups: ["batch"]
+        resources: ["jobs", "cronjobs"]
+        verbs: ["get", "list", "watch"]
+      - apiGroups: ["autoscaling"]
+        resources: ["horizontalpodautoscalers"]
+        verbs: ["get", "list", "watch"]
+
+    # OtelDeployment clusterRoleBinding
+    clusterRoleBinding:
+      # -- Annotations to add to the clusterRoleBinding
+      annotations: {}
+      # -- The name of the clusterRoleBinding to use.
+      # If not set and create is true, a name is generated using the fullname template
+      name: ""
+
+  # -- Configurations for OtelDeployment
+  # @default -- See `values.yaml` for defaults
+  config:
+    receivers:
+      # k8s cluster metrics
+      k8s_cluster:
+        collection_interval: 30s
+        node_conditions_to_report: [Ready, MemoryPressure]
+        allocatable_types_to_report: [cpu, memory]
+      # prometheus scrape config
+      prometheus:
+        config:
+          scrape_configs:
+            # deployment internal metrics
+            - job_name: "otel-deployment"
+              scrape_interval: 60s
+              static_configs:
+                - targets:
+                  - ${MY_POD_IP}:8888
+    processors:
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
+      # Memory Limiter processor.
+      # If set to null, will be overridden with values based on k8s resource limits.
+      memory_limiter: null
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+      zpages:
+        endpoint: localhost:55679
+      pprof:
+        endpoint: localhost:1777
+    exporters:
+      otlp:
+        endpoint: ${OTEL_COLLECTOR_ENDPOINT}
+        tls:
+          insecure: true
+    service:
+      telemetry:
+        metrics:
+          address: 0.0.0.0:8888
+      extensions: [health_check, zpages, pprof]
+      pipelines:
+        metrics:
+          receivers: [k8s_cluster, prometheus]
+          processors: [batch]
+          exporters: [otlp]

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -307,10 +307,14 @@ otelAgent:
           network: {}
       filelog/k8s:
         include:
+          # Include logs from all container
           - /var/log/pods/*/*/*.log
         exclude:
-          # Exclude logs from all containers named otel-collector
-          - /var/log/pods/*/otel-collector/*.log
+          # Exclude logs from all containers from kube-system namespace
+          - /var/log/pods/kube-system_*/*/*.log
+          # Exclude logs from all hotrod containers
+          - /var/log/pods/*_hotrod-*/*/*.log
+          - /var/log/pods/*_locust-*_*/*/*.log
         start_at: beginning
         include_file_path: true
         include_file_name: false


### PR DESCRIPTION
This PR introduces `k8s-infra` chart which makes it very easy to collect metrics and logs from any external Kubernetes cluster.

### Installation
After the PR is merged, we can install it by running the command below:

```bash
helm install my-release signoz/k8s-infra  \
  --set otelCollectorEndpoint=<IP-or-Endpoint-of-SigNoz-OtelCollector>:4317
```

If `otelCollectorEndpoint` is not set, it will default to `my-release-signoz-otel-collector.platform.svc.cluster.local:4317`.

### Remarks
- By default, logs from `kube-system` is disabled. To enable, comment out specific section from `filelog/k8s.exclude` in `otelAgent`.
- By default, logs from hotrod sample app is disabled. To enable, comment out specific section from `filelog/k8s.exclude` in `otelAgent`.
- It can be used to send captured metrics and logs to any OpenTelemetry backend like SigNoz and others.