### PR TITLE
Set internalTrafficPolicy on agent service when supported

### DIFF
--- a/charts/k8s-infra/templates/otel-agent/service.yaml
+++ b/charts/k8s-infra/templates/otel-agent/service.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.otelAgent.enabled -}}
+{{- $serviceSupportsTrafficPolicy := (semverCompare ">=1.26-0" .Capabilities.KubeVersion.GitVersion) -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,5 +18,8 @@ spec:
     {{- include "otel.portsConfig" . | nindent 4 }}
   selector:
     {{- include "otelAgent.selectorLabels" $ | nindent 4 }}
+  {{- if $serviceSupportsTrafficPolicy }}
+  internalTrafficPolicy: {{ .service.internalTrafficPolicy }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -330,6 +330,9 @@ otelAgent:
     annotations: {}
     # -- Service Type: LoadBalancer (allows external access) or NodePort (more secure, no extra cost)
     type: ClusterIP
+    #  -- Traffic Policy: Local (route requests to pod on same host) or Cluster (route to all)
+    # https://kubernetes.io/docs/reference/networking/virtual-ips/#internal-traffic-policy
+    internalTrafficPolicy: Local
 
   serviceAccount:
     # Specifies whether a service account should be created


### PR DESCRIPTION
When sending traces to the agent via the service it is necessary to route to the agent on the same host as the sending pod so that the k8s resource can look up the IP address and augment the data.

Kubernetes 1.26 introduced [internalTrafficPolicy](https://kubernetes.io/docs/reference/networking/virtual-ips/#internal-traffic-policy) to enabled this
