### PR TITLE
chore(k8s-infra): tolerate all nodes in otel-agent daemonset as default

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.11.4
+version: 0.11.5
 appVersion: "0.88.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -572,7 +572,8 @@ otelAgent:
   nodeSelector: {}
 
   # -- Toleration labels for OtelAgent pod assignment
-  tolerations: []
+  tolerations:
+    - operator: Exists
 
   # -- Affinity settings for OtelAgent pod
   affinity: {}


### PR DESCRIPTION
Signed-off-by: Prashant Shahi <prashant@signoz.io>
