### PR TITLE
feat: add scheduler hints for SchemaMigrator

### DIFF
--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -181,6 +181,9 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `alertmanager.config`                    | Alertmanager configurations                                             | See `values.yaml` for defaults    |
 | `alertmanager.configmapReload`           | Configure ConfigMap reload                                              | See `values.yaml` for defaults    |
 | `alertmanager.templates`                 | Set alert templates                                                     | See `values.yaml` for defaults    |
+| `schemaMigrator.nodeSelector`    | Node labels for schemaMigrator pod assignment                                   | `{}`                              |
+| `schemaMigrator.tolerations`     | schemaMigrator tolerations                                                      | `[]`                              |
+| `schemaMigrator.nodeAffinity`    |  schemaMigrator affinity policy                                                 | `{}`                              |
 | `schemaMigrator.initContainers.init.enabled`    | Schema migrator initContainer enabled                            | `true`                            |
 | `schemaMigrator.initContainers.init.image.registry`   | Schema migrator initContainer registry name                | `docker.io`                       |
 | `schemaMigrator.initContainers.init.image.repository` | Schema migrator initContainer image name                   | `busybox`                         |

--- a/charts/signoz/templates/schema-migrator/migrations-init.yaml
+++ b/charts/signoz/templates/schema-migrator/migrations-init.yaml
@@ -71,7 +71,7 @@ spec:
       {{- if .Values.schemaMigrator.tolerations }}
       tolerations: {{ toYaml .Values.schemaMigrator.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.nodeSelector }}
+      {{- if .Values.schemaMigrator.nodeSelector }}
       nodeSelector: {{ toYaml .Values.schemaMigrator.tolerations | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/signoz/templates/schema-migrator/migrations-init.yaml
+++ b/charts/signoz/templates/schema-migrator/migrations-init.yaml
@@ -72,6 +72,6 @@ spec:
       tolerations: {{ toYaml .Values.schemaMigrator.tolerations | nindent 8 }}
       {{- end }}
       {{- if .Values.schemaMigrator.nodeSelector }}
-      nodeSelector: {{ toYaml .Values.schemaMigrator.tolerations | nindent 8 }}
+      nodeSelector: {{ toYaml .Values.schemaMigrator.nodeSelector | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/signoz/templates/schema-migrator/migrations-init.yaml
+++ b/charts/signoz/templates/schema-migrator/migrations-init.yaml
@@ -65,4 +65,13 @@ spec:
             - {{ . | quote }}
             {{- end }}
       restartPolicy: OnFailure
+      {{- if .Values.schemaMigrator.affinity }}
+      affinity: {{ toYaml .Values.schemaMigrator.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.schemaMigrator.tolerations }}
+      tolerations: {{ toYaml .Values.schemaMigrator.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.schemaMigrator.tolerations | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/signoz/templates/schema-migrator/migrations-upgrade.yaml
+++ b/charts/signoz/templates/schema-migrator/migrations-upgrade.yaml
@@ -73,6 +73,6 @@ spec:
       tolerations: {{ toYaml .Values.schemaMigrator.tolerations | nindent 8 }}
       {{- end }}
       {{- if .Values.schemaMigrator.nodeSelector }}
-      nodeSelector: {{ toYaml .Values.schemaMigrator.tolerations | nindent 8 }}
+      nodeSelector: {{ toYaml .Values.schemaMigrator.nodeSelector | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/signoz/templates/schema-migrator/migrations-upgrade.yaml
+++ b/charts/signoz/templates/schema-migrator/migrations-upgrade.yaml
@@ -66,4 +66,13 @@ spec:
             - {{ . | quote }}
             {{- end }}
       restartPolicy: OnFailure
+      {{- if .Values.schemaMigrator.affinity }}
+      affinity: {{ toYaml .Values.schemaMigrator.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.schemaMigrator.tolerations }}
+      tolerations: {{ toYaml .Values.schemaMigrator.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.schemaMigrator.tolerations | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/signoz/templates/schema-migrator/migrations-upgrade.yaml
+++ b/charts/signoz/templates/schema-migrator/migrations-upgrade.yaml
@@ -72,7 +72,7 @@ spec:
       {{- if .Values.schemaMigrator.tolerations }}
       tolerations: {{ toYaml .Values.schemaMigrator.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.nodeSelector }}
+      {{- if .Values.schemaMigrator.nodeSelector }}
       nodeSelector: {{ toYaml .Values.schemaMigrator.tolerations | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1236,6 +1236,13 @@ schemaMigrator:
 
   # -- Whether to enable replication for schemaMigrator
   enableReplication: false
+  
+  # -- Node selector for settings for schemaMigrator
+  nodeSelector: {}
+  # -- Toleration labels for schemaMigrator assignment
+  tolerations: []
+  # -- Affinity settings for schemaMigrator
+  affinity: {}
 
   initContainers:
     wait:

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1236,7 +1236,7 @@ schemaMigrator:
 
   # -- Whether to enable replication for schemaMigrator
   enableReplication: false
-  
+
   # -- Node selector for settings for schemaMigrator
   nodeSelector: {}
   # -- Toleration labels for schemaMigrator assignment


### PR DESCRIPTION
add scheduler hints to the schema migrator templates for init and upgrade in the form of `schemaMigrator.nodeSelector` `schemaMigrator.tolerations` and `schemaMigrator.nodeAffinity`.

fixes #428 