### PR TITLE
k8s-infra chart improvements

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "0.55.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/templates/_helpers.tpl
+++ b/charts/k8s-infra/templates/_helpers.tpl
@@ -34,7 +34,7 @@ Create chart name and version as used by the chart label.
 Return namespace of the release
 */}}
 {{- define "k8s-infra.namespace" -}}
-{{- .Release.Namespace -}}
+{{- default .Release.Namespace .Values.namespace }}
 {{- end -}}
 
 {{/*

--- a/charts/k8s-infra/templates/_helpers.tpl
+++ b/charts/k8s-infra/templates/_helpers.tpl
@@ -206,10 +206,46 @@ Create the name of the clusterRoleBinding to use for deployment.
 {{- end }}
 
 {{/*
+Create a fully qualified app name for signoz.
+Assuming defaults for fullnameOverride and nameOverride.
+*/}}
+{{- define "signoz.qualifiedname" -}}
+{{- $name := "signoz" }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create a fully qualified app name for otel-collector.
+*/}}
+{{- define "otel.qualifiedname" -}}
+{{- printf "%s-%s" (include "signoz.qualifiedname" .) "otel-collector" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Return the service name of OtelCollector.
+Assuming defaults for overrides and otel component name.
+*/}}
+{{- define "otel.servicename" -}}
+{{- if and .Values.namespace (ne .Values.namespace .Release.Namespace) }}
+{{- printf "%s.%s.svc.%s" (include "otel.qualifiedname" .) .Release.Namespace .Values.clusterDomain }}
+{{- else }}
+{{- include "otel.qualifiedname" . }}
+{{- end }}
+{{- end }}
+
+{{/*
 Return endpoint of OtelCollector.
 */}}
 {{- define "otel.endpoint" -}}
-{{- default "my-release-signoz-otel-collector.platform.svc.cluster.local:4317" .Values.otelCollectorEndpoint }}
+{{- if .Values.otelCollectorEndpoint }}
+{{- .Values.otelCollectorEndpoint }}
+{{- else if not .Chart.IsRoot }}
+{{- printf "%s:%s" (include "otel.servicename" .) "4317" }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/k8s-infra/templates/namespace.yaml
+++ b/charts/k8s-infra/templates/namespace.yaml
@@ -1,0 +1,6 @@
+{{- if and .Values.namespace (ne .Values.namespace .Release.Namespace) }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "k8s-infra.namespace" . }}
+{{- end }}

--- a/charts/k8s-infra/templates/otel-agent/configmap.yaml
+++ b/charts/k8s-infra/templates/otel-agent/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "otelAgent.fullname" . }}
+  namespace: {{ include "k8s-infra.namespace" . }}
   labels:
     {{- include "otelAgent.labels" . | nindent 4 }}
 data:

--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "otelAgent.fullname" . }}
+  namespace: {{ include "k8s-infra.namespace" . }}
   labels:
     {{- include "otelAgent.labels" . | nindent 4 }}
   {{- if .Values.otelAgent.annotations }}

--- a/charts/k8s-infra/templates/otel-agent/service.yaml
+++ b/charts/k8s-infra/templates/otel-agent/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "otelAgent.fullname" . }}
+  namespace: {{ include "k8s-infra.namespace" . }}
   labels:
     {{- include "otelAgent.labels" . | nindent 4 }}
 {{- with .Values.otelAgent }}

--- a/charts/k8s-infra/templates/otel-agent/serviceaccount.yaml
+++ b/charts/k8s-infra/templates/otel-agent/serviceaccount.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "otelAgent.serviceAccountName" . }}
+  namespace: {{ include "k8s-infra.namespace" . }}
   labels:
     {{- include "otelAgent.labels" . | nindent 4 }}
   {{- with .Values.otelAgent.serviceAccount.annotations }}

--- a/charts/k8s-infra/templates/otel-deployment/configmap.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "otelDeployment.fullname" . }}
+  namespace: {{ include "k8s-infra.namespace" . }}
   labels:
     {{- include "otelDeployment.labels" . | nindent 4 }}
 data:

--- a/charts/k8s-infra/templates/otel-deployment/deployment.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "otelDeployment.fullname" . }}
+  namespace: {{ include "k8s-infra.namespace" . }}
   labels:
     {{- include "otelDeployment.labels" . | nindent 4 }}
   {{- if .Values.otelDeployment.annotations }}

