### PR TITLE
improve metrics and labels

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.4.2
+version: 0.4.3
 appVersion: "0.66.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/templates/_helpers.tpl
+++ b/charts/k8s-infra/templates/_helpers.tpl
@@ -338,3 +338,50 @@ Return if ingress is stable.
 {{- include "k8s-infra.fullname" . }}-secrets
 {{- end }}
 {{- end -}}
+
+{{/*
+Common K8s environment variables used by OtelAgent and OtelDeployment.
+*/}}
+{{- define "snippet.k8s-env" }}
+- name: K8S_NODE_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: spec.nodeName
+- name: K8S_POD_IP
+  valueFrom:
+    fieldRef:
+      apiVersion: v1
+      fieldPath: status.podIP
+- name: K8S_HOST_IP
+  valueFrom:
+    fieldRef:
+      fieldPath: status.hostIP
+- name: K8S_POD_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.name
+- name: K8S_POD_UID
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.uid
+- name: K8S_NAMESPACE
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.namespace
+{{- end }}
+
+{{/*
+OTLP exporter environment variables used by OtelAgent and OtelDeployment.
+*/}}
+{{- define "snippet.otlp-env" }}
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: {{ include "otel.endpoint" . }}
+- name: OTEL_EXPORTER_OTLP_INSECURE
+  value: {{ include "otel.insecure" . }}
+- name: SIGNOZ_API_KEY
+  value: {{ include "otel.signozApiKey" . }}
+- name: OTEL_EXPORTER_OTLP_INSECURE_SKIP_VERIFY
+  value: {{ include "otel.insecureSkipVerify" . }}
+- name: OTEL_SECRETS_PATH
+  value: {{ include "otel.secretsPath" . }}
+{{- end }}

--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -52,35 +52,10 @@ spec:
             - {{ . | quote }}
             {{- end }}
           env:
-            - name: K8S_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: HOST_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-            - name: K8S_NAMESPACE
-              valueFrom:
-                  fieldRef:
-                    fieldPath: metadata.namespace
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
+            {{- include "snippet.otlp-env" . | nindent 12 }}
+            {{- include "snippet.k8s-env" . | nindent 12 }}
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: host.name=$(K8S_NODE_NAME)
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: {{ include "otel.endpoint" . }}
-            - name: OTEL_EXPORTER_OTLP_INSECURE
-              value: {{ include "otel.insecure" . }}
-            - name: SIGNOZ_API_KEY
-              value: {{ include "otel.signozApiKey" . }}
-            - name: OTEL_EXPORTER_OTLP_INSECURE_SKIP_VERIFY
-              value: {{ include "otel.insecureSkipVerify" . }}
-            - name: OTEL_SECRETS_PATH
-              value: {{ include "otel.secretsPath" . }}
+              value: host.name=$(K8S_NODE_NAME),signoz.component=otel-deployment
           volumeMounts:
             - name: otel-agent-config-vol
               mountPath: /conf

--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -54,8 +54,10 @@ spec:
           env:
             {{- include "snippet.otlp-env" . | nindent 12 }}
             {{- include "snippet.k8s-env" . | nindent 12 }}
+            - name: K8S_CLUSTER_NAME
+              value: {{ default .Values.global.clusterName .Values.clusterName }}
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: host.name=$(K8S_NODE_NAME),signoz.component=otel-deployment
+              value: host.name=$(K8S_NODE_NAME),signoz.component=otel-deployment,k8s.cluster.name=${K8S_CLUSTER_NAME}
           volumeMounts:
             - name: otel-agent-config-vol
               mountPath: /conf

--- a/charts/k8s-infra/templates/otel-deployment/deployment.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/deployment.yaml
@@ -57,8 +57,10 @@ spec:
           env:
             {{- include "snippet.otlp-env" . | nindent 12 }}
             {{- include "snippet.k8s-env" . | nindent 12 }}
