### PR TITLE
chore(k8s-infra): 🔧  otel-collector config changes

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.7.3
+version: 0.8.0
 appVersion: "0.71.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -114,17 +114,8 @@ Build config file for deployment OpenTelemetry Collector: OtelDeployment
 {{- $values := deepCopy .Values }}
 {{- $data := dict "Values" $values | mustMergeOverwrite (deepCopy .) }}
 {{- $config := include "otelDeployment.baseConfig" $data | fromYaml }}
-{{- if .Values.presets.hostMetrics.enabled }}
-{{- $config = (include "opentelemetry-collector.applyHostMetricsConfig" (dict "Values" $data "config" $config) | fromYaml) }}
-{{- end }}
-{{- if .Values.presets.kubernetesAttributes.enabled }}
-{{- $config = (include "opentelemetry-collector.applyKubernetesAttributesConfig" (dict "Values" $data "config" $config) | fromYaml) }}
-{{- end }}
 {{- if .Values.presets.resourceDetectionInternal.enabled }}
 {{- $config = (include "opentelemetry-collector.applyResourceDetectionInternalConfig" (dict "Values" $data "config" $config) | fromYaml) }}
-{{- end }}
-{{- if .Values.presets.resourceDetection.enabled }}
-{{- $config = (include "opentelemetry-collector.applyResourceDetectionConfig" (dict "Values" $data "config" $config) | fromYaml) }}
 {{- end }}
 {{- if .Values.presets.clusterMetrics.enabled }}
 {{- $config = (include "opentelemetry-collector.applyClusterMetricsConfig" (dict "Values" $data "config" $config) | fromYaml) }}
@@ -140,8 +131,8 @@ Build config file for deployment OpenTelemetry Collector: OtelDeployment
 
 {{- define "opentelemetry-collector.applyClusterMetricsConfig" -}}
 {{- $config := mustMergeOverwrite (include "opentelemetry-collector.clusterMetricsConfig" .Values | fromYaml) .config }}
-{{- if $config.service.pipelines.metrics }}
-{{- $_ := set $config.service.pipelines.metrics "receivers" (append $config.service.pipelines.metrics.receivers "k8s_cluster" | uniq)  }}
+{{- if index $config.service.pipelines "metrics/generic" }}
+{{- $_ := set (index $config.service.pipelines "metrics/generic") "receivers" (append (index (index $config.service.pipelines "metrics/generic") "receivers") "k8s_cluster" | uniq)  }}
 {{- end }}
 {{- $config | toYaml }}
 {{- end }}

--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -57,8 +57,8 @@ Build config file for daemonset OpenTelemetry Collector: OtelAgent
 {{- if $config.service.pipelines.traces }}
 {{- $_ := set $config.service.pipelines.traces "exporters" (prepend $config.service.pipelines.traces.exporters "logging" | uniq)  }}
 {{- end }}
-{{- if index $config.service.pipelines "metrics/generic" }}
-{{- $_ := set (index $config.service.pipelines "metrics/generic") "exporters" (prepend (index (index $config.service.pipelines "metrics/generic") "exporters") "logging" | uniq)  }}
+{{- if index $config.service.pipelines "metrics/internal" }}
+{{- $_ := set (index $config.service.pipelines "metrics/internal") "exporters" (prepend (index (index $config.service.pipelines "metrics/internal") "exporters") "logging" | uniq)  }}
 {{- end }}
 {{- $config | toYaml }}
 {{- end }}
@@ -85,8 +85,8 @@ exporters:
 {{- if $config.service.pipelines.traces }}
 {{- $_ := set $config.service.pipelines.traces "exporters" (prepend $config.service.pipelines.traces.exporters "otlp" | uniq)  }}
 {{- end }}
-{{- if index $config.service.pipelines "metrics/generic" }}
-{{- $_ := set (index $config.service.pipelines "metrics/generic") "exporters" (prepend (index (index $config.service.pipelines "metrics/generic") "exporters") "otlp" | uniq)  }}
+{{- if index $config.service.pipelines "metrics/internal" }}
+{{- $_ := set (index $config.service.pipelines "metrics/internal") "exporters" (prepend (index (index $config.service.pipelines "metrics/internal") "exporters") "otlp" | uniq)  }}
 {{- end }}
 {{- $config | toYaml }}
 {{- end }}
@@ -131,8 +131,8 @@ Build config file for deployment OpenTelemetry Collector: OtelDeployment
 
 {{- define "opentelemetry-collector.applyClusterMetricsConfig" -}}
 {{- $config := mustMergeOverwrite (include "opentelemetry-collector.clusterMetricsConfig" .Values | fromYaml) .config }}
