### PR TITLE
Fix character limit when setting prometheus receiver

### DIFF
--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -991,7 +991,7 @@ otelCollector:
       nodePort: ""
       # -- Protocol to use for Zipkin
       protocol: TCP
-    prometheus-metrics:
+    prometheus:
       # -- Whether to enable service port for SigNoz exported prometheus metrics
       enabled: false
       # -- Container port for SigNoz exported prometheus metrics


### PR DESCRIPTION
There's a limit of 15 characters when creating a service in kubernetes. Prometheus-metrics exceeds this limits. 
Renaming it to solve. 