+            - name: K8S_CLUSTER_NAME
+              value: {{ default .Values.global.clusterName .Values.clusterName }}
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: host.name=$(K8S_NODE_NAME),signoz.component=otel-deployment
+              value: host.name=$(K8S_NODE_NAME),signoz.component=otel-deployment,k8s.cluster.name=${K8S_CLUSTER_NAME}
           volumeMounts:
             - name: otel-deployment-config-vol
               mountPath: /conf

--- a/charts/k8s-infra/templates/otel-deployment/deployment.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/deployment.yaml
@@ -55,21 +55,10 @@ spec:
           securityContext:
             {{- toYaml .Values.otelDeployment.securityContext | nindent 12 }}
           env:
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: {{ include "otel.endpoint" . }}
-            - name: OTEL_EXPORTER_OTLP_INSECURE
-              value: {{ include "otel.insecure" . }}
-            - name: SIGNOZ_API_KEY
-              value: {{ include "otel.signozApiKey" . }}
-            - name: OTEL_EXPORTER_OTLP_INSECURE_SKIP_VERIFY
-              value: {{ include "otel.insecureSkipVerify" . }}
-            - name: OTEL_SECRETS_PATH
-              value: {{ include "otel.secretsPath" . }}
+            {{- include "snippet.otlp-env" . | nindent 12 }}
+            {{- include "snippet.k8s-env" . | nindent 12 }}
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: host.name=$(K8S_NODE_NAME),signoz.component=otel-deployment
           volumeMounts:
             - name: otel-deployment-config-vol
               mountPath: /conf

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -8,6 +8,12 @@ global:
   # -- Kubernetes cluster domain
   # It is used only when components are installed in different namespace
   clusterDomain: cluster.local
+  # -- Kubernetes cluster name
+  # It is used to attached to telemetry data via resource detection processor
+  clusterName: ""
+
+# -- Whether to enable K8s infra chart
+enabled: true
 
 # -- K8s infra chart name override
 nameOverride: ""
@@ -15,8 +21,8 @@ nameOverride: ""
 # -- K8s infra chart full name override
 fullnameOverride: ""
 
-# -- Whether to enable K8s infra chart
-enabled: true
+# -- Name of the K8s cluster. Used by OtelCollectors to attach in telemetry data.
+clusterName: ""
 
 # -- Endpoint/IP Address of the SigNoz or any other OpenTelemetry backend.
 # Set it to `ingest.signoz.io:4317` for SigNoz SaaS.

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -487,20 +487,23 @@ otelAgent:
           http:
             endpoint: 0.0.0.0:4318
     processors:
+      # Batch processor config.
+      # ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md
       batch:
         send_batch_size: 10000
         timeout: 200ms
       # Resource detection processor config.
       # ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/README.md
       resourcedetection:
-        detectors: [env, system]  # Include ec2/eks for AWS, gce/gke for GCP and azure/aks for Azure
-        # Using OTEL_RESOURCE_ATTRIBUTES envvar, env detector adds custom labels
+        # detectors: include ec2/eks for AWS, gce/gke for GCP and azure/aks for Azure
+        # env detector included below adds custom labels using OTEL_RESOURCE_ATTRIBUTES envvar
+        detectors: [env, system]
         timeout: 2s
         system:
-          hostname_sources: [os]  # Alternatively, use [dns,os] for setting FQDN as host.name and os as fallback
-      # Memory Limiter processor config.
+          hostname_sources: [os]
+      # Memory Limiter processor.
       # If set to null, will be overridden with values based on k8s resource limits.
-      # ref: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor
+      # ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md
       memory_limiter: null
     extensions:
       health_check:
@@ -774,12 +777,23 @@ otelDeployment:
   config:
     receivers: {}
     processors:
+      # Batch processor config.
+      # ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md
       batch:
         send_batch_size: 10000
         timeout: 1s
-
+      # Resource detection processor config.
+      # ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/README.md
+      resourcedetection:
+        # detectors: include ec2/eks for AWS, gce/gke for GCP and azure/aks for Azure
+        # env detector included below adds custom labels using OTEL_RESOURCE_ATTRIBUTES envvar
+        detectors: [env, system]
+        timeout: 2s
+        system:
+          hostname_sources: [os]
       # Memory Limiter processor.
       # If set to null, will be overridden with values based on k8s resource limits.
