### PR TITLE
FIX: Alertmanager - Add arg cluster.advertise-address at all times

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.25.3
+version: 0.25.4
 appVersion: "0.29.3"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/templates/alertmanager/statefulset.yaml
+++ b/charts/signoz/templates/alertmanager/statefulset.yaml
@@ -110,8 +110,8 @@ spec:
           args:
             - --storage.path=/alertmanager
             - --queryService.url=http://{{ include "queryService.internalUrl" . }}
-            {{- if or (gt (int .Values.alertmanager.replicaCount) 1) (.Values.alertmanager.additionalPeers) }}
             - --cluster.advertise-address=$(POD_IP):{{ $svcClusterPort }}
+            {{- if or (gt (int .Values.alertmanager.replicaCount) 1) (.Values.alertmanager.additionalPeers) }}
             - --cluster.listen-address=0.0.0.0:{{ $svcClusterPort }}
             {{- end }}
             {{- if gt (int .Values.alertmanager.replicaCount) 1 }}


### PR DESCRIPTION
With single replica of Alertmanager it is failing to start without argument --cluster.advertise-address=$(POD_IP):{{ $svcClusterPort }}

More info: https://github.com/SigNoz/charts/issues/283