--- a/charts/k8s-infra/templates/otel-deployment/ingress.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/ingress.yaml
@@ -7,6 +7,7 @@ apiVersion: {{ include "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "k8s-infra.namespace" . }}
   labels:
     {{- include "otelDeployment.labels" . | nindent 4 }}
   {{- with .Values.otelDeployment.ingress.annotations }}

--- a/charts/k8s-infra/templates/otel-deployment/service.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "otelDeployment.fullname" . }}
+  namespace: {{ include "k8s-infra.namespace" . }}
   labels:
     {{- include "otelDeployment.labels" . | nindent 4 }}
 {{- with .Values.otelAgent }}

--- a/charts/k8s-infra/templates/otel-deployment/serviceaccount.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "otelDeployment.serviceAccountName" . }}
+  namespace: {{ include "k8s-infra.namespace" . }}
   labels:
     {{- include "otelDeployment.labels" . | nindent 4 }}
   {{- with .Values.otelDeployment.serviceAccount.annotations }}

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -17,7 +17,10 @@ enabled: true
 
 # -- Endpoint/IP Address of the SigNoz or any other OpenTelemetry backend.
 # Set it to `ingest.signoz.io:4317` for SigNoz SaaS.
-otelCollectorEndpoint: my-release-signoz-otel-collector.platform.svc.cluster.local:4317
+#
+# If set to null and the chart is installed as dependency, it will attempt
+# to autogenerate the endpoint of SigNoz OtelCollector.
+otelCollectorEndpoint: null
 
 # -- Whether the OTLP endpoint is insecure.
 # Set this to false, in case of secure OTLP endpoint.
@@ -25,6 +28,9 @@ otelInsecure: true
 
 # -- API key of SigNoz SaaS
 signozApiKey: ""
+
+# -- Kubernetes cluster domain used when k8s-infra component installed in different namespace
+clusterDomain: cluster.local
 
 # -- Which namespace to install k8s-infra components.
 # By default installed to the namespace same as the chart.
@@ -403,8 +409,8 @@ otelAgent:
                 - ${MY_POD_IP}:8888
     processors:
       batch:
-        send_batch_size: 10000
-        timeout: 10s
+        send_batch_size: 5000
+        timeout: 5s
       # Resource detection processor config.
       # ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/README.md
       resourcedetection:
@@ -709,8 +715,8 @@ otelDeployment:
                   - ${MY_POD_IP}:8888
     processors:
       batch:
-        send_batch_size: 10000
-        timeout: 10s
+        send_batch_size: 5000
+        timeout: 5s
       # Memory Limiter processor.
       # If set to null, will be overridden with values based on k8s resource limits.
       memory_limiter: null

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -26,6 +26,10 @@ otelInsecure: true
 # -- API key of SigNoz SaaS
 signozApiKey: ""
 
+# -- Which namespace to install k8s-infra components.
+# By default installed to the namespace same as the chart.
+namespace: ""
+
 # Default values for OtelAgent
 otelAgent:
   name: "otel-agent"

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1582,8 +1582,26 @@ k8s-infra:
   # -- Whether to enable K8s infra monitoring
   enabled: true
 
-  # -- Endpoint/IP Address of the SigNoz.
-  otelCollectorEndpoint: my-release-signoz-otel-collector.platform.svc.cluster.local:4317
+  # -- Endpoint/IP Address of the SigNoz or any other OpenTelemetry backend.
+  # Set it to `ingest.signoz.io:4317` for SigNoz SaaS.
+  #
+  # If set to null and the chart is installed as dependency, it will attempt
+  # to autogenerate the endpoint of SigNoz OtelCollector.
+  otelCollectorEndpoint: null
+
+  # -- Whether the OTLP endpoint is insecure.
+  # Set this to false, in case of secure OTLP endpoint.
+  otelInsecure: true
+
+  # -- API key of SigNoz SaaS
+  signozApiKey: ""
+
+  # -- Kubernetes cluster domain used when k8s-infra component installed in different namespace
+  clusterDomain: cluster.local
+
+  # -- Which namespace to install k8s-infra components.
+  # By default installed to the namespace same as the chart.
+  namespace: ""
 
   # Default values for OtelAgent
   otelAgent:


### PR DESCRIPTION
- custom namespace support for k8s-infra chart
- otel endpoint automatically generated when installed as dependency of signoz chart
- k8s-infra patch release: `0.1.3`