+      # ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md
       memory_limiter: null
     extensions:
       health_check:
@@ -797,5 +811,5 @@ otelDeployment:
       pipelines:
         metrics:
           receivers: []
-          processors: [batch]
+          processors: [resourcedetection, batch]
           exporters: []

--- a/charts/signoz/templates/_otelcol.tpl
+++ b/charts/signoz/templates/_otelcol.tpl
@@ -1,0 +1,26 @@
+{{/*
+Common K8s environment variables used by SigNoz OtelCollector.
+*/}}
+{{- define "snippet.k8s-env" }}
+- name: K8S_NODE_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: spec.nodeName
+- name: K8S_POD_IP
+  valueFrom:
+    fieldRef:
+      apiVersion: v1
+      fieldPath: status.podIP
+- name: K8S_POD_NAME
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.name
+- name: K8S_POD_UID
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.uid
+- name: K8S_NAMESPACE
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.namespace
+{{- end }}

--- a/charts/signoz/templates/otel-collector-metrics/deployment.yaml
+++ b/charts/signoz/templates/otel-collector-metrics/deployment.yaml
@@ -73,11 +73,11 @@ spec:
           {{- end }}
           env:
             {{- include "snippet.clickhouse-env" . | nindent 12 }}
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
+            - name: K8S_CLUSTER_NAME
+              value: {{ default .Values.global.clusterName .Values.clusterName }}
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: host.name=signoz-host,os.type=linux,signoz.component=otel-collector-metrics
+            {{- include "snippet.k8s-env" . | nindent 12 }}
           volumeMounts:
             - name: otel-collector-metrics-config-vol
               mountPath: /conf

--- a/charts/signoz/templates/otel-collector/deployment.yaml
+++ b/charts/signoz/templates/otel-collector/deployment.yaml
@@ -73,13 +73,11 @@ spec:
           {{- end }}
           env:
             {{- include "snippet.clickhouse-env" . | nindent 12 }}
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
+            - name: K8S_CLUSTER_NAME
+              value: {{ default .Values.global.clusterName .Values.clusterName }}
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: host.name=signoz-host,os.type=linux
+              value: host.name=signoz-host,os.type=linux,signoz.component=otel-collector,k8s.cluster.name=${K8S_CLUSTER_NAME}
+            {{- include "snippet.k8s-env" . | nindent 12 }}
           volumeMounts:
             - name: otel-collector-config-vol
               mountPath: /conf

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -8,6 +8,9 @@ global:
   # -- Kubernetes cluster domain
   # It is used only when components are installed in different namespace
   clusterDomain: cluster.local
+  # -- Kubernetes cluster name
+  # It is used to attached to telemetry data via resource detection processor
+  clusterName: ""
 
 # -- SigNoz chart name override
 nameOverride: ""
@@ -15,15 +18,28 @@ nameOverride: ""
 # -- SigNoz chart full name override
 fullnameOverride: ""
 
+# -- Name of the K8s cluster. Used by SigNoz OtelCollectors to attach in telemetry data.
+clusterName: ""
+
 # Clickhouse default values
 # For complete list of configurations, check `values.yaml` of `clickhouse` chart.
 # @ignored
 clickhouse:
+  # -- Whether to install clickhouse. If false, `clickhouse.host` must be set
+  enabled: true
+
   # -- Cloud service being deployed on (example: `aws`, `azure`, `gcp`, `hcloud`, `other`).
   # Based on the cloud, storage class for the persistent volume is selected.
   # When set to 'aws' or 'gcp', new expandible storage class is created.
   # When set to something else or not set, the default storage class (if any) from the k8s cluster is selected.
   cloud: other
+
+  # -- Which namespace to install clickhouse and `clickhouse-operator` to (defaults to namespace chart is installed to)
+  namespace: ""
+  # -- Name override for clickhouse
+  nameOverride: ""
+  # -- Fullname override for clickhouse
+  fullnameOverride: ""
 
   # Zookeeper default values
   # @ignored
@@ -44,16 +60,6 @@ clickhouse:
 
     # -- Whether to install zookeeper into a different namespace than the parent
     namespaceOverride: ""
