### PR TITLE
chore(clickhouse-operator): 🔧 use namespaced Role instead of ClusterRole

### DIFF
--- a/charts/clickhouse/templates/clickhouse-operator/role.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
-  name: {{ include "clickhouseOperator.fullname" . }}-{{ include "clickhouse.namespace" . }}
+  name: {{ include "clickhouseOperator.fullname" . }}
   namespace: {{ include "clickhouse.namespace" . }}
   labels:
     {{- include "clickhouseOperator.labels" . | nindent 4 }}

--- a/charts/clickhouse/templates/clickhouse-operator/rolebinding.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/rolebinding.yaml
@@ -1,16 +1,15 @@
-# Setup ClusterRoleBinding between ClusterRole and ServiceAccount.
-# ClusterRoleBinding is namespace-less and must have unique name
+# Setup RoleBinding between Role and ServiceAccount.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: {{ include "clickhouseOperator.fullname" . }}-{{ include "clickhouse.namespace" . }}
+  name: {{ include "clickhouseOperator.fullname" . }}
   namespace: {{ include "clickhouse.namespace" . }}
   labels:
     {{- include "clickhouseOperator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ include "clickhouseOperator.fullname" . }}-{{ include "clickhouse.namespace" . }}
+  kind: Role
+  name: {{ include "clickhouseOperator.fullname" . }}
 subjects:
 - kind: ServiceAccount
   {{- if .Values.clickhouseOperator.serviceAccount.create }}


### PR DESCRIPTION
Fixes #257

Ref: https://github.com/Altinity/clickhouse-operator/issues/994#issuecomment-1227132257

Signed-off-by: Prashant Shahi <prashant@signoz.io>
