### PR TITLE
fix: remove sending_queue and retry_on_failure settings

### DIFF
--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1723,13 +1723,6 @@ otelCollector:
       clickhouselogsexporter:
         dsn: tcp://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/?username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}
         timeout: 10s
-        sending_queue:
-          queue_size: 100
-        retry_on_failure:
-          enabled: true
-          initial_interval: 5s
-          max_interval: 30s
-          max_elapsed_time: 300s
       prometheus:
         endpoint: 0.0.0.0:8889
     service:


### PR DESCRIPTION
Use default values of sending_queue and retry_on_failure.

since values of retry_on_failure is same as default have removed it.
https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md