### PR TITLE
fix(migrator-job): schema migrator job cleanup

### DIFF
--- a/charts/signoz/templates/_helpers.tpl
+++ b/charts/signoz/templates/_helpers.tpl
@@ -327,16 +327,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: {{ default "schema-migrator" .Values.schemaMigrator.name }}
 {{- end -}}
 
-{{- define "schemaMigrator.jobSuffix" -}}
-{{- $key := cat (include "schemaMigrator.selectorLabels" .) "" }}
-{{- $key := cat $key .Values.schemaMigrator.image.repository }}
-{{- $key := cat $key .Values.schemaMigrator.image.tag }}
-{{- $key := cat $key .Values.schemaMigrator.image.pullPolicy }}
-{{- $key := cat $key (include "schemamigrator.dsn" .) }}
-{{- $key := cat $key .Values.schemaMigrator.args }}
-{{- sha1sum $key | substr 0 12 }}
-{{- end -}}
-
 {{/*
 Create a default fully qualified app name for otelCollector.
 */}}

--- a/charts/signoz/templates/otel-collector-metrics/deployment.yaml
+++ b/charts/signoz/templates/otel-collector-metrics/deployment.yaml
@@ -57,7 +57,7 @@ spec:
           imagePullPolicy: {{ .Values.otelCollectorMetrics.image.pullPolicy }}
           args: 
           - "job"
-          - "{{ include "schemaMigrator.fullname" . }}-{{ include "schemaMigrator.jobSuffix" . }}"
+          - "{{ include "schemaMigrator.fullname" . }}"
         {{- end }}
         {{- if .Values.otelCollectorMetrics.initContainers.init.enabled }}
         - name: {{ include "otelCollectorMetrics.fullname" . }}-init

--- a/charts/signoz/templates/otel-collector/deployment.yaml
+++ b/charts/signoz/templates/otel-collector/deployment.yaml
@@ -64,7 +64,7 @@ spec:
           imagePullPolicy: {{ .Values.otelCollector.image.pullPolicy }}
           args: 
           - "job"
-          - "{{ include "schemaMigrator.fullname" . }}-{{ include "schemaMigrator.jobSuffix" . }}"
+          - "{{ include "schemaMigrator.fullname" . }}"
         {{- end }}
         {{- if .Values.otelCollector.initContainers.init.enabled }}
         - name: {{ include "otelCollector.fullname" . }}-init

--- a/charts/signoz/templates/otel-collector/schema-migrator-job.yaml
+++ b/charts/signoz/templates/otel-collector/schema-migrator-job.yaml
@@ -2,9 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "schemaMigrator.fullname" . }}-{{ include "schemaMigrator.jobSuffix" . }}
+  name: {{ include "schemaMigrator.fullname" . }}
   labels:
     {{- include "schemaMigrator.selectorLabels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   template:
     metadata:


### PR DESCRIPTION
This will delete old job using hooks before creation of new job for schema-migrator.

Pros: Clean up old migrator job on its own.

Cons: Uses static job name. Deletes old job before re-creating the job with same name for each `helm upgrade` or equivalent.

Signed-off-by: Prashant Shahi <prashant@signoz.io>
