### PR TITLE
Fix APIKey Secrets Not Found issue in K8s Infra

### DIFF
--- a/charts/k8s-infra/templates/apikey-secret.yaml
+++ b/charts/k8s-infra/templates/apikey-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: {{ include "k8s-infra.fullname" . }}-apikey-secret
+  name: {{ include "k8s-infra.fullname" . }}-apikey-secrets
   labels:
     {{- include "k8s-infra.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
Fixes #390 

As per changes in PR #388, Default secrets name for api key does not matches with secrets defined in `k8s-infra/secrets.yaml` template, This causes secrets not found issue for default secrets.