### PR TITLE
chore: 🔧 migrator Job cleanup using ttlSecondsAfterFinished

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.28.2
+version: 0.28.3
 appVersion: "0.32.1"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/templates/otel-collector/schema-migrator-job.yaml
+++ b/charts/signoz/templates/otel-collector/schema-migrator-job.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "schemaMigrator.labels" . | nindent 4 }}
 spec:
+  ttlSecondsAfterFinished: {{ .Values.schemaMigrator.ttlSecondsAfterFinished }}
   template:
     metadata:
       labels:

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1122,6 +1122,8 @@ alertmanager:
 # Default values for schemaMigrator
 schemaMigrator:
   name: "schema-migrator"
+  # -- Number of seconds to wait after Job completion before deleting it. (default: 600)
+  ttlSecondsAfterFinished: 600
   initContainers:
     init:
       enabled: true


### PR DESCRIPTION
Signed-off-by: Prashant Shahi <prashant@signoz.io>
