### PR TITLE
Release/signoz 0.44.0

### DIFF
--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -612,9 +612,9 @@ otelAgent:
         send_batch_size: 10000
         timeout: 200ms
       # Memory Limiter processor.
-      # If set to null, will be overridden with values based on k8s resource limits.
+      # If not set, will be overridden with values based on k8s resource limits.
       # ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md
-      memory_limiter: null
+      # memory_limiter: null
     extensions:
       health_check:
         endpoint: 0.0.0.0:13133
@@ -908,9 +908,9 @@ otelDeployment:
         send_batch_size: 10000
         timeout: 1s
       # Memory Limiter processor.
-      # If set to null, will be overridden with values based on k8s resource limits.
+      # If not set, will be overridden with values based on k8s resource limits.
       # ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md
-      memory_limiter: null
+      # memory_limiter: null
     extensions:
       health_check:
         endpoint: 0.0.0.0:13133

--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.43.0
+version: 0.44.0
 appVersion: "0.48.0"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: signoz
 version: 0.43.0
-appVersion: "0.47.0"
+appVersion: "0.48.0"
 description: SigNoz Observability Platform Helm Chart
 type: application
 home: https://signoz.io/

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -71,7 +71,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `queryService.name`                      | Query Service component name                                            | `query-service`                   |
 | `queryService.image.registry`            | Query Service image registry name                                       | `docker.io`                       |
 | `queryService.image.repository`          | Container image name                                                    | `signoz/query-service`            |
-| `queryService.image.tag`                 | Container image tag                                                     | `0.47.0`                          |
+| `queryService.image.tag`                 | Container image tag                                                     | `0.48.0`                          |
 | `queryService.image.pullPolicy`          | Container pull policy                                                   | `IfNotPresent`                    |
 | `queryService.replicaCount`              | Number of query-service nodes                                           | `1`                               |
 | `queryService.initContainers.init.enabled`      | Query Service initContainer enabled                              | `true`                            |
@@ -110,7 +110,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `frontend.name`                          | Frontend component name                                                 | `frontend`                        |
 | `frontend.image.registry`                | Frontend image registry name                                            | `docker.io`                       |
 | `frontend.image.repository`              | Container image name                                                    | `signoz/frontend`                 |
-| `frontend.image.tag`                     | Container image tag                                                     | `0.47.0`                          |
+| `frontend.image.tag`                     | Container image tag                                                     | `0.48.0`                          |
 | `frontend.image.pullPolicy`              | Container pull policy                                                   | `IfNotPresent`                    |
 | `frontend.replicaCount`                  | Number of query-service nodes                                           | `1`                               |
 | `frontend.initContainers.init.enabled`   | Frontend initContainer enabled                                          | `true`                            |
@@ -195,7 +195,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `otelCollector.name`                     | Otel Collector component name                                           | `otel-collector`                  |
 | `otelCollector.image.registry`           | Otel Collector image registry name                                      | `docker.io`                       |
 | `otelCollector.image.repository`         | Container image name                                                    | `signoz/signoz-otel-collector`    |
-| `otelCollector.image.tag`                | Container image tag                                                     | `0.88.26`                         |
+| `otelCollector.image.tag`                | Container image tag                                                     | `0.102.0`                         |
 | `otelCollector.image.pullPolicy`         | Container pull policy                                                   | `IfNotPresent`                    |
 | `otelCollector.replicaCount`             | Number of otel-collector nodes                                          | `1`                               |
 | `otelCollector.service.type`             | Otel Collector service type                                             | `ClusterIP`                       |
@@ -235,7 +235,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `otelCollectorMetrics.name`              | Otel Collector Metrics component name                                   | `otel-collector-metrics`          |
 | `otelCollectorMetrics.image.registry`    | Otel Collector Metrics image registry name                              | `docker.io`                       |
 | `otelCollectorMetrics.image.repository`  | Container image name                                                    | `signoz/signoz-otel-collector`    |
