### PR TITLE
ci(chart-testing): 👷 bump up actions and related components

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.0
+        with:
+          version: "3.8.0"
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.0

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,10 +21,10 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.10
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,10 +21,10 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.10
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -35,7 +35,7 @@ jobs:
           fi
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.4.0
+        uses: helm/kind-action@v1.8.0
         with:
           wait: 600s
         # Only build a kind cluster if there are chart changes to test.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.0
+        with:
+          version: "3.8.0"
 
       - name: Run chart-testing (list-changed)
         id: list-changed


### PR DESCRIPTION
Suddenly, charts CI tests are failing due to cosign unavailability.

_Screenshot:_

<img width="762" alt="Screenshot" src="https://github.com/SigNoz/charts/assets/11138844/4a9210d9-85cf-4bbf-b934-2e5492d93cb4">

Signed-off-by: Prashant Shahi <prashant@signoz.io>
