### PR TITLE
fix(clickhouse): remove hook weight for chOperator

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for ClickHouse
 type: application
-version: 24.1.6
+version: 24.1.7
 appVersion: "24.1.2"
 icon: https://github.com/ClickHouse/clickhouse-docs/raw/84f38d893eb7e561c7296279d7953b6a508ec413/static/img/clickhouse-logo.svg
 sources:

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -488,8 +488,7 @@ clickhouseOperator:
     name:
 
   # -- Clickhouse Operator deployment annotations
-  annotations:
-    "helm.sh/hook-weight": "-5"
+  annotations: {}
 
   # -- Clickhouse Operator pod(s) annotation.
   podAnnotations: {}


### PR DESCRIPTION
#### Fixes

- remove hook weight for clickhouse operator

This was added for clean installation and deletion of the resources of clickhouse operator.
However this seems to depend on other dependent resources as well which would require the same helm hooks weight added to each of them.