### PR TITLE
otel-agent: collect kubelet stats from host IP

### DIFF
--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -213,7 +213,7 @@ presets:
     enabled: true
     collectionInterval: 30s
     authType: serviceAccount
-    endpoint: ${K8S_NODE_NAME}:10250
+    endpoint: ${K8S_HOST_IP}:10250
     insecureSkipVerify: true
     extraMetadataLabels:
       - container.id

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -2468,7 +2468,7 @@ k8s-infra:
       enabled: true
       collectionInterval: 30s
       authType: serviceAccount
-      endpoint: ${K8S_NODE_NAME}:10250
+      endpoint: ${K8S_HOST_IP}:10250
       insecureSkipVerify: true
     kubernetesAttributes:
       enabled: true


### PR DESCRIPTION
Not all k8s deployments resolve the node host name to an IP. This is
generally true inside of cloud providers, but not necessarily the case
when self-hosting.

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22843
