### PR TITLE
chore(migrator-job): use post install/upgrade helm hooks

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.30.7
+version: 0.30.8
 appVersion: "0.34.4"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/templates/otel-collector/schema-migrator-job.yaml
+++ b/charts/signoz/templates/otel-collector/schema-migrator-job.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "schemaMigrator.selectorLabels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   template:


### PR DESCRIPTION
The previous hooks `pre-install,pre-upgrade` only works for those upgrading from existing signoz installation but not new ones.

Signed-off-by: Prashant Shahi <prashant@signoz.io>
