### PR TITLE
Make OTEL_RESOURCE_ATTRIBUTES a value

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.10.1
+version: 0.10.2
 appVersion: "0.88.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -95,7 +95,7 @@ spec:
             - name: SIGNOZ_COMPONENT
               value: {{ default "otel-agent" .Values.otelAgent.name }}
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: signoz.component=$(SIGNOZ_COMPONENT),k8s.cluster.name=$(K8S_CLUSTER_NAME),k8s.pod.uid=$(K8S_POD_UID),k8s.pod.ip=$(K8S_POD_IP)
+              value: {{ .Values.presets.resourceDetection.envResourceAttributes | quote }}
             {{- range $key, $val := .Values.otelAgent.additionalEnvs }}
             - name: {{ $key }}
               value: {{ $val | toYaml }}

--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -95,7 +95,11 @@ spec:
             - name: SIGNOZ_COMPONENT
               value: {{ default "otel-agent" .Values.otelAgent.name }}
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: {{ .Values.presets.resourceDetection.envResourceAttributes | quote }}
+              {{- $attribs := "signoz.component=$(SIGNOZ_COMPONENT),k8s.cluster.name=$(K8S_CLUSTER_NAME),k8s.pod.uid=$(K8S_POD_UID),k8s.pod.ip=$(K8S_POD_IP)" }}
+              {{- if .Values.presets.resourceDetection.envResourceAttributes }}
+              {{- $attribs = printf "%s,%s" $attribs .Values.presets.resourceDetection.envResourceAttributes }}
+              {{- end }}
+              value: {{ $attribs | quote }}
             {{- range $key, $val := .Values.otelAgent.additionalEnvs }}
             - name: {{ $key }}
               value: {{ $val | toYaml }}

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -277,7 +277,7 @@ presets:
     # DO NOT CHANGE BELOW TO false, causes data duplication in case attributes mismatched.
     override: true
     # detectors: include ec2/eks for AWS, gcp for GCP and azure/aks for Azure
-    # env detector included below adds custom labels using OTEL_RESOURCE_ATTRIBUTES envvar
+    # env detector included below adds custom labels using OTEL_RESOURCE_ATTRIBUTES envvar (set envResourceAttributes value)
     detectors:
       # - elastic_beanstalk
       # - eks
@@ -292,6 +292,7 @@ presets:
       - os
       # - cname
       # - lookup
+    envResourceAttributes: ""
 
 # Default values for OtelAgent
 otelAgent:


### PR DESCRIPTION
Fixes #347 

In order to use the `env` resource detector you need to be able to set the `OTEL_RESOURCE_ATTRIBUTES` env var, and at present it is hard-coded. This PR makes it a value.