-
-  # -- Whether to install clickhouse. If false, `clickhouse.host` must be set
-  enabled: true
-
-  # -- Which namespace to install clickhouse and `clickhouse-operator` to (defaults to namespace chart is installed to)
-  namespace: ""
-  # -- Name override for clickhouse
-  nameOverride: ""
-  # -- Fullname override for clickhouse
-  fullnameOverride: ""
 
   # -- Clickhouse cluster
   cluster: cluster
@@ -921,8 +927,9 @@ otelCollector:
   # -- OtelColector pod(s) annotation.
   podAnnotations:
     signoz.io/scrape: 'true'
-    signoz.io/port: '8889'
-    signoz.io/path: /metrics
+    signoz.io/port: '8888'
+    apm.signoz.io/scrape: 'true'
+    apm.signoz.io/port: '8889'
 
   minReadySeconds: 5
   progressDeadlineSeconds: 120
@@ -1229,42 +1236,25 @@ otelCollector:
           disk: {}
           filesystem: {}
           network: {}
-      prometheus:
-        config:
-          global:
-            scrape_interval: 60s
-          scrape_configs:
-            - job_name: otel-collector
-              static_configs:
-                - targets:
-                    - ${MY_POD_IP}:8888
-                  labels:
-                    job_name: otel-collector
     processors:
+      # Batch processor config.
+      # ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md
       batch:
         send_batch_size: 50000
         timeout: 1s
-
-      # memory_limiter:
-      #   check_interval: 1s
-      #   # 80% of maximum memory up to 2G
-      #   limit_mib: 1500
-      #   # 25% of limit up to 2G
-      #   spike_limit_mib: 512
-      #   check_interval: 5s
-      #
-      #   # 80% of the maximum memory
-      #   limit_percentage: 80
-      #   # 60% of max memory usage spike expected
-      #   spike_limit_percentage: 60
-
-      # Ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/README.md
+      # Resource detection processor config.
+      # ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/README.md
       resourcedetection:
         detectors: [env, system]  # Include ec2/eks for AWS, gce/gke for GCP and azure/aks for Azure
         # Using OTEL_RESOURCE_ATTRIBUTES envvar, env detector adds custom labels
         timeout: 2s
         system:
           hostname_sources: [os]  # Alternatively, use [dns,os] for setting FQDN as host.name and os as fallback
+      # Memory Limiter processor config.
+      # If set to null, will be overridden with values based on k8s resource limits.
+      # ref: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor
+      memory_limiter: null
+      # SigNoz internal spanmetrics processor which generates metrics from traces
       signozspanmetrics/prometheus:
         metrics_exporter: prometheus
         latency_histogram_buckets:
@@ -1293,6 +1283,22 @@ otelCollector:
             default: default
           - name: deployment.environment
             default: default
+      k8sattributes:
+        passthrough: true
+        pod_association:
+          - from: resource_attribute
+            name: k8s.pod.ip
+          - from: resource_attribute
+            name: k8s.pod.uid
+          - from: connection
+        extract:
+          metadata:
+            - k8s.namespace.name
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.pod.start_time
+            - k8s.deployment.name
+            - k8s.node.name
     extensions:
       health_check:
         endpoint: 0.0.0.0:13133
@@ -1307,8 +1313,6 @@ otelCollector:
         endpoint: tcp://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/?database=${CLICKHOUSE_DATABASE}&username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}
         resource_to_telemetry_conversion:
           enabled: true
-      clickhousemetricswrite/prometheus:
-        endpoint: tcp://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/?database=${CLICKHOUSE_DATABASE}&username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}
       clickhouselogsexporter:
         dsn: tcp://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/?username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}
         timeout: 10s
@@ -1329,7 +1333,7 @@ otelCollector:
       pipelines:
         traces:
           receivers: [jaeger, otlp]
-          processors: [signozspanmetrics/prometheus, batch]
+          processors: [k8sattributes, signozspanmetrics/prometheus, batch]
           exporters: [clickhousetraces]
         metrics:
           receivers: [otlp]
