### PR TITLE
Fix values for k8s-infra

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,5 +43,5 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install --config ct.yaml --helm-extra-set-args '--set=otelCollectorEndpoint=testingapp.signoz.io:4317'
+        run: ct install --config ct.yaml --helm-extra-set-args '--set=otelCollectorEndpoint=endpoint-that-does-not-exist:4317'
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --config ct.yaml)
+          changed=$(ct list-changed --config ct.yaml --helm-extra-set-args '--set=otelCollectorEndpoint=testingapp.signoz.io:4317')
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
@@ -43,5 +43,5 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install --config ct.yaml
+        run: ct install --config ct.yaml --helm-extra-set-args '--set=otelCollectorEndpoint=testingapp.signoz.io:4317'
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --config ct.yaml --helm-extra-set-args '--set=otelCollectorEndpoint=testingapp.signoz.io:4317')
+          changed=$(ct list-changed --config ct.yaml)
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> $GITHUB_OUTPUT
           fi

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -81,7 +81,7 @@ namespace: ""
 # -- Presets to easily set up OtelCollector configurations.
 presets:
   loggingExporter:
-    enabled: true
+    enabled: false
     # Verbosity of the logging export: basic, normal, detailed
     verbosity: basic
     # Number of messages initially logged each second
@@ -89,7 +89,7 @@ presets:
     # Sampling rate after the initial messages are logged
     samplingThereafter: 500
   otlpExporter:
-    enabled: false
+    enabled: true
   logsCollection:
     enabled: true
     startAt: beginning


### PR DESCRIPTION
The decision to change the default settings for logging and OTLP exporters, reportedly due to CI concerns, seems misguided. The OTLP exporter should remain enabled by default. Users of k8s-infra should have their data collected and sent to SigNoz or other OTLP backends. With current defaults, users will not have any idea that their data is being collected but not sent anywhere.

Being able to perform simple install and provide an endpoint to send data is a great onboarding experience and we should strive to keep the experience simple with sensible defaults.