-{{- if index $config.service.pipelines "metrics/generic" }}
-{{- $_ := set (index $config.service.pipelines "metrics/generic") "receivers" (append (index (index $config.service.pipelines "metrics/generic") "receivers") "k8s_cluster" | uniq)  }}
+{{- if index $config.service.pipelines "metrics/internal" }}
+{{- $_ := set (index $config.service.pipelines "metrics/internal") "receivers" (append (index (index $config.service.pipelines "metrics/internal") "receivers") "k8s_cluster" | uniq)  }}
 {{- end }}
 {{- $config | toYaml }}
 {{- end }}
@@ -149,8 +149,8 @@ receivers:
 
 {{- define "opentelemetry-collector.applyHostMetricsConfig" -}}
 {{- $config := mustMergeOverwrite (include "opentelemetry-collector.hostMetricsConfig" .Values | fromYaml) .config }}
-{{- if index $config.service.pipelines "metrics/generic" }}
-{{- $_ := set (index $config.service.pipelines "metrics/generic") "receivers" (append (index (index $config.service.pipelines "metrics/generic") "receivers") "hostmetrics" | uniq)  }}
+{{- if index $config.service.pipelines "metrics/internal" }}
+{{- $_ := set (index $config.service.pipelines "metrics/internal") "receivers" (append (index (index $config.service.pipelines "metrics/internal") "receivers") "hostmetrics" | uniq)  }}
 {{- end }}
 {{- $config | toYaml }}
 {{- end }}
@@ -167,8 +167,8 @@ receivers:
 
 {{- define "opentelemetry-collector.applyKubeletMetricsConfig" -}}
 {{- $config := mustMergeOverwrite (include "opentelemetry-collector.kubeletMetricsConfig" .Values | fromYaml) .config }}
-{{- if index $config.service.pipelines "metrics/generic" }}
-{{- $_ := set (index $config.service.pipelines "metrics/generic") "receivers" (append (index (index $config.service.pipelines "metrics/generic") "receivers") "kubeletstats" | uniq)  }}
+{{- if index $config.service.pipelines "metrics/internal" }}
+{{- $_ := set (index $config.service.pipelines "metrics/internal") "receivers" (append (index (index $config.service.pipelines "metrics/internal") "receivers") "kubeletstats" | uniq)  }}
 {{- end }}
 {{- $config | toYaml }}
 {{- end }}
@@ -250,8 +250,8 @@ receivers:
 {{- if $config.service.pipelines.traces }}
 {{- $_ := set $config.service.pipelines.traces "processors" (prepend $config.service.pipelines.traces.processors "k8sattributes" | uniq) }}
 {{- end }}
-{{- if index $config.service.pipelines "metrics/generic" }}
-{{- $_ := set (index $config.service.pipelines "metrics/generic") "processors" (prepend (index (index $config.service.pipelines "metrics/generic") "processors") "k8sattributes" | uniq) }}
+{{- if index $config.service.pipelines "metrics/internal" }}
+{{- $_ := set (index $config.service.pipelines "metrics/internal") "processors" (prepend (index (index $config.service.pipelines "metrics/internal") "processors") "k8sattributes" | uniq) }}
 {{- end }}
 {{- $config | toYaml }}
 {{- end }}
@@ -273,8 +273,8 @@ processors:
 
 {{- define "opentelemetry-collector.applyResourceDetectionConfig" -}}
 {{- $config := mustMergeOverwrite (include "opentelemetry-collector.resourceDetectionConfig" .Values | fromYaml) .config }}
-{{- if index $config.service.pipelines "metrics/generic" }}
-{{- $_ := set (index $config.service.pipelines "metrics/generic") "processors" (prepend (index (index $config.service.pipelines "metrics/generic") "processors") "resourcedetection" | uniq) }}
+{{- if index $config.service.pipelines "metrics/internal" }}
+{{- $_ := set (index $config.service.pipelines "metrics/internal") "processors" (prepend (index (index $config.service.pipelines "metrics/internal") "processors") "resourcedetection" | uniq) }}
 {{- end }}
 {{- $config | toYaml }}
 {{- end }}
@@ -295,8 +295,8 @@ processors:
 
 {{- define "opentelemetry-collector.applyResourceDetectionInternalConfig" -}}
 {{- $config := mustMergeOverwrite (include "opentelemetry-collector.resourceDetectionInternalConfig" .Values | fromYaml) .config }}