-| `otelCollectorMetrics.image.tag`         | Container image tag                                                     | `0.88.26`                         |
+| `otelCollectorMetrics.image.tag`         | Container image tag                                                     | `0.102.0`                         |
 | `otelCollectorMetrics.image.pullPolicy`  | Container pull policy                                                   | `IfNotPresent`                    |
 | `otelCollectorMetrics.replicaCount`      | Number of otel-collector-metrics nodes                                  | `1`                               |
 | `otelCollectorMetrics.service.type`         | Otel Collector service type                                          | `ClusterIP`                       |

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -574,7 +574,7 @@ queryService:
   image:
     registry: docker.io
     repository: signoz/query-service
-    tag: 0.47.0
+    tag: 0.48.0
     pullPolicy: IfNotPresent
 
   # -- Image Registry Secret Names for Query-Service
@@ -804,7 +804,7 @@ frontend:
   image:
     registry: docker.io
     repository: signoz/frontend
-    tag: 0.47.0
+    tag: 0.48.0
     pullPolicy: IfNotPresent
 
   # -- Image Registry Secret Names for Frontend
@@ -1240,7 +1240,7 @@ schemaMigrator:
   image:
     registry: docker.io
     repository: signoz/signoz-schema-migrator
-    tag: 0.88.26
+    tag: 0.102.0
     pullPolicy: IfNotPresent
 
   args: {}
@@ -1354,7 +1354,7 @@ otelCollector:
   image:
     registry: docker.io
     repository: signoz/signoz-otel-collector
-    tag: 0.88.26
+    tag: 0.102.0
     pullPolicy: IfNotPresent
 
   # -- Image Registry Secret Names for OtelCollector
@@ -1981,7 +1981,7 @@ otelCollectorMetrics:
   image:
     registry: docker.io
     repository: signoz/signoz-otel-collector
-    tag: 0.88.26
+    tag: 0.102.0
     pullPolicy: IfNotPresent
 
   # -- Image Registry Secret Names for OtelCollector

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1838,9 +1838,9 @@ otelCollector:
         system:
           hostname_sources: [dns, os]
       # Memory Limiter processor.
-      # If set to null, will be overridden with values based on k8s resource limits.
+      # If not set, will be overridden with values based on k8s resource limits.
       # ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md
-      memory_limiter: null
+      # memory_limiter: null
       signozspanmetrics/cumulative:
         metrics_exporter: clickhousemetricswrite
         latency_histogram_buckets:
@@ -2334,9 +2334,9 @@ otelCollectorMetrics:
         system:
           hostname_sources: [dns, os]
       # Memory Limiter processor.
-      # If set to null, will be overridden with values based on k8s resource limits.
+      # If not set, will be overridden with values based on k8s resource limits.
       # ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md
-      memory_limiter: null
+      # memory_limiter: null
       # K8s Attribute processor config.
       # ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md
       k8sattributes/hostmetrics:
@@ -2731,9 +2731,9 @@ k8s-infra:
           send_batch_size: 10000
           timeout: 200ms
         # Memory Limiter processor.
-        # If set to null, will be overridden with values based on k8s resource limits.
+        # If not set, will be overridden with values based on k8s resource limits.
         # ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md
-        memory_limiter: null
+        # memory_limiter: null
       extensions:
         health_check:
           endpoint: 0.0.0.0:13133
@@ -2835,9 +2835,9 @@ k8s-infra:
           send_batch_size: 10000
           timeout: 1s
         # Memory Limiter processor.
-        # If set to null, will be overridden with values based on k8s resource limits.
+        # If not set, will be overridden with values based on k8s resource limits.
         # ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md
-        memory_limiter: null
+        # memory_limiter: null
       extensions:
         health_check:
           endpoint: 0.0.0.0:13133


### PR DESCRIPTION
### Summary

Release PR:

- bump up `frontend` and `query-service` to `0.48.0`
- bump up `otel-collector`, `otel-collector-metrics` and `schema-migrator` to `0.102.0`

Signed-off-by: Prashant Shahi <prashant@signoz.io>
