### PR TITLE
fix: use default override setting

### DIFF
--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -417,7 +417,6 @@ otelAgent:
         detectors: [env, system]  # Include ec2/eks for AWS, gce/gke for GCP and azure/aks for Azure
         # Using OTEL_RESOURCE_ATTRIBUTES envvar, env detector adds custom labels
         timeout: 2s
-        override: false
         system:
           hostname_sources: [os]  # Alternatively, use [dns,os] for setting FQDN as host.name and os as fallback
       # Memory Limiter processor config.

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1188,7 +1188,6 @@ otelCollector:
         detectors: [env, system]  # Include ec2/eks for AWS, gce/gke for GCP and azure/aks for Azure
         # Using OTEL_RESOURCE_ATTRIBUTES envvar, env detector adds custom labels
         timeout: 2s
-        override: false
         system:
           hostname_sources: [os]  # Alternatively, use [dns,os] for setting FQDN as host.name and os as fallback
       signozspanmetrics/prometheus:


### PR DESCRIPTION
The current config is probably taken directly from examples as is but the default and preferred way is to override the existing keys https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/common#attribute-collections. The `resourcedetection` configured with env adds `service.instance.id` and any data that is already received which has that attribute will not be overridden with the given config. This is also the reason why other metrics including up couldn't be written to DB hence not showing up in dashboards. There is an ongoing effort to stabilize and spec'd out the details of OTLP -> Prom data conversion and we should update parts of our exporter which will be addressed another issue.