@@ -1339,16 +1343,12 @@ otelCollector:
           receivers: [hostmetrics]
           processors: [resourcedetection, batch]
           exporters: [clickhousemetricswrite]
-        metrics/prometheus:
-          receivers: [prometheus]
-          processors: [batch]
-          exporters: [clickhousemetricswrite/prometheus]
         metrics/spanmetrics:
           receivers: [otlp/spanmetrics]
           exporters: [prometheus]
         logs:
           receivers: [otlp]
-          processors: [batch]
+          processors: [k8sattributes, batch]
           exporters: [clickhouselogsexporter]
 
 # Default values for OtelCollectorMetrics
@@ -1391,7 +1391,10 @@ otelCollectorMetrics:
   # -- OtelColectorMetrics Deployment annotation.
   annotations: {}
   # -- OtelColectorMetrics pod(s) annotation.
-  podAnnotations: {}
+  podAnnotations:
+    signoz.io/scrape: 'true'
+    signoz.io/port: '8888'
+    signoz.io/path: /metrics
 
   podSecurityContext: {}
     # fsGroup: 2000
@@ -1570,14 +1573,54 @@ otelCollectorMetrics:
       prometheus:
         config:
           scrape_configs:
-            # otel-collector-metrics internal metrics
-            - job_name: "otel-collector-metrics"
+            # internal signoz apm spanmetrics scraper (scrapped when pod annotations are set)
+            - job_name: "signoz-spanmetrics-collector"
               scrape_interval: 60s
-              static_configs:
-                - targets:
-                    - ${MY_POD_IP}:8888
-                  labels:
-                    job_name: otel-collector-metrics
+              kubernetes_sd_configs:
+                - role: pod
+              relabel_configs:
+                - source_labels:
+                    [__meta_kubernetes_pod_annotation_apm_signoz_io_scrape]
+                  action: keep
+                  regex: true
+                - source_labels:
+                    [__meta_kubernetes_pod_annotation_apm_signoz_io_path]
+                  action: replace
+                  target_label: __metrics_path__
+                  regex: (.+)
+                - source_labels:
+                    [
+                      __meta_kubernetes_pod_ip,
+                      __meta_kubernetes_pod_annotation_apm_signoz_io_port,
+                    ]
+                  action: replace
+                  separator: ":"
+                  target_label: __address__
+                - target_label: job_name
+                  replacement: signoz-spanmetrics-collector
+                - action: labelmap
+                  regex: __meta_kubernetes_pod_label_(.+)
+                - source_labels: [__meta_kubernetes_namespace]
+                  action: replace
+                  target_label: k8s_namespace_name
+                - source_labels: [__meta_kubernetes_pod_name]
+                  action: replace
+                  target_label: k8s_pod_name
+                - source_labels: [__meta_kubernetes_pod_uid]
+                  action: replace
+                  target_label: k8s_pod_uid
+                - source_labels: [__meta_kubernetes_pod_container_name]
+                  action: replace
+                  target_label: k8s_container_name
+                - source_labels: [__meta_kubernetes_pod_node_name]
+                  action: replace
+                  target_label: k8s_node_name
+                - source_labels: [__meta_kubernetes_pod_ready]
+                  action: replace
+                  target_label: k8s_pod_ready
+                - source_labels: [__meta_kubernetes_pod_phase]
+                  action: replace
+                  target_label: k8s_pod_phase
             # generic prometheus metrics scraper (scrapped when pod annotations are set)
             - job_name: "generic-collector"
               scrape_interval: 60s
@@ -1601,33 +1644,49 @@ otelCollectorMetrics:
                   action: replace
                   separator: ":"
                   target_label: __address__
+                - target_label: job_name
+                  replacement: generic-collector
                 - action: labelmap
                   regex: __meta_kubernetes_pod_label_(.+)
                 - source_labels: [__meta_kubernetes_namespace]
                   action: replace
-                  target_label: k8s_namespace
+                  target_label: k8s_namespace_name
                 - source_labels: [__meta_kubernetes_pod_name]
                   action: replace
