### PR TITLE
chore: 🔧 remove init container label from scrapped metrics

### DIFF
--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1693,6 +1693,9 @@ otelCollectorMetrics:
                 - source_labels: [__meta_kubernetes_pod_container_name]
                   action: replace
                   target_label: k8s_container_name
+                - source_labels: [__meta_kubernetes_pod_container_name]
+                  regex: (.+)-init
+                  action: drop
                 - source_labels: [__meta_kubernetes_pod_node_name]
                   action: replace
                   target_label: k8s_node_name


### PR DESCRIPTION
Signed-off-by: Prashant Shahi <prashant@signoz.io>