### PR TITLE
chore: pin SigNoz OtelCollector 0.88.21 and update ClickHouse dsn

### DIFF
--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -149,6 +149,8 @@ cluster: cluster
 database: signoz_metrics
 # -- Clickhouse trace database (SigNoz Traces)
 traceDatabase: signoz_traces
+# -- Clickhouse log database (SigNoz Logs)
+logDatabase: signoz_logs
 # -- Clickhouse user
 user: admin
 # -- Clickhouse password

--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -20,11 +20,11 @@ sources:
   - https://github.com/signoz/signoz-otel-collector
 dependencies:
   - name: clickhouse
-    repository: "https://signoz.github.io/charts"
+    repository: https://signoz.github.io/charts
     condition: clickhouse.enabled
     version: 23.13.0
   - name: k8s-infra
-    repository: "https://signoz.github.io/charts"
+    repository: https://signoz.github.io/charts
     condition: k8s-infra.enabled
     version: 0.11.4
   - name: cert-manager

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -194,7 +194,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `otelCollector.name`                     | Otel Collector component name                                           | `otel-collector`                  |
 | `otelCollector.image.registry`           | Otel Collector image registry name                                      | `docker.io`                       |
 | `otelCollector.image.repository`         | Container image name                                                    | `signoz/signoz-otel-collector`    |
-| `otelCollector.image.tag`                | Container image tag                                                     | `0.88.20`                         |
+| `otelCollector.image.tag`                | Container image tag                                                     | `0.88.21`                         |
 | `otelCollector.image.pullPolicy`         | Container pull policy                                                   | `IfNotPresent`                    |
 | `otelCollector.replicaCount`             | Number of otel-collector nodes                                          | `1`                               |
 | `otelCollector.service.type`             | Otel Collector service type                                             | `ClusterIP`                       |
@@ -234,7 +234,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `otelCollectorMetrics.name`              | Otel Collector Metrics component name                                   | `otel-collector-metrics`          |
 | `otelCollectorMetrics.image.registry`    | Otel Collector Metrics image registry name                              | `docker.io`                       |
 | `otelCollectorMetrics.image.repository`  | Container image name                                                    | `signoz/signoz-otel-collector`    |
-| `otelCollectorMetrics.image.tag`         | Container image tag                                                     | `0.88.20`                         |
+| `otelCollectorMetrics.image.tag`         | Container image tag                                                     | `0.88.21`                         |
 | `otelCollectorMetrics.image.pullPolicy`  | Container pull policy                                                   | `IfNotPresent`                    |
 | `otelCollectorMetrics.replicaCount`      | Number of otel-collector-metrics nodes                                  | `1`                               |
 | `otelCollectorMetrics.service.type`         | Otel Collector service type                                          | `ClusterIP`                       |

--- a/charts/signoz/templates/_clickhouse.tpl
+++ b/charts/signoz/templates/_clickhouse.tpl
@@ -24,6 +24,8 @@ Common ClickHouse ENV variables and helpers used by SigNoz
   value: {{ default "signoz_metrics" .Values.clickhouse.database | quote }}
 - name: CLICKHOUSE_TRACE_DATABASE
   value: {{ default "signoz_traces" .Values.clickhouse.traceDatabase | quote }}
+- name: CLICKHOUSE_LOG_DATABASE
+  value: {{ default "signoz_logs" .Values.clickhouse.logDatabase | quote }}
 - name: CLICKHOUSE_USER
   value: {{ .Values.clickhouse.user | quote }}
 - name: CLICKHOUSE_PASSWORD
@@ -45,6 +47,8 @@ Common ClickHouse ENV variables and helpers used by SigNoz
   value: {{ default "signoz_metrics" .Values.externalClickhouse.database | quote }}
 - name: CLICKHOUSE_TRACE_DATABASE
   value: {{ default "signoz_traces" .Values.externalClickhouse.traceDatabase | quote }}
+- name: CLICKHOUSE_LOG_DATABASE
+  value: {{ default "signoz_logs" .Values.externalClickhouse.logDatabase | quote }}
 - name: CLICKHOUSE_USER
   value: {{ .Values.externalClickhouse.user | quote }}
 {{- if .Values.externalClickhouse.existingSecret }}
@@ -200,9 +204,9 @@ Return the ClickHouse Metrics URL
 */}}
 {{- define "clickhouse.metricsUrl" -}}
 {{- if .Values.clickhouse.enabled -}}
-  {{- include "clickhouse.servicename" . }}:{{ include "clickhouse.tcpPort" . }}?database={{ .Values.clickhouse.database }}&username={{ .Values.clickhouse.user }}&password={{ .Values.clickhouse.password -}}
+  tcp://{{ .Values.clickhouse.user }}:{{ .Values.clickhouse.password }}@{{ include "clickhouse.servicename" . }}:{{ include "clickhouse.tcpPort" . }}/{{ .Values.clickhouse.database -}}
 {{- else -}}
-  {{- required "externalClickhouse.host is required if using external clickhouse" .Values.externalClickhouse.host }}:{{ include "clickhouse.tcpPort" . }}?database={{ .Values.externalClickhouse.database }}&username={{ .Values.externalClickhouse.user }}&password={{ include "clickhouse.externalPasswordKey" . -}}
+  tcp://{{ .Values.externalClickhouse.user }}:{{ include "clickhouse.externalPasswordKey" . }}@{{- required "externalClickhouse.host is required if using external clickhouse" .Values.externalClickhouse.host }}:{{ include "clickhouse.tcpPort" . }}/{{ .Values.externalClickhouse.database -}}
 {{- end -}}
 {{- end -}}
 
@@ -211,9 +215,9 @@ Return the ClickHouse Traces URL
 */}}
 {{- define "clickhouse.tracesUrl" -}}
 {{- if .Values.clickhouse.enabled -}}
-  {{- include "clickhouse.servicename" . }}:{{ include "clickhouse.tcpPort" . }}?database={{ .Values.clickhouse.traceDatabase }}&username={{ .Values.clickhouse.user }}&password={{ .Values.clickhouse.password -}}
+  tcp://{{ .Values.clickhouse.user }}:{{ .Values.clickhouse.password }}@{{ include "clickhouse.servicename" . }}:{{ include "clickhouse.tcpPort" . }}/{{ .Values.clickhouse.traceDatabase -}}
 {{- else -}}
-  {{- required "externalClickhouse.host is required if using external clickhouse" .Values.externalClickhouse.host }}:{{ include "clickhouse.tcpPort" . }}?database={{ .Values.externalClickhouse.traceDatabase }}&username={{ .Values.externalClickhouse.user }}&password=$(CLICKHOUSE_PASSWORD)
+  tcp://{{ .Values.externalClickhouse.user }}:$(CLICKHOUSE_PASSWORD)@{{ required "externalClickhouse.host is required if using external clickhouse" .Values.externalClickhouse.host }}:{{ include "clickhouse.tcpPort" . }}/{{ .Values.externalClickhouse.traceDatabase -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/signoz/templates/query-service/configmap.yaml
+++ b/charts/signoz/templates/query-service/configmap.yaml
@@ -28,7 +28,7 @@ data:
     scrape_configs: []
 
     remote_read:
-      - url: tcp://{{ include "clickhouse.metricsUrl" . }}
+      - url: {{ include "clickhouse.metricsUrl" . }}
 
   {{ if .Values.queryService.cache.enabled }}
   cache.yaml: |

--- a/charts/signoz/templates/schema-migrator/migrations-init.yaml
+++ b/charts/signoz/templates/schema-migrator/migrations-init.yaml
@@ -59,7 +59,7 @@ spec:
             {{- include "snippet.clickhouse-credentials" . | nindent 12 }}
           args:
             - "--dsn"
-            - "tcp://{{ include "schemamigrator.url" . }}?username=$(CLICKHOUSE_USER)&password=$(CLICKHOUSE_PASSWORD)"
+            - "tcp://$(CLICKHOUSE_USER):$(CLICKHOUSE_PASSWORD)@{{ include "schemamigrator.url" . }}"
             {{- if .Values.schemaMigrator.enableReplication }}
             - "--replication"
             {{- end }}

--- a/charts/signoz/templates/schema-migrator/migrations-upgrade.yaml
+++ b/charts/signoz/templates/schema-migrator/migrations-upgrade.yaml
@@ -60,7 +60,7 @@ spec:
             {{- include "snippet.clickhouse-credentials" . | nindent 12 }}
           args:
             - "--dsn"
-            - "tcp://{{ include "schemamigrator.url" . }}?username=$(CLICKHOUSE_USER)&password=$(CLICKHOUSE_PASSWORD)"
+            - "tcp://$(CLICKHOUSE_USER):$(CLICKHOUSE_PASSWORD)@{{ include "schemamigrator.url" . }}"
             {{- if .Values.schemaMigrator.enableReplication }}
             - "--replication"
             {{- end }}

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -95,6 +95,8 @@ clickhouse:
   database: signoz_metrics
   # -- Clickhouse trace database (SigNoz Traces)
   traceDatabase: signoz_traces
+  # -- Clickhouse log database (SigNoz Logs)
+  logDatabase: signoz_logs
   # -- Clickhouse user
   user: admin
   # -- Clickhouse password
@@ -546,6 +548,8 @@ externalClickhouse:
   database: signoz_metrics
   # -- Clickhouse trace database (SigNoz Traces)
   traceDatabase: signoz_traces
+  # -- Clickhouse log database (SigNoz Logs)
+  logDatabase: signoz_logs
   # -- User name for the external cluster to connect to the external cluster as
   user: ""
   # -- Password for the cluster. Ignored if externalClickhouse.existingSecret is set
@@ -667,7 +671,7 @@ queryService:
     storage: clickhouse
     # ClickHouse URL is set and applied internally.
     # Don't override unless you know what you are doing.
-    # clickHouseUrl: tcp://my-release-clickhouse:9000/?database=signoz_traces&username=clickhouse_operator&password=clickhouse_operator_password
+    # clickHouseUrl: tcp://clickhouse_operator:clickhouse_operator_password@my-release-clickhouse:9000/signoz_traces
     goDebug: netdns=go
     telemetryEnabled: true
     deploymentType: kubernetes-helm
@@ -1929,15 +1933,15 @@ otelCollector:
         endpoint: localhost:1777
     exporters:
       clickhousetraces:
-        datasource: tcp://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/?database=${CLICKHOUSE_TRACE_DATABASE}&username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}
+        datasource: tcp://${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}@${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/${CLICKHOUSE_TRACE_DATABASE}
         low_cardinal_exception_grouping: ${LOW_CARDINAL_EXCEPTION_GROUPING}
       clickhousemetricswrite:
-        endpoint: tcp://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/?database=${CLICKHOUSE_DATABASE}&username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}
+        endpoint: tcp://${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}@${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/${CLICKHOUSE_DATABASE}
         timeout: 15s
         resource_to_telemetry_conversion:
           enabled: true
       clickhouselogsexporter:
-        dsn: tcp://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/?username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}
+        dsn: tcp://${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}@${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/${CLICKHOUSE_LOG_DATABASE}
         timeout: 10s
       prometheus:
         endpoint: 0.0.0.0:8889
@@ -2365,9 +2369,9 @@ otelCollectorMetrics:
     exporters:
       clickhousemetricswrite:
         timeout: 15s
-        endpoint: tcp://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/?database=${CLICKHOUSE_DATABASE}&username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}
+        endpoint: tcp://${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}@${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/${CLICKHOUSE_DATABASE}
       clickhousemetricswrite/hostmetrics:
-        endpoint: tcp://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/?database=${CLICKHOUSE_DATABASE}&username=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}
+        endpoint: tcp://${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}@${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/${CLICKHOUSE_DATABASE}
         resource_to_telemetry_conversion:
           enabled: true
     service:

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1232,7 +1232,7 @@ schemaMigrator:
   image:
     registry: docker.io
     repository: signoz/signoz-schema-migrator
-    tag: 0.88.20
+    tag: 0.88.21
     pullPolicy: IfNotPresent
 
   args: {}
@@ -1346,7 +1346,7 @@ otelCollector:
   image:
     registry: docker.io
     repository: signoz/signoz-otel-collector
-    tag: 0.88.20
+    tag: 0.88.21
     pullPolicy: IfNotPresent
 
   # -- Image Registry Secret Names for OtelCollector
@@ -1971,7 +1971,7 @@ otelCollectorMetrics:
   image:
     registry: docker.io
     repository: signoz/signoz-otel-collector
-    tag: 0.88.20
+    tag: 0.88.21
     pullPolicy: IfNotPresent
 
   # -- Image Registry Secret Names for OtelCollector


### PR DESCRIPTION
### Summary

Pin latest version of SigNoz OtelCollector `0.88.21` and update ClickHouse dsn as per latest parsing logic

#### Related Issues / PR's

- https://github.com/SigNoz/signoz-otel-collector/pull/294

Signed-off-by: Prashant Shahi <prashant@signoz.io>
