### PR TITLE
feat(metrics): add k8s request and limits

### DIFF
--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -208,6 +208,8 @@ receivers:
       {{ toYaml .Values.presets.kubeletMetrics.extraMetadataLabels | nindent 6 }}
     metric_groups:
       {{ toYaml .Values.presets.kubeletMetrics.metricGroups | nindent 6 }}
+    metrics:
+      {{ toYaml .Values.presets.kubeletMetrics.metrics | nindent 6 }}
 {{- end }}
 
 {{- define "opentelemetry-collector.applyLogsCollectionConfig" -}}

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -229,6 +229,15 @@ presets:
       - pod
       - node
       - volume
+    metrics:
+      k8s.pod.cpu_limit_utilization:
+        enabled: true
+      k8s.pod.cpu_request_utilization:
+        enabled: true
+      k8s.pod.memory_limit_utilization:
+        enabled: true
+      k8s.pod.memory_request_utilization:
+        enabled: true
   kubernetesAttributes:
     enabled: true
     # -- Whether to detect the IP address of agents and add it as an attribute to all telemetry resources.


### PR DESCRIPTION
## Summary

- **New Features**
	- Enhanced configuration for `kubeletMetrics` to allow additional metrics specification.
	- Introduced new metrics for monitoring Kubernetes pod resource utilization: CPU limit, CPU request, memory limit, and memory request, all enabled by default.
  
These updates improve monitoring and observability capabilities within Kubernetes environments.