-                  target_label: k8s_pod
+                  target_label: k8s_pod_name
+                - source_labels: [__meta_kubernetes_pod_uid]
+                  action: replace
+                  target_label: k8s_pod_uid
+                - source_labels: [__meta_kubernetes_pod_container_name]
+                  action: replace
+                  target_label: k8s_container_name
+                - source_labels: [__meta_kubernetes_pod_node_name]
+                  action: replace
+                  target_label: k8s_node_name
+                - source_labels: [__meta_kubernetes_pod_ready]
+                  action: replace
+                  target_label: k8s_pod_ready
+                - source_labels: [__meta_kubernetes_pod_phase]
+                  action: replace
+                  target_label: k8s_pod_phase
     processors:
+      # Batch processor config.
+      # ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md
       batch:
         send_batch_size: 10000
         timeout: 1s
-
-      # -- Memory Limiter processor
+      # Resource detection processor config.
+      # ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/README.md
+      resourcedetection:
+        detectors: [env, system]  # Include ec2/eks for AWS, gce/gke for GCP and azure/aks for Azure
+        # Using OTEL_RESOURCE_ATTRIBUTES envvar, env detector adds custom labels
+        timeout: 2s
+        system:
+          hostname_sources: [os]  # Alternatively, use [dns,os] for setting FQDN as host.name and os as fallback
+      # Memory Limiter processor config.
       # If set to null, will be overridden with values based on k8s resource limits.
+      # ref: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor
       memory_limiter: null
-      # memory_limiter:
-      #   # 80% of maximum memory up to 2G
-      #   limit_mib: 1500
-      #   # 25% of limit up to 2G
-      #   spike_limit_mib: 512
-      #   check_interval: 5s
-      #
-      #   # 50% of the maximum memory
-      #   limit_percentage: 50
-      #   # 20% of max memory usage spike expected
-      #   spike_limit_percentage: 20
     extensions:
       health_check:
         endpoint: 0.0.0.0:13133
@@ -1646,6 +1705,9 @@ otelCollectorMetrics:
       pipelines:
         metrics:
           receivers: [prometheus]
+          # other processor which appends attributes would basically be no-op
+          # since resource to telemetry conversion is not enabled for the exporter
+          # processors: [batch]
           processors: [batch]
           exporters: [clickhousemetricswrite]
 
@@ -1892,6 +1954,8 @@ k8s-infra:
             http:
               endpoint: 0.0.0.0:4318
       processors:
+        # Batch processor config.
+        # ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md
         batch:
           send_batch_size: 10000
           timeout: 200ms
@@ -1992,11 +2056,22 @@ k8s-infra:
     config:
       receivers: {}
       processors:
+        # Batch processor config.
+        # ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md
         batch:
           send_batch_size: 10000
           timeout: 1s
-        # Memory Limiter processor.
+        # Resource detection processor config.
+        # ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/README.md
+        resourcedetection:
+          detectors: [env, system]  # Include ec2/eks for AWS, gce/gke for GCP and azure/aks for Azure
+          # Using OTEL_RESOURCE_ATTRIBUTES envvar, env detector adds custom labels
+          timeout: 2s
+          system:
+            hostname_sources: [os]  # Alternatively, use [dns,os] for setting FQDN as host.name and os as fallback
+        # Memory Limiter processor config.
         # If set to null, will be overridden with values based on k8s resource limits.
+        # ref: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor
         memory_limiter: null
       extensions:
         health_check:


### PR DESCRIPTION
- snippet templates to include K8s and Otel envvars 
- attach more k8s labels using `relabel_config`
- introduce `clusterName` configuration in both signoz and k8s-infra charts which is attached to telemetry data using resourcedection env
- introduce `apm.signoz.io/scrape` annotations for signoz apm spanmetrics
- otelcol internal metrics: switch from `static_config` scraping to `signoz.io/scrape` annotation scraping for consistent labels across both charts
- use `k8sattributes` processor in OtelCollector and `resourcedetection` processor from missing pipelines

Note: After `resource_to_telemetry_conversion` issue is resolved, we could include `k8sattributes`, `resourcedetection` or `resource` processors in metrics pipeline.