### PR TITLE
chore: include topologySpreadConstraints for all components

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for ClickHouse
 type: application
-version: 24.1.0
+version: 24.1.1
 appVersion: "24.1.2"
 icon: https://github.com/ClickHouse/clickhouse-docs/raw/84f38d893eb7e561c7296279d7953b6a508ec413/static/img/clickhouse-logo.svg
 sources:

--- a/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
+++ b/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
@@ -150,6 +150,9 @@ spec:
           {{- if .Values.nodeSelector }}
           nodeSelector: {{ toYaml .Values.nodeSelector | nindent 12 }}
           {{- end }}
+          {{- with .Values.topologySpreadConstraints }}
+          topologySpreadConstraints: {{ toYaml . | nindent 8 }}
+          {{- end }}
           {{- if .Values.securityContext.enabled }}
           securityContext: {{- omit .Values.securityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -221,6 +221,8 @@ nodeSelector: {}
 tolerations: []
 # -- Affinity settings for clickhouse pod
 affinity: {}
+# -- TopologySpreadConstraints describes how clickhouse pods ought to spread
+topologySpreadConstraints: []
 
 # -- Configure resource requests and limits. Update according to your own use
 # case as these values might not be suitable for your workload.

--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.11.6
+version: 0.11.7
 appVersion: "0.88.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/templates/otel-deployment/deployment.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/deployment.yaml
@@ -44,6 +44,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.otelDeployment.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: otel-deployment-config-vol
           configMap:

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -851,6 +851,9 @@ otelDeployment:
   # -- Affinity settings for OtelDeployment pod
   affinity: {}
 
+  # -- TopologySpreadConstraints describes how OtelDeployment pods ought to spread
+  topologySpreadConstraints: []
+
   # OtelDeployment RBAC config
   clusterRole:
     # -- Specifies whether a clusterRole should be created

--- a/charts/signoz/templates/schema-migrator/migrations-init.yaml
+++ b/charts/signoz/templates/schema-migrator/migrations-init.yaml
@@ -76,4 +76,7 @@ spec:
       {{- if .Values.schemaMigrator.nodeSelector }}
       nodeSelector: {{ toYaml .Values.schemaMigrator.nodeSelector | nindent 8 }}
       {{- end }}
+      {{- if .Values.schemaMigrator.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml .Values.schemaMigrator.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/signoz/templates/schema-migrator/migrations-upgrade.yaml
+++ b/charts/signoz/templates/schema-migrator/migrations-upgrade.yaml
@@ -77,4 +77,7 @@ spec:
       {{- if .Values.schemaMigrator.nodeSelector }}
       nodeSelector: {{ toYaml .Values.schemaMigrator.nodeSelector | nindent 8 }}
       {{- end }}
+      {{- if .Values.schemaMigrator.topologySpreadConstraints }}
+      topologySpreadConstraints: {{ toYaml .Values.schemaMigrator.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1257,6 +1257,8 @@ schemaMigrator:
   tolerations: []
   # -- Affinity settings for schemaMigrator
   affinity: {}
+  # -- TopologySpreadConstraints describes how schemaMigrator pods ought to spread
+  topologySpreadConstraints: []
 
   initContainers:
     wait:


### PR DESCRIPTION
- include topologySpreadConstraints for all remaining components: clickhouse, otel-deployment, and schema migrator. 
- bump up clickhouse to `24.1.1`
- bump up k8s-infra to `0.11.7`

Signed-off-by: Prashant Shahi <prashant@signoz.io>
