### PR TITLE
disable default metrics scraping in dependency charts

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for ClickHouse
 type: application
-version: 23.10.0
+version: 23.10.1
 appVersion: "22.8.8"
 icon: https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/website/images/logo-400x240.png
 sources:

--- a/charts/clickhouse/templates/clickhouse-operator/deployment.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/deployment.yaml
@@ -24,8 +24,8 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if .Values.clickhouseOperator.podAnnotations }}
-          {{- toYaml .Values.clickhouseOperator.podAnnotations | nindent 8 }}
+        {{- with .Values.clickhouseOperator.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/clickhouse-operator/configmap.yaml") . | sha256sum }}
       labels:

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -332,7 +332,7 @@ defaultSettings:
 # -- ClickHouse pod(s) annotation.
 podAnnotations: {}
   # Uncomment lines below to enable scraping of ClickHouse metrics.
-  # Be sure to uncomment `setting` to enable built-in Prometheus HTTP endpoint.
+  # Be sure to uncomment `settings` to enable built-in Prometheus HTTP endpoint.
   # signoz.io/scrape: 'true'
   # signoz.io/port: '9363'
   # signoz.io/path: /metrics
@@ -449,9 +449,9 @@ clickhouseOperator:
     name:
 
   # -- Clickhouse Operator pod(s) annotation.
-  podAnnotations:
-    signoz.io/port: '8888'
-    signoz.io/scrape: 'true'
+  podAnnotations: {}
+    # signoz.io/port: '8888'
+    # signoz.io/scrape: 'true'
 
   # -- Clickhouse Operator pod-level security attributes and common container settings.
   podSecurityContext: {}

--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: "0.71.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -17,8 +17,8 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if .Values.otelAgent.podAnnotations }}
-          {{- toYaml .Values.otelAgent.podAnnotations | nindent 8 }}
+        {{- with .Values.otelAgent.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/otel-agent/configmap.yaml") . | sha256sum }}
       labels:

--- a/charts/k8s-infra/templates/otel-deployment/deployment.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/deployment.yaml
@@ -19,8 +19,8 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if .Values.otelDeployment.podAnnotations }}
-          {{- toYaml .Values.otelDeployment.podAnnotations | nindent 8 }}
+        {{- with .Values.otelDeployment.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/otel-deployment/configmap.yaml") . | sha256sum }}
       labels:

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -319,10 +319,10 @@ otelAgent:
   # -- OtelAgent daemonset annotation.
   annotations: {}
   # -- OtelAgent pod(s) annotation.
-  podAnnotations:
-    signoz.io/scrape: 'true'
-    signoz.io/port: '8888'
-    signoz.io/path: /metrics
+  podAnnotations: {}
+    # signoz.io/scrape: 'true'
+    # signoz.io/port: '8888'
+    # signoz.io/path: /metrics
 
   # -- Minimum number of seconds for which a newly created Pod should be ready
   # without any of its containers crashing, for it to be considered available.
@@ -653,10 +653,10 @@ otelDeployment:
   # -- OtelDeployment deployment annotation.
   annotations: {}
   # -- OtelDeployment pod(s) annotation.
-  podAnnotations:
-    signoz.io/scrape: 'true'
-    signoz.io/port: '8888'
-    signoz.io/path: /metrics
+  podAnnotations: {}
+    # signoz.io/scrape: 'true'
+    # signoz.io/port: '8888'
+    # signoz.io/path: /metrics
 
   # -- Pod-level security configuration
   podSecurityContext: {}

--- a/charts/signoz/templates/otel-collector-metrics/deployment.yaml
+++ b/charts/signoz/templates/otel-collector-metrics/deployment.yaml
@@ -18,8 +18,8 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if .Values.otelCollectorMetrics.podAnnotations -}}
-          {{- toYaml .Values.otelCollectorMetrics.podAnnotations | nindent 8 -}}
+        {{- with .Values.otelCollectorMetrics.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/otel-collector-metrics/configmap.yaml") . | sha256sum }}
       labels:

--- a/charts/signoz/templates/otel-collector/deployment.yaml
+++ b/charts/signoz/templates/otel-collector/deployment.yaml
@@ -20,14 +20,14 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if .Values.otelCollector.podAnnotations -}}
-          {{- toYaml .Values.otelCollector.podAnnotations | nindent 8 -}}
+        {{- with .Values.otelCollector.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/otel-collector/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "otelCollector.selectorLabels" . | nindent 8 }}
-        {{- if .Values.otelCollector.podLabels -}}
-          {{- toYaml .Values.otelCollector.podLabels | nindent 8 -}}
+        {{- with .Values.otelCollector.podLabels }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       {{- with .Values.otelCollector.imagePullSecrets }}

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1526,7 +1526,7 @@ otelCollector:
           receivers: [otlp]
           processors: [batch]
           exporters: [clickhousemetricswrite]
-        metrics/generic:
+        metrics/internal:
           receivers: [hostmetrics]
           processors: [resourcedetection, k8sattributes, batch]
           exporters: [clickhousemetricswrite]

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1061,10 +1061,9 @@ otelCollector:
   podAnnotations:
     signoz.io/scrape: 'true'
     signoz.io/port: '8888'
-    signoz.io/path: /metrics
     apm.signoz.io/scrape: 'true'
     apm.signoz.io/port: '8889'
-    apm.signoz.io/path: /metrics
+
   # -- OtelCollector pod(s) labels.
   podLabels: {}
 
@@ -1585,7 +1584,6 @@ otelCollectorMetrics:
   podAnnotations:
     signoz.io/scrape: 'true'
     signoz.io/port: '8888'
-    signoz.io/path: /metrics
 
   podSecurityContext: {}
     # fsGroup: 2000


### PR DESCRIPTION
- pod annotations changes like formatting and removal of default `/metrics` path annotations
- use `metrics/internal` instead of `metrics/general` in otelCollector config

Signed-off-by: Prashant Shahi <prashant@signoz.io>
