### PR TITLE
fix(k8s-infra): enable k8sattributes to match other information

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.11.11
-appVersion: "0.88.0"
+version: 0.11.12
+appVersion: "0.109.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg
 keywords:

--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -364,6 +364,10 @@ processors:
   resourcedetection/internal:
     detectors:
       - env
+      - k8snode
+    k8snode:
+      node_from_env_var: K8S_NODE_NAME
+      auth_type: serviceAccount
     timeout: {{ .Values.presets.resourceDetectionInternal.timeout }}
     override: {{ .Values.presets.resourceDetectionInternal.override }}
 {{- end }}

--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -99,7 +99,7 @@ spec:
             - name: SIGNOZ_COMPONENT
               value: {{ default "otel-agent" .Values.otelAgent.name }}
             - name: OTEL_RESOURCE_ATTRIBUTES
-              {{- $attribs := "signoz.component=$(SIGNOZ_COMPONENT),k8s.cluster.name=$(K8S_CLUSTER_NAME),k8s.pod.uid=$(K8S_POD_UID),k8s.pod.ip=$(K8S_POD_IP)" }}
+              {{- $attribs := "signoz.component=$(SIGNOZ_COMPONENT),k8s.cluster.name=$(K8S_CLUSTER_NAME),k8s.node.name=$(K8S_NODE_NAME)" }}
               {{- if .Values.presets.resourceDetection.envResourceAttributes }}
               {{- $attribs = printf "%s,%s" $attribs .Values.presets.resourceDetection.envResourceAttributes }}
               {{- end }}

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -123,88 +123,8 @@ presets:
       containers: []
       additionalInclude: []
     operators:
-      # Find out which format is used by kubernetes
-      - type: router
-        id: get-format
-        routes:
-          - output: parser-docker
-            expr: 'body matches "^\\{"'
-          - output: parser-crio
-            expr: 'body matches "^[^ Z]+ "'
-          - output: parser-containerd
-            expr: 'body matches "^[^ Z]+Z"'
-      # Parse CRI-O format
-      - type: regex_parser
-        id: parser-crio
-        regex: '^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$'
-        output: extract_metadata_from_filepath
-        timestamp:
-          parse_from: attributes.time
-          layout_type: gotime
-          layout: '2006-01-02T15:04:05.000000000-07:00'
-      # Parse CRI-Containerd format
-      - type: regex_parser
-        id: parser-containerd
-        regex: '^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$'
-        output: extract_metadata_from_filepath
-        timestamp:
-          parse_from: attributes.time
-          layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-      # Parse Docker format
-      - type: json_parser
-        id: parser-docker
-        output: extract_metadata_from_filepath
-        timestamp:
-          parse_from: attributes.time
-          layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-      # Extract metadata from file path
-      - type: regex_parser
-        id: extract_metadata_from_filepath
-        regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
-        parse_from: attributes["log.file.path"]
-        output: add_cluster_name
-      # Add cluster name attribute from environment variable
-      - id: add_cluster_name
-        type: add
-        field: resource["k8s.cluster.name"]
-        value: EXPR(env("K8S_CLUSTER_NAME"))
-        output: move_stream
-      # Rename attributes
-      - type: move
-        id: move_stream
-        from: attributes.stream
-        to: attributes["log.iostream"]
-        output: move_container_name
-      - type: move
-        id: move_container_name
-        from: attributes.container_name
-        to: resource["k8s.container.name"]
-        output: move_namespace
-      - type: move
-        id: move_namespace
-        from: attributes.namespace
-        to: resource["k8s.namespace.name"]
-        output: move_pod_name
-      - type: move
-        id: move_pod_name
-        from: attributes.pod_name
-        to: resource["k8s.pod.name"]
-        output: move_restart_count
-      - type: move
-        id: move_restart_count
-        from: attributes.restart_count
-        to: resource["k8s.container.restart_count"]
-        output: move_uid
-      - type: move
-        id: move_uid
-        from: attributes.uid
-        to: resource["k8s.pod.uid"]
-        output: move_log
-      # Clean up log body
-      - type: move
-        id: move_log
-        from: attributes.log
-        to: body
+      - id: container-parser
+        type: container
   hostMetrics:
     enabled: true
     collectionInterval: 30s
@@ -321,7 +241,7 @@ otelAgent:
   image:
     registry: docker.io
     repository: otel/opentelemetry-collector-contrib
-    tag: 0.88.0
+    tag: 0.109.0
     pullPolicy: IfNotPresent
 
   # -- Image Registry Secret Names for OtelAgent.

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -262,11 +262,16 @@ presets:
     # -- Which pod/namespace metadata to extract from a list of default metadata fields.
     extractMetadatas:
       - k8s.namespace.name
+      - k8s.deployment.name
+      - k8s.statefulset.name
+      - k8s.daemonset.name
+      - k8s.cronjob.name
+      - k8s.job.name
+      - k8s.node.name
+      - k8s.node.uid
       - k8s.pod.name
       - k8s.pod.uid
       - k8s.pod.start_time
-      - k8s.deployment.name
-      - k8s.node.name
   clusterMetrics:
     enabled: true
     collectionInterval: 30s


### PR DESCRIPTION
## Summary
#### **New Features**
- Introduced a new `k8snode` detector to add k8s.node.uid for hostmetrics.
- Updated logging configuration to the new streamlined container parser for better maintainability.

#### **Fixes**
- The removal of k8s.pod.uid and k8s.pod.ip attributes and the inclusion of k8s.node.name attribute instead should resolve the interference issue with the k8sprocessor and improve its ability to match and enrich telemetry data accurately.

#### **Chores**
- Incremented Helm chart version and OpenTelemetry collector image version for new features and improvements.