-{{- if index $config.service.pipelines "metrics/generic" }}
-{{- $_ := set (index $config.service.pipelines "metrics/generic") "processors" (prepend (index (index $config.service.pipelines "metrics/generic") "processors") "resourcedetection/internal" | uniq) }}
+{{- if index $config.service.pipelines "metrics/internal" }}
+{{- $_ := set (index $config.service.pipelines "metrics/internal") "processors" (prepend (index (index $config.service.pipelines "metrics/internal") "processors") "resourcedetection/internal" | uniq) }}
 {{- end }}
 {{- $config | toYaml }}
 {{- end }}

--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -65,7 +65,12 @@ Build config file for daemonset OpenTelemetry Collector: OtelAgent
 
 {{- define "opentelemetry-collector.loggingExporterConfig" -}}
 exporters:
-  logging: {}
+  logging:
+    {{- with .Values.presets.loggingExporter }}
+    verbosity: {{ .verbosity }}
+    sampling_initial: {{ .samplingInitial }}
+    sampling_thereafter: {{ .samplingThereafter }}
+    {{- end }}
 {{- end }}
 
 

--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -95,7 +95,7 @@ spec:
             - name: SIGNOZ_COMPONENT
               value: {{ default "otel-agent" .Values.otelAgent.name }}
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: host.name=$(K8S_NODE_NAME),signoz.component=$(SIGNOZ_COMPONENT),k8s.cluster.name=$(K8S_CLUSTER_NAME),k8s.pod.uid=$(K8S_POD_UID),k8s.pod.ip=$(K8S_POD_IP)
+              value: signoz.component=$(SIGNOZ_COMPONENT),k8s.cluster.name=$(K8S_CLUSTER_NAME),k8s.pod.uid=$(K8S_POD_UID),k8s.pod.ip=$(K8S_POD_IP)
           volumeMounts:
             - name: otel-agent-config-vol
               mountPath: /conf

--- a/charts/k8s-infra/templates/otel-deployment/deployment.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/deployment.yaml
@@ -90,7 +90,7 @@ spec:
             - name: SIGNOZ_COMPONENT
               value: {{ default "otel-deployment" .Values.otelDeployment.name }}
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: host.name=$(K8S_NODE_NAME),signoz.component=$(SIGNOZ_COMPONENT),k8s.cluster.name=$(K8S_CLUSTER_NAME),k8s.pod.uid=$(K8S_POD_UID),k8s.pod.ip=$(K8S_POD_IP)
+              value: signoz.component=$(SIGNOZ_COMPONENT),k8s.cluster.name=$(K8S_CLUSTER_NAME),k8s.pod.uid=$(K8S_POD_UID),k8s.pod.ip=$(K8S_POD_IP)
           volumeMounts:
             - name: otel-deployment-config-vol
               mountPath: /conf

--- a/charts/k8s-infra/templates/otel-deployment/deployment.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/deployment.yaml
@@ -90,7 +90,7 @@ spec:
             - name: SIGNOZ_COMPONENT
               value: {{ default "otel-deployment" .Values.otelDeployment.name }}
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: signoz.component=$(SIGNOZ_COMPONENT),k8s.cluster.name=$(K8S_CLUSTER_NAME),k8s.pod.uid=$(K8S_POD_UID),k8s.pod.ip=$(K8S_POD_IP)
+              value: signoz.component=$(SIGNOZ_COMPONENT),k8s.cluster.name=$(K8S_CLUSTER_NAME)
           volumeMounts:
             - name: otel-deployment-config-vol
               mountPath: /conf

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -75,9 +75,9 @@ presets:
     # Verbosity of the logging export: basic, normal, detailed
     verbosity: basic
     # Number of messages initially logged each second
-    sampling_initial: 2
+    samplingInitial: 2
     # Sampling rate after the initial messages are logged
-    sampling_thereafter: 500
+    samplingThereafter: 500
   otlpExporter:
     enabled: true
   logsCollection:

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -72,6 +72,12 @@ namespace: ""
 presets:
   loggingExporter:
     enabled: false
+    # Verbosity of the logging export: basic, normal, detailed
+    verbosity: basic
+    # Number of messages initially logged each second
+    sampling_initial: 2
+    # Sampling rate after the initial messages are logged
+    sampling_thereafter: 500
   otlpExporter:
     enabled: true
   logsCollection:

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -881,10 +881,6 @@ otelDeployment:
           address: 0.0.0.0:8888
       extensions: [health_check, zpages, pprof]
       pipelines:
-        metrics:
-          receivers: []
-          processors: [batch]
-          exporters: []
         metrics/generic:
           receivers: []
           processors: [batch]

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -600,7 +600,7 @@ otelAgent:
           receivers: [otlp]
           processors: [batch]
           exporters: []
-        metrics/generic:
+        metrics/internal:
           receivers: []
           processors: [batch]
           exporters: []
