### PR TITLE
feat: Added ability to add additional environment variables for the query service

### DIFF
--- a/charts/signoz/templates/query-service/statefulset.yaml
+++ b/charts/signoz/templates/query-service/statefulset.yaml
@@ -117,6 +117,10 @@ spec:
               value: {{ quote .Values.queryService.configVars.telemetryEnabled }}
             - name: DEPLOYMENT_TYPE
               value: {{ .Values.queryService.configVars.deploymentType }}
+            {{- range $key, $val := .Values.queryService.additionalEnvs }}
+            - name: {{ $key }}
+              value: {{ $val | toYaml }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /api/v1/version

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -481,6 +481,10 @@ queryService:
     # Must be use with service.type=NodePort
     internalNodePort: null
 
+  # -- Additional environments to set for queryService
+  additionalEnvs: {}
+    # env_key: env_value
+
   initContainers:
     init:
       enabled: true


### PR DESCRIPTION
I've added the ability to add  additional environment variables for the query service. This is needed for our setup to be able to set the CONTEXT_TIMEOUT environment variable added by a coleague of mine in https://github.com/SigNoz/signoz/commit/dcad77746ae68d411319bdd60d29e1f1b4cddff1