### PR TITLE
Update ZooKeeper values

### DIFF
--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -58,6 +58,33 @@ clickhouse:
     # -- Whether to install zookeeper. If false, `clickhouse.externalZookeeper` must be set.
     enabled: true
 
+    podAnnotations:
+      signoz.io/scrape: "true"
+      signoz.io/port: "9141"
+      signoz.io/path: "/metrics"
+    metrics:
+      enabled: true
+    logLevel: INFO
+    livenessProbe:
+      enabled: false
+    readinessProbe:
+      enabled: false
+    customLivenessProbe:
+      exec:
+        command: ['/bin/bash', '-c', 'curl -s -m 2 http://localhost:8080/commands/ruok | grep ruok']
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 6
+    customReadinessProbe:
+      exec:
+        command: ['/bin/bash', '-c', 'curl -s -m 2 http://localhost:8080/commands/ruok | grep error | grep null']
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 6
     # Zookeeper image
     image:
       # -- Zookeeper image registry to use.


### PR DESCRIPTION
This change

- Enables metrics collection
- Changes log level from `ERROR` to `INFO`
- Uses the admin endpoint for probes as described in https://github.com/bitnami/charts/tree/main/bitnami/zookeeper#configure-log-level