### PR TITLE
chore(ch-operator): include deployment annotations

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for ClickHouse
 type: application
-version: 24.1.4
+version: 24.1.5
 appVersion: "24.1.2"
 icon: https://github.com/ClickHouse/clickhouse-docs/raw/84f38d893eb7e561c7296279d7953b6a508ec413/static/img/clickhouse-logo.svg
 sources:

--- a/charts/clickhouse/templates/clickhouse-operator/deployment.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ include "clickhouse.namespace" . }}
   labels:
     {{- include "clickhouseOperator.labels" . | nindent 4 }}
+  {{- if .Values.clickhouseOperator.annotations }}
+  annotations:
+    {{- toYaml .Values.clickhouseOperator.annotations | nindent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   selector:

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -487,6 +487,10 @@ clickhouseOperator:
     # If not set and create is true, a name is generated using the fullname template
     name:
 
+  # -- Clickhouse Operator deployment annotations
+  annotations:
+    "helm.sh/hook-weight": "-5"
+
   # -- Clickhouse Operator pod(s) annotation.
   podAnnotations: {}
     # signoz.io/port: '8888'


### PR DESCRIPTION
#### Chores

- include deployment annotations for clickhouse operator
- include default hook-weight of -5 