### PR TITLE
chore(signoz): 📌 pin versions: SigNoz OtelCollector v0.88.19

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.38.0
+version: 0.38.1
 appVersion: "0.42.0"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -191,7 +191,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `otelCollector.name`                     | Otel Collector component name                                           | `otel-collector`                  |
 | `otelCollector.image.registry`           | Otel Collector image registry name                                      | `docker.io`                       |
 | `otelCollector.image.repository`         | Container image name                                                    | `signoz/signoz-otel-collector`    |
-| `otelCollector.image.tag`                | Container image tag                                                     | `0.88.18`                         |
+| `otelCollector.image.tag`                | Container image tag                                                     | `0.88.19`                         |
 | `otelCollector.image.pullPolicy`         | Container pull policy                                                   | `IfNotPresent`                    |
 | `otelCollector.replicaCount`             | Number of otel-collector nodes                                          | `1`                               |
 | `otelCollector.service.type`             | Otel Collector service type                                             | `ClusterIP`                       |
@@ -231,7 +231,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `otelCollectorMetrics.name`              | Otel Collector Metrics component name                                   | `otel-collector-metrics`          |
 | `otelCollectorMetrics.image.registry`    | Otel Collector Metrics image registry name                              | `docker.io`                       |
 | `otelCollectorMetrics.image.repository`  | Container image name                                                    | `signoz/signoz-otel-collector`    |
-| `otelCollectorMetrics.image.tag`         | Container image tag                                                     | `0.88.18`                         |
+| `otelCollectorMetrics.image.tag`         | Container image tag                                                     | `0.88.19`                         |
 | `otelCollectorMetrics.image.pullPolicy`  | Container pull policy                                                   | `IfNotPresent`                    |
 | `otelCollectorMetrics.replicaCount`      | Number of otel-collector-metrics nodes                                  | `1`                               |
 | `otelCollectorMetrics.service.type`         | Otel Collector service type                                          | `ClusterIP`                       |

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -191,7 +191,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `otelCollector.name`                     | Otel Collector component name                                           | `otel-collector`                  |
 | `otelCollector.image.registry`           | Otel Collector image registry name                                      | `docker.io`                       |
 | `otelCollector.image.repository`         | Container image name                                                    | `signoz/signoz-otel-collector`    |
-| `otelCollector.image.tag`                | Container image tag                                                     | `0.88.17`                         |
+| `otelCollector.image.tag`                | Container image tag                                                     | `0.88.18`                         |
 | `otelCollector.image.pullPolicy`         | Container pull policy                                                   | `IfNotPresent`                    |
 | `otelCollector.replicaCount`             | Number of otel-collector nodes                                          | `1`                               |
 | `otelCollector.service.type`             | Otel Collector service type                                             | `ClusterIP`                       |
@@ -231,7 +231,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `otelCollectorMetrics.name`              | Otel Collector Metrics component name                                   | `otel-collector-metrics`          |
 | `otelCollectorMetrics.image.registry`    | Otel Collector Metrics image registry name                              | `docker.io`                       |
 | `otelCollectorMetrics.image.repository`  | Container image name                                                    | `signoz/signoz-otel-collector`    |
-| `otelCollectorMetrics.image.tag`         | Container image tag                                                     | `0.88.17`                         |
+| `otelCollectorMetrics.image.tag`         | Container image tag                                                     | `0.88.18`                         |
 | `otelCollectorMetrics.image.pullPolicy`  | Container pull policy                                                   | `IfNotPresent`                    |
 | `otelCollectorMetrics.replicaCount`      | Number of otel-collector-metrics nodes                                  | `1`                               |
 | `otelCollectorMetrics.service.type`         | Otel Collector service type                                          | `ClusterIP`                       |

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1226,7 +1226,7 @@ schemaMigrator:
   image:
     registry: docker.io
     repository: signoz/signoz-schema-migrator
-    tag: 0.88.17
+    tag: 0.88.18
     pullPolicy: IfNotPresent
 
   args: {}
@@ -1320,7 +1320,7 @@ otelCollector:
   image:
     registry: docker.io
     repository: signoz/signoz-otel-collector
-    tag: 0.88.17
+    tag: 0.88.18
     pullPolicy: IfNotPresent
 
   # -- Image Registry Secret Names for OtelCollector
@@ -1945,7 +1945,7 @@ otelCollectorMetrics:
   image:
     registry: docker.io
     repository: signoz/signoz-otel-collector
-    tag: 0.88.17
+    tag: 0.88.18
     pullPolicy: IfNotPresent
 
   # -- Image Registry Secret Names for OtelCollector

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1226,7 +1226,7 @@ schemaMigrator:
   image:
     registry: docker.io
     repository: signoz/signoz-schema-migrator
-    tag: 0.88.18
+    tag: 0.88.19
     pullPolicy: IfNotPresent
 
   args: {}
@@ -1320,7 +1320,7 @@ otelCollector:
   image:
     registry: docker.io
     repository: signoz/signoz-otel-collector
-    tag: 0.88.18
+    tag: 0.88.19
     pullPolicy: IfNotPresent
 
   # -- Image Registry Secret Names for OtelCollector
@@ -1945,7 +1945,7 @@ otelCollectorMetrics:
   image:
     registry: docker.io
     repository: signoz/signoz-otel-collector
-    tag: 0.88.18
+    tag: 0.88.19
     pullPolicy: IfNotPresent
 
   # -- Image Registry Secret Names for OtelCollector


### PR DESCRIPTION
This PR releases the support for ClickHouse cluster with multiple replicas, not just shard.

It is not enabled by default. To enable:

```yaml
...
clickhouse:
  layout:
    replicasCount: 2
schemaMigrator:
  enableReplication: true
```

_Note: Multiple replicas increases the availability of the ClickHouse cluster however it incurs additional resource cost. **Proceed with caution!**_

Signed-off-by: Prashant Shahi <prashant@signoz.io>
