### PR TITLE
chore: unset pipelines with no receivers/exporters and enabled flags

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.10.3
+version: 0.10.4
 appVersion: "0.88.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -43,6 +43,44 @@ Build config file for daemonset OpenTelemetry Collector: OtelAgent
 {{- if .Values.presets.otlpExporter.enabled }}
 {{- $config = (include "opentelemetry-collector.applyOtlpExporterConfig" (dict "Values" $data "config" $config) | fromYaml) }}
 {{- end }}
+{{ if or (eq (len $config.service.pipelines.logs.receivers) 0) (eq (len $config.service.pipelines.logs.exporters) 0) }}
+{{- $_ := unset $config.service.pipelines "logs" }}
+{{- end }}
+{{- if or (eq (len $config.service.pipelines.metrics.receivers) 0) (eq (len $config.service.pipelines.metrics.exporters) 0) }}
+{{- $_ := unset $config.service.pipelines "metrics" }}
+{{- end }}
+{{- if or (eq (len $config.service.pipelines.traces.receivers) 0) (eq (len $config.service.pipelines.traces.exporters) 0) }}
+{{- $_ := unset $config.service.pipelines "traces" }}
+{{- end }}
+{{- if or (eq (len (index (index $config.service.pipelines "metrics/internal") "receivers")) 0) (eq (len (index (index $config.service.pipelines "metrics/internal") "exporters")) 0) }}
+{{- $_ := unset $config.service.pipelines "metrics/internal" }}
+{{- end }}
+{{- tpl (toYaml $config) . }}
+{{- end }}
+
+{{/*
+Build config file for deployment OpenTelemetry Collector: OtelDeployment
+*/}}
+{{- define "otelDeployment.config" -}}
+{{- $values := deepCopy .Values }}
+{{- $data := dict "Values" $values | mustMergeOverwrite (deepCopy .) }}
+{{- $config := include "otelDeployment.baseConfig" $data | fromYaml }}
+{{- if .Values.presets.resourceDetectionInternal.enabled }}
+{{- $config = (include "opentelemetry-collector.applyResourceDetectionInternalConfig" (dict "Values" $data "config" $config) | fromYaml) }}
+{{- end }}
+{{- if .Values.presets.clusterMetrics.enabled }}
+{{- $config = (include "opentelemetry-collector.applyClusterMetricsConfig" (dict "Values" $data "config" $config) | fromYaml) }}
+{{- end }}
+{{- if .Values.presets.loggingExporter.enabled }}
+{{- $config = (include "opentelemetry-collector.applyLoggingExporterConfig" (dict "Values" $data "config" $config) | fromYaml) }}
+{{- end }}
+{{- if .Values.presets.otlpExporter.enabled }}
+{{- $config = (include "opentelemetry-collector.applyOtlpExporterConfig" (dict "Values" $data "config" $config) | fromYaml) }}
+{{- end }}
+{{- if or (eq (len (index (index $config.service.pipelines "metrics/internal") "receivers")) 0) (eq (len (index (index $config.service.pipelines "metrics/internal") "exporters")) 0) }}
+{{- $_ := unset $config.service.pipelines "metrics/internal" }}
+{{- end }}
+# - metrics/internal : {{ index $config.service.pipelines "metrics/internal" }}
 {{- tpl (toYaml $config) . }}
 {{- end }}
 
@@ -107,29 +145,6 @@ exporters:
       {{- end }}
     headers:
       "signoz-access-token": "Bearer ${SIGNOZ_API_KEY}"
-{{- end }}
-
-
-{{/*
-Build config file for deployment OpenTelemetry Collector: OtelDeployment
-*/}}
-{{- define "otelDeployment.config" -}}
-{{- $values := deepCopy .Values }}
-{{- $data := dict "Values" $values | mustMergeOverwrite (deepCopy .) }}
-{{- $config := include "otelDeployment.baseConfig" $data | fromYaml }}
-{{- if .Values.presets.resourceDetectionInternal.enabled }}
-{{- $config = (include "opentelemetry-collector.applyResourceDetectionInternalConfig" (dict "Values" $data "config" $config) | fromYaml) }}
-{{- end }}
-{{- if .Values.presets.clusterMetrics.enabled }}
-{{- $config = (include "opentelemetry-collector.applyClusterMetricsConfig" (dict "Values" $data "config" $config) | fromYaml) }}
-{{- end }}
-{{- if .Values.presets.loggingExporter.enabled }}
-{{- $config = (include "opentelemetry-collector.applyLoggingExporterConfig" (dict "Values" $data "config" $config) | fromYaml) }}
-{{- end }}
-{{- if .Values.presets.otlpExporter.enabled }}
-{{- $config = (include "opentelemetry-collector.applyOtlpExporterConfig" (dict "Values" $data "config" $config) | fromYaml) }}
-{{- end }}
-{{- tpl (toYaml $config) . }}
 {{- end }}
 
 {{- define "opentelemetry-collector.applyClusterMetricsConfig" -}}

