### PR TITLE
fix: add if condition to internal trace parser

### DIFF
--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1606,6 +1606,7 @@ otelCollector:
             output: trace_parser
           - type: trace_parser
             id: trace_parser
+            if: '"temp_trace" in attributes'
             trace_id:
               parse_from: attributes.temp_trace.trace_id
             span_id:


### PR DESCRIPTION
All pipeline based logs processors get added before existing processors in initial collector config
Since logstransform/internal processor ends up being after pipeline processors, unless the trace parser in it has an if condition, the trace parser will override any trace values parsed by pipeline logs processors