### PR TITLE
fix: resolve alertmanager internal port issue

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.10.0
+version: 0.10.1
 appVersion: "0.15.0"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/templates/_helpers.tpl
+++ b/charts/signoz/templates/_helpers.tpl
@@ -496,11 +496,11 @@ Return the service name of Clickhouse
 {{/*
 Return `nodePort: null` if service type is ClusterIP
 */}}
-{{- define "service.ifClusterIP" -}}
-{{- if (eq . "ClusterIP") -}}
+{{- define "signoz.service.ifClusterIP" -}}
+{{- if (eq . "ClusterIP") }}
 nodePort: null
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}
 
 {{/*
 Return structured list of ports config.

--- a/charts/signoz/templates/alertmanager/services.yaml
+++ b/charts/signoz/templates/alertmanager/services.yaml
@@ -13,13 +13,13 @@ spec:
   type: {{ .type }}
   ports:
     - port: {{ .port }}
-      {{- include "service.ifClusterIP" .type | nindent 6 }}
+      {{- include "signoz.service.ifClusterIP" .type | nindent 6 }}
       targetPort: http
       protocol: TCP
       name: http
-    {{- if (and (eq .type "NodePort") .nodePort) }}
+      {{- if (and (eq .type "NodePort") .nodePort) }}
       nodePort: {{ .nodePort }}
-    {{- end }}
+      {{- end }}
 {{- end }}
   selector:
     {{- include "alertmanager.selectorLabels" . | nindent 4 }}
@@ -39,12 +39,12 @@ spec:
       protocol: TCP
       name: http
     {{- if or (gt (int .replicaCount) 1) (.additionalPeers) }}
-    - port: 9094
-      targetPort: 9094
+    - port: {{ .service.clusterPort }}
+      targetPort: {{ .service.clusterPort }}
       protocol: TCP
       name: cluster-tcp
-    - port: 9094
-      targetPort: 9094
+    - port: {{ .service.clusterPort }}
+      targetPort: {{ .service.clusterPort }}
       protocol: UDP
       name: cluster-udp
     {{- end }}

--- a/charts/signoz/templates/alertmanager/statefulset.yaml
+++ b/charts/signoz/templates/alertmanager/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- $svcClusterPort := .Values.alertmanager.service.clusterPort }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -109,13 +110,13 @@ spec:
             - --storage.path=/alertmanager
             - --queryService.url=http://{{ include "queryService.internalUrl" . }}
             {{- if or (gt (int .Values.alertmanager.replicaCount) 1) (.Values.alertmanager.additionalPeers) }}
-            - --cluster.advertise-address=$(POD_IP):9094
-            - --cluster.listen-address=0.0.0.0:9094
+            - --cluster.advertise-address=$(POD_IP):{{ $svcClusterPort }}
+            - --cluster.listen-address=0.0.0.0:{{ $svcClusterPort }}
             {{- end }}
             {{- if gt (int .Values.alertmanager.replicaCount) 1 }}
             {{- $fullName := include "alertmanager.fullname" . }}
             {{- range $i := until (int .Values.alertmanager.replicaCount) }}
-            - --cluster.peer={{ $fullName }}-{{ $i }}.{{ $fullName }}-headless:9094
+            - --cluster.peer={{ $fullName }}-{{ $i }}.{{ $fullName }}-headless:{{ $svcClusterPort }}
             {{- end }}
             {{- end }}
             {{- if .Values.alertmanager.additionalPeers }}
@@ -128,7 +129,7 @@ spec:
             {{- end }}
           ports:
             - name: http
-              containerPort: 9093
+              containerPort: {{ default 9093 .Values.alertmanager.service.port }}
               protocol: TCP
           livenessProbe:
             {{- toYaml .Values.alertmanager.livenessProbe | nindent 12 }}

--- a/charts/signoz/templates/frontend/service.yaml
+++ b/charts/signoz/templates/frontend/service.yaml
@@ -13,7 +13,7 @@ spec:
   type: {{ .type }}
   ports:
     - port: {{ .port }}
-      {{- include "service.ifClusterIP" .type | nindent 6 }}
+      {{- include "signoz.service.ifClusterIP" .type | nindent 6 }}
       targetPort: http
       protocol: TCP
       name: http

--- a/charts/signoz/templates/query-service/service.yaml
+++ b/charts/signoz/templates/query-service/service.yaml
@@ -12,16 +12,22 @@ metadata:
 spec:
   type: {{ .type }}
   ports:
-    - port: {{ .port }}
-      {{- include "service.ifClusterIP" .type | nindent 6 }}
-      targetPort: http
+    - name: http
+      port: {{ .port }}
+      {{- include "signoz.service.ifClusterIP" .type | indent 6 }}
       protocol: TCP
-      name: http
-    - port: {{ .internalPort }}
-      {{- include "service.ifClusterIP" .type | nindent 6 }}
       targetPort: http
+      {{- if (and (eq .type "NodePort") .nodePort) }}
+      nodePort: {{ .nodePort }}
+      {{- end }}
+    - name: http-internal
+      port: {{ .internalPort }}
+      {{- include "signoz.service.ifClusterIP" .type | indent 6 }}
       protocol: TCP
-      name: http-internal
+      targetPort: http-internal
+      {{- if (and (eq .type "NodePort") .internalNodePort) }}
+      nodePort: {{ .internalNodePort }}
+      {{- end }}
 {{- end }}
   selector:
     {{- include "queryService.selectorLabels" . | nindent 4 }}

--- a/charts/signoz/templates/query-service/statefulset.yaml
+++ b/charts/signoz/templates/query-service/statefulset.yaml
@@ -51,7 +51,10 @@ spec:
           args: ["-config=/root/config/prometheus.yml"]
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: {{ default 8080  .Values.queryService.service.port }}
+              protocol: TCP
+            - name: http-internal
+              containerPort: {{ default 8085 .Values.queryService.service.internalPort }}
               protocol: TCP
           env:
             {{- include "snippet.clickhouse-credentials" . | nindent 12 }}

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -454,6 +454,12 @@ queryService:
     port: 8080
     # -- Query-Service Internal port
     internalPort: 8085
+    # -- Set this to you want to force a specific nodePort for http.
+    # Must be use with service.type=NodePort
+    nodePort: null
+    # -- Set this to you want to force a specific nodePort for internal.
+    # Must be use with service.type=NodePort
+    internalNodePort: null
 
   initContainers:
     init:
@@ -758,6 +764,8 @@ alertmanager:
     type: ClusterIP
     # -- Alertmanager HTTP port
     port: 9093
+    # -- Alertmanager cluster port
+    clusterPort: 9094
     # -- Set this to you want to force a specific nodePort. Must be use with service.type=NodePort
     nodePort: null
 


### PR DESCRIPTION
Tested the changes:
```
$ kubectl exec -n platform -it signoz-alertmanager-0 -- sh
Defaulted container "signoz-alertmanager" out of: signoz-alertmanager, signoz-alertmanager-init (init)

/alertmanager $ wget -q -O - signoz-query-service:8085/api/v1/channels

{"status":"success","data":[]}
```

Signed-off-by: Prashant Shahi <prashant@signoz.io>
