### PR TITLE
chore(otel-config): 🔧 remove k8sattr and resourcedetection processors from otlp pipeline

### DIFF
--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1518,12 +1518,12 @@ otelCollector:
       extensions: [health_check, zpages]
       pipelines:
         traces:
-          receivers: [jaeger, otlp]
-          processors: [signozspanmetrics/prometheus, k8sattributes, batch]
+          receivers: [otlp, jaeger]
+          processors: [signozspanmetrics/prometheus, batch]
           exporters: [clickhousetraces]
         metrics:
           receivers: [otlp]
-          processors: [k8sattributes, batch]
+          processors: [batch]
           exporters: [clickhousemetricswrite]
         metrics/generic:
           receivers: [hostmetrics]
@@ -1534,7 +1534,7 @@ otelCollector:
           exporters: [prometheus]
         logs:
           receivers: [otlp]
-          processors: [k8sattributes, batch]
+          processors: [batch]
           exporters: [clickhouselogsexporter]
 
 # Default values for OtelCollectorMetrics


### PR DESCRIPTION
Fixes #184 

_Screenshot:_

<img width="365" alt="Screenshot 2023-03-14 at 5 44 27 AM" src="https://user-images.githubusercontent.com/11138844/224903784-f22b0e4d-0735-4cee-88b8-4c07342505a4.png">


Signed-off-by: Prashant Shahi <prashant@signoz.io>