### PR TITLE
chore: support for ARM

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for ClickHouse
 type: application
-version: 23.10.1
+version: 23.10.2
 appVersion: "22.8.8"
 icon: https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/website/images/logo-400x240.png
 sources:

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -43,7 +43,7 @@ zookeeper:
     # -- Zookeeper image tag.
     # Note: SigNoz ClickHouse does not support all versions of Zookeeper.
     # Please override the default only if you know what you are doing.
-    tag: 3.7.0-debian-10-r70
+    tag: 3.7.1
 
   # -- Name override for zookeeper app
   nameOverride: ""

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -135,7 +135,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `alertmanager.name`                      | Alertmanager component name                                             | `alertmanager`                    |
 | `alertmanager.image.registry`            | Alertmanager image registry name                                        | `docker.io`                       |
 | `alertmanager.image.repository`          | Container image name                                                    | `signoz/alertmanager`             |
-| `alertmanager.image.tag`                 | Container image tag                                                     | `0.23.0-0.2`                      |
+| `alertmanager.image.tag`                 | Container image tag                                                     | `0.23.1`                          |
 | `alertmanager.image.pullPolicy`          | Container pull policy                                                   | `IfNotPresent`                    |
 | `alertmanager.replicaCount`              | Number of Alertmanager nodes                                            | `1`                               |
 | `alertmanager.command`                   | Set container command to execute                                        | `[]`                              |

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -65,7 +65,7 @@ clickhouse:
       # -- Zookeeper image tag.
       # Note: SigNoz ClickHouse does not support all versions of Zookeeper.
       # Please override the default only if you know what you are doing.
-      tag: 3.7.0-debian-10-r70
+      tag: 3.7.1
 
     # -- Replica count for zookeeper
     replicaCount: 1
@@ -780,7 +780,7 @@ alertmanager:
     repository: signoz/alertmanager
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 0.23.0-0.2
+    tag: 0.23.1
 
   # -- Image Registry Secret Names for Alertmanager
   # If set, this has higher precedence than the root level or global value of imagePullSecrets.


### PR DESCRIPTION
- chore: 📌  pin versions: bitnami/zookeeper 3.7.1, alertmanager 0.23.1 
- chore(release): 🔖 Bump up clickhouse to 23.10.2

Signed-off-by: Prashant Shahi <prashant@signoz.io>
