### PR TITLE
fix default values.yaml and ingress hostname in post install NOTES

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.4.4
+version: 0.4.5
 appVersion: "0.11.2"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/templates/NOTES.txt
+++ b/charts/signoz/templates/NOTES.txt
@@ -13,7 +13,7 @@
 {{- range $host := .Values.frontend.ingress.hosts }}
 
   {{- range .paths }}
-  http{{ if $.Values.frontend.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  http{{ if $.Values.frontend.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 
 {{- end }}

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1897,7 +1897,7 @@ k8s-infra:
 # @ignored
 cert-manager:
   enabled: false
-  installCRDs: true
+  installCRDs: false
 
 ###
 ###
@@ -1954,6 +1954,7 @@ keycloak:
 
   postgresql:
     auth:
+      postgresPassword: pgadminpass123
       username: bn_keycloak
       password: bn_keycloak@123
       database: bitnami_keycloak


### PR DESCRIPTION
Fixes #95 

-  fix ingress hostname in post install NOTES 
- fix default values.yaml:
  - disable `installCRDs` of `cert-manager`
  - include `postgresPassword` configuration for `keycloak`

Signed-off-by: Prashant Shahi <prashant@signoz.io>
