### PR TITLE
Add ability to specify podLabels for otelCollector

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.14.2
+version: 0.14.3
 appVersion: "0.18.3"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/templates/otel-collector/deployment.yaml
+++ b/charts/signoz/templates/otel-collector/deployment.yaml
@@ -26,6 +26,9 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/otel-collector/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "otelCollector.selectorLabels" . | nindent 8 }}
+        {{- if .Values.otelCollector.podLabels -}}
+          {{- toYaml .Values.otelCollector.podLabels | nindent 8 -}}
+        {{- end }}
     spec:
       {{- with .Values.otelCollector.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1065,6 +1065,8 @@ otelCollector:
     apm.signoz.io/scrape: 'true'
     apm.signoz.io/port: '8889'
     apm.signoz.io/path: /metrics
+  # -- OtelCollector pod(s) labels.
+  podLabels: {}
 
   # -- Whether to enable grouping of exceptions with same name and different stack trace.
   # This is useful when you have a lot of exceptions with same name but different stack trace.


### PR DESCRIPTION
Add ability to specify podLabels for otelCollector.

We need this to selectively inject Istio sidecars only for otelCollector pods - for added observability into latency and such.

Signed-off-by: Andriy Mykhaylyk erp.lsf@gmail.com