### PR TITLE
fix(signoz): match correct path for namespace exclusion

### DIFF
--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -208,13 +208,13 @@ receivers:
     # The file format is /var/log/pods/<namespace_name>_<pod_name>_<pod_uid>/<container_name>/<run_id>.log
     exclude:
       {{- if .Values.presets.logsCollection.blacklist.signozLogs }}
-      - /var/log/pods/{{ .Release.Namespace }}_*.log
+      - /var/log/pods/{{ .Release.Namespace }}_*/*/*.log
       {{- if and .Values.namespace (ne .Release.Namespace .Values.namespace) }}
-      - /var/log/pods/{{ .Values.namespace }}_*.log
+      - /var/log/pods/{{ .Values.namespace }}_*/*/*.log
       {{- end }}
       {{- end }}
       {{- range $namespace := $namespaces }}
-      - /var/log/pods/{{ $namespace }}_*.log
+      - /var/log/pods/{{ $namespace }}_*/*/*.log
       {{- end }}
       {{- range $pod := $pods }}
       - /var/log/pods/*_{{ $pod }}*_*/*/*.log


### PR DESCRIPTION
Path for a container log is something like:

```
"/var/log/pods/platform_mon-signoz-otel-collector-dffb45dbb-r9c6r_e951d249-f208-47f3-aa35-81a096ba2ade/istio-proxy/0.log"
```

The existing rule:

```
/var/log/pods/{{ .Release.Namespace }}_*.log
```

excludes log files files in /var/log/pods rather than the container pod logs.

Fixes: https://github.com/SigNoz/charts/issues/193