### PR TITLE
k8s-infra: improve kubeletstats receiver

### DIFF
--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -164,6 +164,10 @@ receivers:
     auth_type: {{ .Values.presets.kubeletMetrics.authType }}
     endpoint: {{ .Values.presets.kubeletMetrics.endpoint }}
     insecure_skip_verify: {{ default true .Values.presets.kubeletMetrics.insecureSkipVerify }}
+    extra_metadata_labels:
+      {{ toYaml .Values.presets.kubeletMetrics.extraMetadataLabels | nindent 6 }}
+    metric_groups:
+      {{ toYaml .Values.presets.kubeletMetrics.metricGroups | nindent 6 }}
 {{- end }}
 
 {{- define "opentelemetry-collector.applyLogsCollectionConfig" -}}
@@ -178,7 +182,8 @@ receivers:
 receivers:
   filelog/k8s:
     # Include logs from all container
-    include: {{ .Values.presets.logsCollection.include }}
+    include:
+      {{ toYaml .Values.presets.logsCollection.include | nindent 6 }}
     # Blacklist specific namespaces, pods or containers if enabled
     {{- if .Values.presets.logsCollection.blacklist.enabled }}
     {{- $namespaces := .Values.presets.logsCollection.blacklist.namespaces }}
@@ -245,7 +250,5 @@ processors:
     {{ end }}
     extract:
       metadata:
-      {{ range $metadata := .Values.presets.kubernetesAttributes.extractMetadatas }}
-        - {{ $metadata }}
-      {{ end }}
+        {{ toYaml .Values.presets.kubernetesAttributes.extractMetadatas | nindent 8 }}
 {{- end }}

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -160,6 +160,14 @@ presets:
     authType: serviceAccount
     endpoint: ${K8S_NODE_NAME}:10250
     insecureSkipVerify: true
+    extraMetadataLabels: []
+      # - container.id
+      # - k8s.volume.type
+    metricGroups:
+      - container
+      - pod
+      - node
+      - volume
   kubernetesAttributes:
     enabled: true
     # -- Whether to detect the IP address of agents and add it as an attribute to all telemetry resources.


### PR DESCRIPTION
Configuration to set up metrics groups and extra metadata labels.

By default enable following `metricGroups`:
- container
- pod
- node
- volume

Signed-off-by: Prashant Shahi <prashant@signoz.io>