--- a/charts/k8s-infra/templates/otel-agent/clusterrole.yaml
+++ b/charts/k8s-infra/templates/otel-agent/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.otelAgent.clusterRole.create -}}
+{{- if and .Values.otelAgent.clusterRole.create .Values.otelAgent.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/k8s-infra/templates/otel-agent/clusterrolebinding.yaml
+++ b/charts/k8s-infra/templates/otel-agent/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.otelAgent.clusterRole.create -}}
+{{- if  and .Values.otelAgent.clusterRole.create .Values.otelAgent.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/k8s-infra/templates/otel-agent/configmap.yaml
+++ b/charts/k8s-infra/templates/otel-agent/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.otelAgent.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,3 +9,4 @@ metadata:
 data:
   otel-agent-config.yaml: |-
     {{- include "otelAgent.config" . | nindent 4 }}
+{{- end }}

--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.otelAgent.enabled -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -155,3 +156,4 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.otelAgent.resources | nindent 12 }}
+{{- end }}

--- a/charts/k8s-infra/templates/otel-agent/ingress.yaml
+++ b/charts/k8s-infra/templates/otel-agent/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.otelAgent.ingress.enabled -}}
+{{- if and .Values.otelAgent.ingress.enabled .Values.otelAgent.enabled -}}
 {{- $fullName := include "otelAgent.fullname" . -}}
 {{- $ingressApiIsStable := eq (include "ingress.isStable" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}

--- a/charts/k8s-infra/templates/otel-agent/service.yaml
+++ b/charts/k8s-infra/templates/otel-agent/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.otelAgent.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,4 +17,5 @@ spec:
     {{- include "otel.portsConfig" . | nindent 4 }}
   selector:
     {{- include "otelAgent.selectorLabels" $ | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/k8s-infra/templates/otel-agent/serviceaccount.yaml
+++ b/charts/k8s-infra/templates/otel-agent/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.otelAgent.serviceAccount.create -}}
+{{- if and .Values.otelAgent.serviceAccount.create .Values.otelAgent.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/k8s-infra/templates/otel-deployment/clusterrole.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.otelDeployment.clusterRole.create -}}
+{{- if and .Values.otelDeployment.clusterRole.create .Values.otelDeployment.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/k8s-infra/templates/otel-deployment/clusterrolebinding.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.otelDeployment.clusterRole.create -}}
+{{- if and .Values.otelDeployment.clusterRole.create .Values.otelDeployment.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/k8s-infra/templates/otel-deployment/configmap.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.otelDeployment.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,3 +9,4 @@ metadata:
 data:
   otel-deployment-config.yaml: |-
     {{- include "otelDeployment.config" . | nindent 4 }}
+{{- end }}

--- a/charts/k8s-infra/templates/otel-deployment/deployment.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.otelDeployment.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -136,3 +137,4 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.otelDeployment.resources | nindent 12 }}
+{{- end }}

--- a/charts/k8s-infra/templates/otel-deployment/ingress.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.otelDeployment.ingress.enabled -}}
+{{- if and .Values.otelDeployment.ingress.enabled .Values.otelDeployment.enabled -}}
 {{- $fullName := include "otelDeployment.fullname" . -}}
 {{- $ingressApiIsStable := eq (include "ingress.isStable" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}

--- a/charts/k8s-infra/templates/otel-deployment/service.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.otelDeployment.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,5 +18,4 @@ spec:
   selector:
     {{- include "otelDeployment.selectorLabels" $ | nindent 4 }}
 {{- end }}
-
-
+{{- end }}

--- a/charts/k8s-infra/templates/otel-deployment/serviceaccount.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.otelDeployment.serviceAccount.create -}}
+{{- if and .Values.otelDeployment.serviceAccount.create .Values.otelDeployment.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -296,6 +296,7 @@ presets:
 
 # Default values for OtelAgent
 otelAgent:
+  enabled: true
   name: "otel-agent"
   image:
     registry: docker.io
@@ -639,6 +640,7 @@ otelAgent:
 
 # Default values for OtelDeployment
 otelDeployment:
+  enabled: true
   name: "otel-deployment"
   image:
     registry: docker.io

--- a/charts/signoz/templates/alertmanager/configmap.yaml
+++ b/charts/signoz/templates/alertmanager/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.alertmanager.config }}
+{{- if and .Values.alertmanager.config .Values.alertmanager.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/signoz/templates/alertmanager/ingress.yaml
+++ b/charts/signoz/templates/alertmanager/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.alertmanager.ingress.enabled -}}
+{{- if and .Values.alertmanager.ingress.enabled .Values.alertmanager.enabled -}}
 {{- $fullName := include "alertmanager.fullname" . -}}
 {{- $ingressApiIsStable := eq (include "ingress.isStable" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}

--- a/charts/signoz/templates/alertmanager/pdb.yaml
+++ b/charts/signoz/templates/alertmanager/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.alertmanager.podDisruptionBudget -}}
+{{- if and .Values.alertmanager.podDisruptionBudget .Values.alertmanager.enabled -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/signoz/templates/alertmanager/serviceaccount.yaml
+++ b/charts/signoz/templates/alertmanager/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.alertmanager.serviceAccount.create -}}
+{{- if and .Values.alertmanager.serviceAccount.create .Values.alertmanager.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/signoz/templates/alertmanager/services.yaml
+++ b/charts/signoz/templates/alertmanager/services.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -51,3 +52,4 @@ spec:
 {{- end }}
   selector:
     {{- include "alertmanager.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/signoz/templates/alertmanager/statefulset.yaml
+++ b/charts/signoz/templates/alertmanager/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled -}}
 {{- $svcClusterPort := .Values.alertmanager.service.clusterPort }}
 apiVersion: apps/v1
 kind: StatefulSet
@@ -188,3 +189,4 @@ spec:
       {{- end }}
       {{- end }}
   {{- end }}
+{{- end }}

--- a/charts/signoz/templates/otel-collector-metrics/clusterrole.yaml
+++ b/charts/signoz/templates/otel-collector-metrics/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.otelCollectorMetrics.clusterRole.create -}}
+{{- if and .Values.otelCollectorMetrics.clusterRole.create .Values.otelCollectorMetrics.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/signoz/templates/otel-collector-metrics/clusterrolebinding.yaml
+++ b/charts/signoz/templates/otel-collector-metrics/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.otelCollectorMetrics.clusterRole.create -}}
+{{- if and .Values.otelCollectorMetrics.clusterRole.create .Values.otelCollectorMetrics.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/signoz/templates/otel-collector-metrics/configmap.yaml
+++ b/charts/signoz/templates/otel-collector-metrics/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.otelCollectorMetrics.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,3 +8,4 @@ metadata:
 data:
   otel-collector-metrics-config.yaml: |-
     {{- toYaml .Values.otelCollectorMetrics.config | nindent 4 }}
+{{- end }}

--- a/charts/signoz/templates/otel-collector-metrics/deployment.yaml
+++ b/charts/signoz/templates/otel-collector-metrics/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.otelCollectorMetrics.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -168,3 +169,4 @@ spec:
 #                path: cert.pem
 #              - key: key.pem
 #                path: key.pem
+{{- end }}

--- a/charts/signoz/templates/otel-collector-metrics/ingress.yaml
+++ b/charts/signoz/templates/otel-collector-metrics/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.otelCollectorMetrics.ingress.enabled -}}
+{{- if and .Values.otelCollectorMetrics.ingress.enabled .Values.otelCollectorMetrics.enabled }}
 {{- $fullName := include "otelCollectorMetrics.fullname" . -}}
 {{- $ingressApiIsStable := eq (include "ingress.isStable" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}

--- a/charts/signoz/templates/otel-collector-metrics/service.yaml
+++ b/charts/signoz/templates/otel-collector-metrics/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.otelCollectorMetrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,3 +17,4 @@ spec:
 {{- end }}
   selector:
     {{- include "otelCollectorMetrics.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/signoz/templates/otel-collector-metrics/serviceaccount.yaml
+++ b/charts/signoz/templates/otel-collector-metrics/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.otelCollectorMetrics.serviceAccount.create -}}
+{{- if and .Values.otelCollectorMetrics.serviceAccount.create .Values.otelCollectorMetrics.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -874,6 +874,7 @@ frontend:
 
 # Default values for Alertmanager
 alertmanager:
+  enabled: true
   name: "alertmanager"
   replicaCount: 1
 
@@ -1805,6 +1806,7 @@ otelCollector:
 
 # Default values for OtelCollectorMetrics
 otelCollectorMetrics:
+  enabled: true
   name: "otel-collector-metrics"
   image:
     registry: docker.io


### PR DESCRIPTION
- fixed config template to unset invalid pipelines
- enabled flags for OtelAgent, OtelDeployment, Alertmanager, OtelCollectorMetrics