### PR TITLE
fix: Fix rendering error when clickhouse files are specified

### DIFF
--- a/charts/clickhouse/templates/_helper.tpl
+++ b/charts/clickhouse/templates/_helper.tpl
@@ -184,8 +184,7 @@ Return list of files and contents.
 */}}
 {{- define "clickhouse.files" -}}
 {{- range $key,$value := .Values.files }}
-{{ $key }}: |
-  {{ $value }}
+{{ $key }}: {{ $value | toYaml }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
If trying to render clickhouse with the following
```bash
helm template charts/clickhouse -f broken-values.yaml
```

and the values.yaml
```yaml
files:
  config.d/log_rotation.xml: |
    <clickhouse>
      <logger>
        <level>xxx</level>
        <console>true</console>
        <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
        <log>/var/log/clickhouse-server/clickhouse-server.log</log>
        <size>100M</size>
        <count>10</count>
      </logger>
    </clickhouse>
```

helm unindentds and break the output yaml
```
coalesce.go:175: warning: skipped value for zookeeper.initContainers: Not a table.
Error: YAML parse error on clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml: error converting YAML to JSON: yaml: line 77: could not find expected ':'
```
