### PR TITLE
chore(clickhouse): set OnRootMismatch file system change policy

### DIFF
--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -239,6 +239,7 @@ securityContext:
   runAsUser: 101
   runAsGroup: 101
   fsGroup: 101
+  fsGroupChangePolicy: OnRootMismatch
 
 # -- An allowlist of IP addresses or network masks the ClickHouse user is
 # allowed to access from. By default anything within a private network will be

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -178,6 +178,7 @@ clickhouse:
     runAsUser: 101
     runAsGroup: 101
     fsGroup: 101
+    fsGroupChangePolicy: OnRootMismatch
 
   # -- An allowlist of IP addresses or network masks the ClickHouse user is
   # allowed to access from. By default anything within a private network will be


### PR DESCRIPTION
This helps to shorten the time to change ownership and permission of a volume.
When you have lots of files in the volume, it could fail to mount with `timed out waiting for the condition` error.
This change should help resolve it. 


> OnRootMismatch: Only change permissions and ownership if the permission and the ownership of root directory does not match with expected permissions of the volume. This could help shorten the time it takes to change ownership and permission of a volume.

Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods