### PR TITLE
fix(k8s-infra): remove deprecated Bearer header

### DIFF
--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -143,7 +143,7 @@ exporters:
       {{- end }}
       {{- end }}
     headers:
-      "signoz-access-token": "Bearer ${SIGNOZ_API_KEY}"
+      "signoz-access-token": "${SIGNOZ_API_KEY}"
 {{- end }}
 
 {{- define "opentelemetry-collector.applyClusterMetricsConfig" -}}


### PR DESCRIPTION
#### Fixes

- Removes deprecated `Bearer` annotation for pushing to signoz