### PR TITLE
Add timeout for clickhousemetricswrite

### DIFF
--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1893,6 +1893,7 @@ otelCollector:
         low_cardinal_exception_grouping: ${LOW_CARDINAL_EXCEPTION_GROUPING}
       clickhousemetricswrite:
         endpoint: tcp://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/?database=${CLICKHOUSE_DATABASE}&username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}
+        timeout: 15s
         resource_to_telemetry_conversion:
           enabled: true
       clickhouselogsexporter:
@@ -2321,6 +2322,7 @@ otelCollectorMetrics:
         endpoint: localhost:1777
     exporters:
       clickhousemetricswrite:
+        timeout: 15s
         endpoint: tcp://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/?database=${CLICKHOUSE_DATABASE}&username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}
       clickhousemetricswrite/hostmetrics:
         endpoint: tcp://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/?database=${CLICKHOUSE_DATABASE}&username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}


### PR DESCRIPTION
The context timeout could cause the abrupt connection closing and cause broken pipe errors. I don't have much idea as to why the default 5s is not enough. This adjusts the setting to a little higher till I get to figure out the underlying reason.

Part of https://github.com/SigNoz/engineering-pod/issues/1148