### PR TITLE
feat(k8s-infra): introduce override config for presets

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.11.7
+version: 0.11.8
 appVersion: "0.88.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -223,16 +223,26 @@ receivers:
     {{- if .overrideConfig }}
     {{- toYaml .overrideConfig | nindent 4 }}
     {{- else }}
-    collection_interval: {{ .collectionInterval }}
     auth_type: {{ .authType }}
+    collection_interval: {{ .collectionInterval }}
     endpoint: {{ .endpoint }}
-    insecure_skip_verify: {{ default true .insecureSkipVerify }}
+    {{- with .extraMetadataLabels }}
     extra_metadata_labels:
-      {{- toYaml .extraMetadataLabels | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    insecure_skip_verify: {{ default true .insecureSkipVerify }}
+    {{- with .k8sApiConfig }}
+    k8s_api_config:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .metricGroups }}
     metric_groups:
-      {{- toYaml .metricGroups | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .metrics }}
     metrics:
-      {{- toYaml .metrics | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -82,6 +82,7 @@ namespace: ""
 presets:
   loggingExporter:
     enabled: false
+    overrideConfig: {}
     # Verbosity of the logging export: basic, normal, detailed
     verbosity: basic
     # Number of messages initially logged each second
@@ -90,8 +91,10 @@ presets:
     samplingThereafter: 500
   otlpExporter:
     enabled: true
+    overrideConfig: {}
   logsCollection:
     enabled: true
+    overrideConfig: {}
     startAt: beginning
     includeFilePath: true
     includeFileName: false
@@ -207,6 +210,7 @@ presets:
         to: body
   hostMetrics:
     enabled: true
+    overrideConfig: {}
     collectionInterval: 30s
     scrapers:
       cpu: {}
@@ -217,6 +221,7 @@ presets:
       network: {}
   kubeletMetrics:
     enabled: true
+    overrideConfig: {}
     collectionInterval: 30s
     authType: serviceAccount
     endpoint: ${K8S_HOST_IP}:10250
@@ -229,8 +234,10 @@ presets:
       - pod
       - node
       - volume
+    metrics: {}
   kubernetesAttributes:
     enabled: true
+    overrideConfig: {}
     # -- Whether to detect the IP address of agents and add it as an attribute to all telemetry resources.
     # If set to true, Agents will not make any k8s API calls, do any discovery of pods or extract any metadata.
     passthrough: false
@@ -260,6 +267,7 @@ presets:
       - k8s.node.name
   clusterMetrics:
     enabled: true
+    overrideConfig: {}
     collectionInterval: 30s
     nodeConditionsToReport:
       - Ready
@@ -274,11 +282,13 @@ presets:
       # - storage
   resourceDetectionInternal:
     enabled: true
+    overrideConfig: {}
     timeout: 2s
     # DO NOT CHANGE BELOW TO false, causes data duplication in case attributes mismatched.
     override: true
   resourceDetection:
     enabled: true
+    overrideConfig: {}
     timeout: 2s
     # DO NOT CHANGE BELOW TO false, causes data duplication in case attributes mismatched.
     override: true

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -229,6 +229,9 @@ presets:
     extraMetadataLabels:
       - container.id
       - k8s.volume.type
+    k8sApiConfig:
+      auth_type: serviceAccount
+      # context: ""
     metricGroups:
       - container
       - pod


### PR DESCRIPTION
- For each `k8s-infra` presets, introduce `overideConfig` configuration
- For `kubeletstats` preset, include `metrics` configuration
- Bump up k8s-infra to 0.11.8

Signed-off-by: Prashant Shahi <prashant@signoz.io>
