### PR TITLE
chore(k8s-infra): bump to 0.11.11

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.11.10
+version: 0.11.20
 appVersion: "0.88.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.11.20
+version: 0.11.11
 appVersion: "0.88.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg


### PR DESCRIPTION
## Summary

- **New Features**
	- Updated the Helm chart version for `k8s-infra` to 0.11.11