@@ -881,7 +881,7 @@ otelDeployment:
           address: 0.0.0.0:8888
       extensions: [health_check, zpages, pprof]
       pipelines:
-        metrics/generic:
+        metrics/internal:
           receivers: []
           processors: [batch]
           exporters: []

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -131,6 +131,12 @@ presets:
         id: extract_metadata_from_filepath
         regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
         parse_from: attributes["log.file.path"]
+        output: add_cluster_name
+      # Add cluster name attribute from environment variable
+      - id: add_cluster_name
+        type: add
+        field: resource["k8s.cluster.name"]
+        value: EXPR(env("K8S_CLUSTER_NAME"))
         output: move_stream
       # Rename attributes
       - type: move
@@ -235,6 +241,11 @@ presets:
       - memory
       # - ephemeral-storage
       # - storage
+  resourceDetectionInternal:
+    enabled: true
+    timeout: 2s
+    # DO NOT CHANGE BELOW TO false, causes data duplication in case attributes mismatched.
+    override: true
   resourceDetection:
     enabled: true
     timeout: 2s
@@ -243,7 +254,6 @@ presets:
     # detectors: include ec2/eks for AWS, gce/gke for GCP and azure/aks for Azure
     # env detector included below adds custom labels using OTEL_RESOURCE_ATTRIBUTES envvar
     detectors:
-      - env
       # - elastic_beanstalk
       # - eks
       # - ecs
@@ -574,7 +584,7 @@ otelAgent:
       telemetry:
         metrics:
           address: 0.0.0.0:8888
-      extensions: [health_check, zpages]
+      extensions: [health_check, zpages, pprof]
       pipelines:
         traces:
           receivers: [otlp]

--- a/charts/signoz/templates/otel-collector-metrics/deployment.yaml
+++ b/charts/signoz/templates/otel-collector-metrics/deployment.yaml
@@ -103,7 +103,7 @@ spec:
             - name: SIGNOZ_COMPONENT
               value: {{ default "otel-collector-metrics" .Values.otelCollectorMetrics.name}}
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: host.name=$(K8S_NODE_NAME),signoz.component=$(SIGNOZ_COMPONENT),k8s.cluster.name=$(K8S_CLUSTER_NAME),k8s.pod.uid=$(K8S_POD_UID),k8s.pod.ip=$(K8S_POD_IP)
+              value: signoz.component=$(SIGNOZ_COMPONENT),k8s.cluster.name=$(K8S_CLUSTER_NAME),k8s.pod.uid=$(K8S_POD_UID),k8s.pod.ip=$(K8S_POD_IP)
           volumeMounts:
             - name: otel-collector-metrics-config-vol
               mountPath: /conf

--- a/charts/signoz/templates/otel-collector/deployment.yaml
+++ b/charts/signoz/templates/otel-collector/deployment.yaml
@@ -103,7 +103,7 @@ spec:
             - name: SIGNOZ_COMPONENT
               value: {{ default "otel-collector" .Values.otelCollector.name}}
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: host.name=$(K8S_NODE_NAME),signoz.component=$(SIGNOZ_COMPONENT),k8s.cluster.name=$(K8S_CLUSTER_NAME),k8s.pod.uid=$(K8S_POD_UID),k8s.pod.ip=$(K8S_POD_IP)
+              value: signoz.component=$(SIGNOZ_COMPONENT),k8s.cluster.name=$(K8S_CLUSTER_NAME),k8s.pod.uid=$(K8S_POD_UID),k8s.pod.ip=$(K8S_POD_IP)
             - name: LOW_CARDINAL_EXCEPTION_GROUPING
               value: {{ default "false" .Values.otelCollector.lowCardinalityExceptionGrouping | quote }}
           volumeMounts:


### PR DESCRIPTION
- deprecated `host_name` for K8s in favour of `k8s_node_name`
- in `filelog`, used `add` operator with `env` expression to include `k8s_cluster_name`
- removed `resourcedetection` processor from pipelines with OTLP receivers
- created `resourcedetection/internal` for `env` detector in `otelAgent` and `otelDeployment`
- more options for logging exporter
- enabled pprof extension in otelAgent but the ports not enabled by default
- removed `k8sattributes` and `resourcedetection` processors as well as `hostmetrics` receiver from `otelDeployment`

Commands to generate complete configs of `otelAgent` and `otelDeployment`:

```bash
helm template charts/k8s-infra -s templates/otel-agent/configmap.yaml > otel-agent-config.yaml

helm template charts/k8s-infra -s templates/otel-deployment/configmap.yaml > otel-deployment-config.yaml
```

Signed-off-by: Prashant Shahi <prashant@signoz.io>
