### PR TITLE
Move to attributes instead of resources.

### DIFF
--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -132,19 +132,19 @@ presets:
         to: attributes["log.iostream"]
       - type: move
         from: attributes.container_name
-        to: resource["k8s.container.name"]
+        to: attributes["k8s.container.name"]
       - type: move
         from: attributes.namespace
-        to: resource["k8s.namespace.name"]
+        to: attributes["k8s.namespace.name"]
       - type: move
         from: attributes.pod_name
-        to: resource["k8s.pod.name"]
+        to: attributes["k8s.pod.name"]
       - type: move
         from: attributes.restart_count
-        to: resource["k8s.container.restart_count"]
+        to: attributes["k8s.container.restart_count"]
       - type: move
         from: attributes.uid
-        to: resource["k8s.pod.uid"]
+        to: attributes["k8s.pod.uid"]
       # Clean up log body
       - type: move
         from: attributes.log


### PR DESCRIPTION
The k8sattribute processor adds to attributes by default, so it can override this and there will be no duplicates.