### PR TITLE
Support for secure clickhouse in SigNoz chart

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,7 @@ on:
       - 'charts/**'
 
 jobs:
-  lint-test:
+  lint-chart:
     runs-on: ubuntu-latest
     env:
       CT_CONFIG: ct-lint.yaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ on:
       - 'charts/**'
 
 jobs:
-  lint-test:
+  test-chart:
     runs-on: ubuntu-latest
     env:
       CT_CONFIG: ct-test.yaml

--- a/charts/signoz/templates/otel-collector-metrics/deployment.yaml
+++ b/charts/signoz/templates/otel-collector-metrics/deployment.yaml
@@ -33,11 +33,13 @@ spec:
         - name: {{ include "otelCollectorMetrics.fullname" . }}-init
           image: {{ include "otelCollectorMetrics.initContainers.init.image" . }}
           imagePullPolicy: {{ .Values.otelCollectorMetrics.initContainers.init.image.pullPolicy }}
+          env:
+            {{- include "snippet.clickhouse-credentials" . | nindent 12 }}
           {{- with .Values.otelCollectorMetrics.initContainers.init.command }}
           command:
             - sh
             - -c
-            - until wget --spider -q {{ include "clickhouse.httpUrl" $ }}{{ .endpoint }}; do echo -e "{{ .waitMessage }}"; sleep {{ .delay }}; done; echo -e "{{ .doneMessage }}";
+            - until wget --user "${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}" --spider -q {{ include "clickhouse.httpUrl" $ }}{{ .endpoint }}; do echo -e "{{ .waitMessage }}"; sleep {{ .delay }}; done; echo -e "{{ .doneMessage }}";
           {{- end -}}
         {{- end }}
       containers:

--- a/charts/signoz/templates/otel-collector/deployment.yaml
+++ b/charts/signoz/templates/otel-collector/deployment.yaml
@@ -35,11 +35,13 @@ spec:
         - name: {{ include "otelCollector.fullname" . }}-init
           image: {{ include "otelCollector.initContainers.init.image" . }}
           imagePullPolicy: {{ .Values.otelCollector.initContainers.init.image.pullPolicy }}
+          env:
+            {{- include "snippet.clickhouse-credentials" . | nindent 12 }}
           {{- with .Values.otelCollector.initContainers.init.command }}
           command:
             - sh
             - -c
-            - until wget --spider -q {{ include "clickhouse.httpUrl" $ }}{{ .endpoint }}; do echo -e "{{ .waitMessage }}"; sleep {{ .delay }}; done; echo -e "{{ .doneMessage }}";
+            - until wget --user "${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}" --spider -q {{ include "clickhouse.httpUrl" $ }}{{ .endpoint }}; do echo -e "{{ .waitMessage }}"; sleep {{ .delay }}; done; echo -e "{{ .doneMessage }}";
           {{- end -}}
         {{- end }}
       containers:

--- a/charts/signoz/templates/query-service/statefulset.yaml
+++ b/charts/signoz/templates/query-service/statefulset.yaml
@@ -25,12 +25,14 @@ spec:
         - name: {{ include "queryService.fullname" . }}-init
           image: {{ include "queryService.initContainers.init.image" . }}
           imagePullPolicy: {{ .Values.queryService.initContainers.init.image.pullPolicy }}
-        {{- with .Values.queryService.initContainers.init.command }}
+          env:
+            {{- include "snippet.clickhouse-credentials" . | nindent 12 }}
+          {{- with .Values.queryService.initContainers.init.command }}
           command:
             - sh
             - -c
-            - until wget --spider -q {{ include "clickhouse.httpUrl" $ }}{{ .endpoint }}; do echo -e "{{ .waitMessage }}"; sleep {{ .delay }}; done; echo -e "{{ .doneMessage }}";
-        {{- end }}
+            - until wget --user "${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}" --spider -q {{ include "clickhouse.httpUrl" $ }}{{ .endpoint }}; do echo -e "{{ .waitMessage }}"; sleep {{ .delay }}; done; echo -e "{{ .doneMessage }}";
+          {{- end }}
       {{- end }}
       containers:
         - name: {{ include "queryService.fullname" . }}
@@ -48,6 +50,7 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
+            {{- include "snippet.clickhouse-credentials" . | nindent 12 }}
             - name: STORAGE
               value: {{ .Values.queryService.configVars.storage }}
             - name: ClickHouseUrl


### PR DESCRIPTION
Support for secure clickhouse in SigNoz chart.

_Note: We will need to make changes in query-service and otel-collector exporters. Tracking issue: [here](https://github.com/SigNoz/engineering-pod/issues/773)._