### PR TITLE
Fix incorrect default values file

### DIFF
--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -380,15 +380,6 @@ clickhouse:
       # -- Whether to send log and errorlog to the console instead of file. To enable, set to 1 or true.
       console: 1
 
-  initContainers:
-    init:
-      enabled: true
-      image:
-        registry: docker.io
-        repository: busybox
-        tag: 1.35
-        pullPolicy: IfNotPresent
-
     # -- Clickhouse Operator pod(s) annotation.
     podAnnotations:
       signoz.io/port: '8888'

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -368,6 +368,18 @@ clickhouse:
       # If not set and create is true, a name is generated using the fullname template
       name:
 
+    # Clickhouse logging config
+    logger:
+      # -- Logging level. Acceptable values: trace, debug, information, warning, error.
+      level: information
+      # -- Size of the file. Applies to log and errorlog. Once the file reaches size,
+      # ClickHouse archives and renames it, and creates a new log file in its place.
+      size: 1000M
+      # -- The number of archived log files that ClickHouse stores.
+      count: 10
+      # -- Whether to send log and errorlog to the console instead of file. To enable, set to 1 or true.
+      console: 1
+
   initContainers:
     init:
       enabled: true
@@ -384,18 +396,6 @@ clickhouse:
 
     # -- Clickhouse Operator node selector
     nodeSelector: {}
-
-    # Clickhouse logging config
-    logger:
-      # -- Logging level. Acceptable values: trace, debug, information, warning, error.
-      level: information
-      # -- Size of the file. Applies to log and errorlog. Once the file reaches size,
-      # ClickHouse archives and renames it, and creates a new log file in its place.
-      size: 1000M
-      # -- The number of archived log files that ClickHouse stores.
-      count: 10
-      # -- Whether to send log and errorlog to the console instead of file. To enable, set to 1 or true.
-      console: 1
 
     # -- Metrics Exporter config.
     metricsExporter:


### PR DESCRIPTION
The clickhouse logging config belongs under clickhouseOperator (see "clickhouse" chart), but it is incorrectly under the "initContainers" key in the signoz default values.yaml