### PR TITLE
chore(clickhouse): 🔧 support for logs persistence and rename templates to default

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for ClickHouse
 type: application
-version: 23.10.0
+version: 23.11.0
 appVersion: "22.8.8"
 icon: https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/website/images/logo-400x240.png
 sources:

--- a/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
+++ b/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
@@ -1,3 +1,5 @@
+{{- $dataVolumeClaimFlag := and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+{{- $logVolumeClaimFlag := and .Values.logPersistence.enabled (not .Values.logPersistence.existingClaim) }}
 apiVersion: clickhouse.altinity.com/v1
 kind: ClickHouseInstallation
 metadata:
@@ -8,9 +10,11 @@ metadata:
 spec:
   defaults:
     templates:
-      {{- if and (.Values.persistence.enabled) (not .Values.persistence.existingClaim) }}
+      {{- if $dataVolumeClaimFlag }}
       dataVolumeClaimTemplate: default
-      # logVolumeClaimTemplate: default-log
+      {{- end }}
+      {{- if $logVolumeClaimFlag }}
+      logVolumeClaimTemplate: default-log
       {{- end }}
       serviceTemplate: default
 
@@ -154,12 +158,18 @@ spec:
           {{- if not .Values.persistence.enabled }}
             - name: data-volume
               emptyDir: {}
-            # - name: log-volume
-            #   emptyDir: {}
           {{- else if .Values.persistence.existingClaim }}
             - name: existing-volumeclaim
               persistentVolumeClaim:
                 claimName: {{ .Values.persistence.existingClaim }}
+          {{- end }}
+          {{- if not .Values.logPersistence.enabled }}
+            - name: log-volume
+              emptyDir: {}
+          {{- else if .Values.logPersistence.existingClaim }}
+            - name: existing-log-volumeclaim
+              persistentVolumeClaim:
+                claimName: {{ .Values.logPersistence.existingClaim }}
           {{- end }}
             - name: shared-binary-volume
               emptyDir: {}
@@ -221,12 +231,18 @@ spec:
                 - name: default
               {{- end }}
                   mountPath: /var/lib/clickhouse
+              {{- if not .Values.logPersistence.enabled }}
+                - name: log-volume
+              {{- else if .Values.logPersistence.existingClaim }}
+                - name: existing-log-volumeclaim
+              {{- else }}
+                - name: default-log
+              {{- end }}
+                  mountPath: /var/log/clickhouse-server
                 - name: shared-binary-volume
                   mountPath: /var/lib/clickhouse/user_scripts
                 - name: custom-functions-volume
                   mountPath: /etc/clickhouse-server/functions
-                # - name: default-log
-                #   mountPath: /var/log/clickhouse-server
 
               {{- if .Values.resources }}
               resources: {{ toYaml .Values.resources | nindent 16 }}
@@ -254,21 +270,44 @@ spec:
               {{ include "service.ifClusterIP" .type -}}
         {{- end }}
 
-    {{- if and (.Values.persistence.enabled) (not .Values.persistence.existingClaim) }}
+    {{- if or $dataVolumeClaimFlag $logVolumeClaimFlag }}
     volumeClaimTemplates:
+      {{- if $dataVolumeClaimFlag }}
+      {{- with .Values.persistence }}
       - name: default
         spec:
           accessModes:
-            {{- toYaml .Values.persistence.accessModes | nindent 12 }}
+            {{- toYaml .accessModes | nindent 12 }}
           resources:
             requests:
-              storage: {{ .Values.persistence.size }}
-        {{- $storageClass := default .Values.persistence.storageClass .Values.global.storageClass -}}
+              storage: {{ .size }}
+        {{- $storageClass := default .storageClass $.Values.global.storageClass -}}
         {{- if $storageClass -}}
         {{- if (eq "-" $storageClass) }}
           storageClassName: ""
         {{- else }}
           storageClassName: {{ $storageClass }}
         {{- end }}
+        {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- if $logVolumeClaimFlag }}
+      {{- with .Values.logPersistence }}
+      - name: default-log
+        spec:
+          accessModes:
+            {{- toYaml .accessModes | nindent 12 }}
+          resources:
+            requests:
+              storage: {{ .size }}
+        {{- $storageClass := default .storageClass $.Values.global.storageClass -}}
+        {{- if $storageClass -}}
+        {{- if (eq "-" $storageClass) }}
+          storageClassName: ""
+        {{- else }}
+          storageClassName: {{ $storageClass }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
+      {{- end }}
     {{- end }}
-  {{- end }}

--- a/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
+++ b/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
@@ -9,10 +9,10 @@ spec:
   defaults:
     templates:
       {{- if and (.Values.persistence.enabled) (not .Values.persistence.existingClaim) }}
-      dataVolumeClaimTemplate: data-volumeclaim-template
-      # logVolumeClaimTemplate: log-volumeclaim-template
+      dataVolumeClaimTemplate: default
+      # logVolumeClaimTemplate: default-log
       {{- end }}
-      serviceTemplate: service-template
+      serviceTemplate: default
 
   configuration:
     users:
@@ -30,7 +30,7 @@ spec:
     clusters:
       - name: {{ .Values.cluster | quote }}
         templates:
-          podTemplate: pod-template
+          podTemplate: default
         layout:
           {{- toYaml .Values.layout | nindent 10 }}
 
@@ -121,7 +121,7 @@ spec:
 
   templates:
     podTemplates:
-      - name: pod-template
+      - name: default
         metadata:
           labels:
             {{- include "clickhouse.labels" . | nindent 12 }}
@@ -218,14 +218,14 @@ spec:
               {{- else if .Values.persistence.existingClaim }}
                 - name: existing-volumeclaim
               {{- else }}
-                - name: data-volumeclaim-template
+                - name: default
               {{- end }}
                   mountPath: /var/lib/clickhouse
                 - name: shared-binary-volume
                   mountPath: /var/lib/clickhouse/user_scripts
                 - name: custom-functions-volume
                   mountPath: /etc/clickhouse-server/functions
-                # - name: log-volumeclaim-template
+                # - name: default-log
                 #   mountPath: /var/log/clickhouse-server
 
               {{- if .Values.resources }}
@@ -233,7 +233,7 @@ spec:
               {{- end }}
 
     serviceTemplates:
-      - name: service-template
+      - name: default
         generateName: {{ include "clickhouse.fullname" . }}
         {{- with .Values.service }}
         metadata:
@@ -256,7 +256,7 @@ spec:
 
     {{- if and (.Values.persistence.enabled) (not .Values.persistence.existingClaim) }}
     volumeClaimTemplates:
-      - name: data-volumeclaim-template
+      - name: default
         spec:
           accessModes:
             {{- toYaml .Values.persistence.accessModes | nindent 12 }}

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -259,6 +259,30 @@ persistence:
   # -- Persistent Volume size
   size: 20Gi
 
+logPersistence:
+  # -- Enable log persistence using PVC.
+  enabled: true
+
+  # -- Use a manually managed Persistent Volume and Claim.
+  # If defined, PVC must be created manually before volume will be bound.
+  #
+  existingClaim: ""
+
+  # -- Persistent Volume Storage Class to use.
+  # If defined, `storageClassName: <storageClass>`.
+  # If set to "-", `storageClassName: ""`, which disables dynamic provisioning
+  # If undefined (the default) or set to `null`, no storageClassName spec is
+  # set, choosing the default provisioner.
+  #
+  storageClass: null
+
+  # -- Access Modes for persistent volume
+  accessModes:
+    - ReadWriteOnce
+
+  # -- Persistent Volume size
+  size: 100Mi
+
 # -- Clickhouse user profile configuration.
 # You can use this to override profile settings, for example
 # `default/max_memory_usage: 40000000000` or `default/max_concurrent_queries: 200`


### PR DESCRIPTION
FIxes #216

- rename chi templates to default to reduce length of generated name
- support for logs persistence

## More context

### Rename chi templates to default

Prior to this PR, `data-volumeclaim-template-chi-my-release-clickhouse-cluster-0-0-0` is the
generated name for clickhouse data PVC. Since the length of the resource name exceeds 63
characters, we are unable to create ClickHouse PVC in GKE 1.26.

After this PR, we will have default generated name as:
- `default-chi-my-release-clickhouse-cluster-0-0-0` for clickhouse data PVC
- `default-log-chi-my-release-clickhouse-cluster-0-0-0` for clickhouse log PVC, if enabled

### Support for logs persistence

Currently, logs of clickhouse would not be persisted in case it starts to crash.
By persisting logs, we should be able to look into the cause of the issue using the persisted logs by execing into `clickhouse-log` container.

Signed-off-by: Prashant Shahi <prashant@signoz.io>
