### PR TITLE
fix(autoscaling): add hook-weight annotation to keda autoscaler

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.51.1
+version: 0.51.2
 appVersion: "0.53.0"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/templates/otel-collector/keda-autoscaler.yaml
+++ b/charts/signoz/templates/otel-collector/keda-autoscaler.yaml
@@ -3,6 +3,11 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: {{ include "otelCollector.fullname" . }}
+  labels:
+    {{- include "otelCollector.labels" . | nindent 4 }}
+  {{- if .Values.otelCollector.autoscaling.keda.annotations }}
+  annotations: {{ toYaml .Values.otelCollector.autoscaling.keda.annotations | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion:    apps/v1  # Optional. Default: apps/v1

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1755,6 +1755,8 @@ otelCollector:
 
     autoscalingTemplate: []
     keda:
+      annotations:
+        "helm.sh/hook-weight": "4"
       enabled: false
       pollingInterval: "30"   # check 30sec periodically for metrics data
       cooldownPeriod: "300"   # once the load decreased, it will wait for 5 min and downscale


### PR DESCRIPTION
#### Description
The otelcollector has a hook weight of 3 but the scaledobjects have no hook weight. This is leading to the scaledobjects being created first which is leading to the error that the otelcollector deployment does not exist. 

This PR puts the hook weight of scaledobjects to > 3.