### PR TITLE
chore(k8s-infra): pin OtelCollector 0.70.0 and related changes for SigNoz SaaS support

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -3,7 +3,7 @@ name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
 version: 0.6.7
-appVersion: "0.66.0"
+appVersion: "0.70.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg
 keywords:

--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.6.7
+version: 0.7.0
 appVersion: "0.70.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -90,8 +90,10 @@ exporters:
     tls:
       insecure: ${OTEL_EXPORTER_OTLP_INSECURE}
       insecure_skip_verify: ${OTEL_EXPORTER_OTLP_INSECURE_SKIP_VERIFY}
+      {{- if .Values.otelTlsSecrets.enabled }}
       cert_file: ${OTEL_SECRETS_PATH}/cert.pem
       key_file: ${OTEL_SECRETS_PATH}/key.pem
+      {{- end }}
     headers:
       "signoz-access-token": "Bearer ${SIGNOZ_API_KEY}"
 {{- end }}

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -251,7 +251,7 @@ otelAgent:
   image:
     registry: docker.io
     repository: otel/opentelemetry-collector-contrib
-    tag: 0.66.0
+    tag: 0.70.0
     pullPolicy: IfNotPresent
 
   # -- Image Registry Secret Names for OtelAgent.
@@ -585,7 +585,7 @@ otelDeployment:
   image:
     registry: docker.io
     repository: otel/opentelemetry-collector-contrib
-    tag: 0.66.0
+    tag: 0.70.0
     pullPolicy: IfNotPresent
 
   # -- Image Registry Secret Names for OtelDeployment.


### PR DESCRIPTION
- include cert and key files only when enabled
- pin versions: OtelCollector `0.70.0`
- release k8s-infra: `0.7.0`

Signed-off-by: Prashant Shahi <prashant@signoz.io>
