### PR TITLE
Revert "chore(query-service): 🔧 include prefer-delta flag"

### DIFF
--- a/charts/signoz/templates/query-service/statefulset.yaml
+++ b/charts/signoz/templates/query-service/statefulset.yaml
@@ -91,10 +91,7 @@ spec:
             {{- toYaml .Values.queryService.securityContext | nindent 12 }}
           image: {{ template "queryService.image" . }}
           imagePullPolicy: {{ .Values.queryService.image.pullPolicy }}
-          args: [
-            "-config=/root/config/prometheus.yml",
-            "--prefer-delta=true"
-          ]
+          args: ["-config=/root/config/prometheus.yml"]
           ports:
             - name: http
               containerPort: {{ default 8080  .Values.queryService.service.port }}


### PR DESCRIPTION
Reverts SigNoz/charts#287


I remembered why we don't want to have prefer-delta true in charts. For our customers, we need to have two pipelines - one each for delta and cumulative and let the data be populated for some time. Then, we remove the cumulative pipeline and set the prefer-delta to true. This is the smooth way to roll out this change: https://github.com/SigNoz/signoz/issues/3579. Otherwise, people won't be able to see data fully.