### PR TITLE
fix(k8s-infra): cleanup resource attribute for all signals

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.11.12
+version: 0.11.13
 appVersion: "0.109.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -34,9 +34,6 @@ Build config file for daemonset OpenTelemetry Collector: OtelAgent
 {{- if .Values.presets.resourceDetection.enabled }}
 {{- $config = (include "opentelemetry-collector.applyResourceDetectionConfig" (dict "Values" $data "config" $config) | fromYaml) }}
 {{- end }}
-{{- if .Values.presets.resourceDetectionInternal.enabled }}
-{{- $config = (include "opentelemetry-collector.applyResourceDetectionInternalConfig" (dict "Values" $data "config" $config) | fromYaml) }}
-{{- end }}
 {{- if .Values.global.deploymentEnvironment }}
 {{- $config = (include "opentelemetry-collector.applyDeploymentEnvironmentConfig" (dict "Values" $data "config" $config) | fromYaml) }}
 {{- end }}
@@ -68,8 +65,8 @@ Build config file for deployment OpenTelemetry Collector: OtelDeployment
 {{- $values := deepCopy .Values }}
 {{- $data := dict "Values" $values | mustMergeOverwrite (deepCopy .) }}
 {{- $config := include "otelDeployment.baseConfig" $data | fromYaml }}
-{{- if .Values.presets.resourceDetectionInternal.enabled }}
-{{- $config = (include "opentelemetry-collector.applyResourceDetectionInternalConfig" (dict "Values" $data "config" $config) | fromYaml) }}
+{{- if .Values.presets.resourceDetection.enabled }}
+{{- $config = (include "opentelemetry-collector.applyResourceDetectionConfig" (dict "Values" $data "config" $config) | fromYaml) }}
 {{- end }}
 {{- if .Values.global.deploymentEnvironment }}
 {{- $config = (include "opentelemetry-collector.applyDeploymentEnvironmentConfig" (dict "Values" $data "config" $config) | fromYaml) }}
@@ -331,6 +328,15 @@ processors:
 
 {{- define "opentelemetry-collector.applyResourceDetectionConfig" -}}
 {{- $config := mustMergeOverwrite (include "opentelemetry-collector.resourceDetectionConfig" .Values | fromYaml) .config }}
+{{- if $config.service.pipelines.logs }}
+{{- $_ := set $config.service.pipelines.logs "processors" (prepend $config.service.pipelines.logs.processors "resourcedetection" | uniq) }}
+{{- end }}
+{{- if $config.service.pipelines.metrics }}
+{{- $_ := set $config.service.pipelines.metrics "processors" (prepend $config.service.pipelines.metrics.processors "resourcedetection" | uniq) }}
+{{- end }}
+{{- if $config.service.pipelines.traces }}
+{{- $_ := set $config.service.pipelines.traces "processors" (prepend $config.service.pipelines.traces.processors "resourcedetection" | uniq) }}
+{{- end }}
 {{- if index $config.service.pipelines "metrics/internal" }}
 {{- $_ := set (index $config.service.pipelines "metrics/internal") "processors" (prepend (index (index $config.service.pipelines "metrics/internal") "processors") "resourcedetection" | uniq) }}
 {{- end }}
@@ -342,6 +348,11 @@ processors:
   resourcedetection:
     detectors:
       {{- toYaml .Values.presets.resourceDetection.detectors | nindent 6 }}
+    {{- if has "k8snode" .Values.presets.resourceDetection.detectors }}
+    k8snode:
+      node_from_env_var: K8S_NODE_NAME
+      auth_type: serviceAccount
+    {{- end }}
     timeout: {{ .Values.presets.resourceDetection.timeout }}
     override: {{ .Values.presets.resourceDetection.override }}
     {{- if has "system" .Values.presets.resourceDetection.detectors }}
@@ -349,36 +360,6 @@ processors:
       hostname_sources:
         {{- toYaml .Values.presets.resourceDetection.systemHostnameSources | nindent 8 }}
     {{- end }}
-{{- end }}
-
-{{- define "opentelemetry-collector.applyResourceDetectionInternalConfig" -}}
-{{- $config := mustMergeOverwrite (include "opentelemetry-collector.resourceDetectionInternalConfig" .Values | fromYaml) .config }}
-{{- if $config.service.pipelines.logs }}
-{{- $_ := set $config.service.pipelines.logs "processors" (prepend $config.service.pipelines.logs.processors "resourcedetection/internal" | uniq) }}
-{{- end }}
-{{- if $config.service.pipelines.metrics }}
-{{- $_ := set $config.service.pipelines.metrics "processors" (prepend $config.service.pipelines.metrics.processors "resourcedetection/internal" | uniq) }}
-{{- end }}
-{{- if $config.service.pipelines.traces }}
-{{- $_ := set $config.service.pipelines.traces "processors" (prepend $config.service.pipelines.traces.processors "resourcedetection/internal" | uniq) }}
-{{- end }}
-{{- if index $config.service.pipelines "metrics/internal" }}
-{{- $_ := set (index $config.service.pipelines "metrics/internal") "processors" (prepend (index (index $config.service.pipelines "metrics/internal") "processors") "resourcedetection/internal" | uniq) }}
-{{- end }}
-{{- $config | toYaml }}
-{{- end }}
-
-{{- define "opentelemetry-collector.resourceDetectionInternalConfig" -}}
-processors:
-  resourcedetection/internal:
-    detectors:
-      - env
-      - k8snode
-    k8snode:
-      node_from_env_var: K8S_NODE_NAME
-      auth_type: serviceAccount
-    timeout: {{ .Values.presets.resourceDetectionInternal.timeout }}
-    override: {{ .Values.presets.resourceDetectionInternal.override }}
 {{- end }}
 
 {{- define "opentelemetry-collector.applyDeploymentEnvironmentConfig" -}}

--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -353,6 +353,15 @@ processors:
 
 {{- define "opentelemetry-collector.applyResourceDetectionInternalConfig" -}}
 {{- $config := mustMergeOverwrite (include "opentelemetry-collector.resourceDetectionInternalConfig" .Values | fromYaml) .config }}
+{{- if $config.service.pipelines.logs }}
+{{- $_ := set $config.service.pipelines.logs "processors" (prepend $config.service.pipelines.logs.processors "resourcedetection/internal" | uniq) }}
+{{- end }}
+{{- if $config.service.pipelines.metrics }}
+{{- $_ := set $config.service.pipelines.metrics "processors" (prepend $config.service.pipelines.metrics.processors "resourcedetection/internal" | uniq) }}
+{{- end }}
+{{- if $config.service.pipelines.traces }}
+{{- $_ := set $config.service.pipelines.traces "processors" (prepend $config.service.pipelines.traces.processors "resourcedetection/internal" | uniq) }}
+{{- end }}
 {{- if index $config.service.pipelines "metrics/internal" }}
 {{- $_ := set (index $config.service.pipelines "metrics/internal") "processors" (prepend (index (index $config.service.pipelines "metrics/internal") "processors") "resourcedetection/internal" | uniq) }}
 {{- end }}

--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -365,8 +365,13 @@ processors:
     timeout: {{ .Values.presets.resourceDetection.timeout }}
     override: {{ .Values.presets.resourceDetection.override }}
     system:
-      hostname_sources:
-        {{- toYaml .Values.presets.resourceDetection.systemHostnameSources | nindent 8 }}
+      resource_attributes:
+        host.name:
+          enabled: false
+        host.id:
+          enabled: false
+        os.type:
+          enabled: true
 {{- end }}
 
 {{- define "opentelemetry-collector.applyDeploymentEnvironmentConfig" -}}

--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -52,9 +52,6 @@ Build config file for daemonset OpenTelemetry Collector: OtelAgent
 {{- if or (eq (len $config.service.pipelines.traces.receivers) 0) (eq (len $config.service.pipelines.traces.exporters) 0) }}
 {{- $_ := unset $config.service.pipelines "traces" }}
 {{- end }}
-{{- if or (eq (len (index (index $config.service.pipelines "metrics/internal") "receivers")) 0) (eq (len (index (index $config.service.pipelines "metrics/internal") "exporters")) 0) }}
-{{- $_ := unset $config.service.pipelines "metrics/internal" }}
-{{- end }}
 {{- tpl (toYaml $config) . }}
 {{- end }}
 
@@ -169,8 +166,8 @@ receivers:
 
 {{- define "opentelemetry-collector.applyHostMetricsConfig" -}}
 {{- $config := mustMergeOverwrite (include "opentelemetry-collector.hostMetricsConfig" .Values | fromYaml) .config }}
-{{- if index $config.service.pipelines "metrics/internal" }}
-{{- $_ := set (index $config.service.pipelines "metrics/internal") "receivers" (append (index (index $config.service.pipelines "metrics/internal") "receivers") "hostmetrics" | uniq)  }}
+{{- if $config.service.pipelines.metrics }}
+{{- $_ := set $config.service.pipelines.metrics "receivers" (append $config.service.pipelines.metrics.receivers "hostmetrics" | uniq)  }}
 {{- end }}
 {{- $config | toYaml }}
 {{- end }}
@@ -188,8 +185,8 @@ receivers:
 
 {{- define "opentelemetry-collector.applyKubeletMetricsConfig" -}}
 {{- $config := mustMergeOverwrite (include "opentelemetry-collector.kubeletMetricsConfig" .Values | fromYaml) .config }}
-{{- if index $config.service.pipelines "metrics/internal" }}
-{{- $_ := set (index $config.service.pipelines "metrics/internal") "receivers" (append (index (index $config.service.pipelines "metrics/internal") "receivers") "kubeletstats" | uniq)  }}
+{{- if $config.service.pipelines.metrics }}
+{{- $_ := set $config.service.pipelines.metrics "receivers" (append $config.service.pipelines.metrics.receivers "kubeletstats" | uniq)  }}
 {{- end }}
 {{- $config | toYaml }}
 {{- end }}

--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -346,8 +346,6 @@ processors:
     # detectors: include ec2/eks for AWS, gcp for GCP and azure/aks for Azure
     # env detector included below adds custom labels using OTEL_RESOURCE_ATTRIBUTES envvar (set envResourceAttributes value)
     detectors:
-      - env
-      - k8snode
       {{- if eq "aws" .Values.global.cloud }}
       - eks
       - ec2
@@ -358,6 +356,8 @@ processors:
       {{- if eq "azure" .Values.global.cloud }}
       - azure
       {{- end }}
+      - k8snode
+      - env
       - system
     k8snode:
       node_from_env_var: K8S_NODE_NAME

--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -99,7 +99,7 @@ spec:
             - name: SIGNOZ_COMPONENT
               value: {{ default "otel-agent" .Values.otelAgent.name }}
             - name: OTEL_RESOURCE_ATTRIBUTES
-              {{- $attribs := "signoz.component=$(SIGNOZ_COMPONENT),k8s.cluster.name=$(K8S_CLUSTER_NAME),k8s.node.name=$(K8S_NODE_NAME)" }}
+              {{- $attribs := "signoz.component=$(SIGNOZ_COMPONENT),k8s.cluster.name=$(K8S_CLUSTER_NAME),k8s.node.name=$(K8S_NODE_NAME),host.name=$(K8S_NODE_NAME)" }}
               {{- if .Values.presets.resourceDetection.envResourceAttributes }}
               {{- $attribs = printf "%s,%s" $attribs .Values.presets.resourceDetection.envResourceAttributes }}
               {{- end }}

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -206,11 +206,6 @@ presets:
       - memory
       # - ephemeral-storage
       # - storage
-  resourceDetectionInternal:
-    enabled: true
-    timeout: 2s
-    # DO NOT CHANGE BELOW TO false, causes data duplication in case attributes mismatched.
-    override: true
   resourceDetection:
     enabled: true
     timeout: 2s
@@ -227,6 +222,8 @@ presets:
       # - azure
       # - heroku
       - system
+      - env
+      - k8snode
     systemHostnameSources:
       - dns
       - os

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -214,6 +214,8 @@ presets:
     # detectors: include ec2/eks for AWS, gcp for GCP and azure/aks for Azure
     # env detector included below adds custom labels using OTEL_RESOURCE_ATTRIBUTES envvar (set envResourceAttributes value)
     detectors:
+      - env
+      - k8snode
       # - elastic_beanstalk
       # - eks
       # - ecs
@@ -222,8 +224,6 @@ presets:
       # - azure
       # - heroku
       - system
-      - env
-      - k8snode
     systemHostnameSources:
       - dns
       - os

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -125,6 +125,10 @@ presets:
     operators:
       - id: container-parser
         type: container
+      - id: add-cluster-name
+        type: add
+        field: resource["k8s.cluster.name"]
+        value: EXPR(env("K8S_CLUSTER_NAME"))
   hostMetrics:
     enabled: true
     collectionInterval: 30s

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -15,7 +15,7 @@ global:
   # -- Deployment environment to be attached to telemetry data
   deploymentEnvironment: ""
   # -- Kubernetes cluster cloud provider along with distribution if any.
-  # example: `aws`, `azure`, `gcp`, `gcp/autogke`, `hcloud`, `other`
+  # example: `aws`, `azure`, `gcp`, `gcp/autogke`, `azure`, and `other`
   cloud: other
 
 # -- K8s infra chart name override
@@ -211,19 +211,6 @@ presets:
     timeout: 2s
     # DO NOT CHANGE BELOW TO false, causes data duplication in case attributes mismatched.
     override: true
-    # detectors: include ec2/eks for AWS, gcp for GCP and azure/aks for Azure
-    # env detector included below adds custom labels using OTEL_RESOURCE_ATTRIBUTES envvar (set envResourceAttributes value)
-    detectors:
-      - env
-      - k8snode
-      # - elastic_beanstalk
-      # - eks
-      # - ecs
-      # - ec2
-      # - gcp
-      # - azure
-      # - heroku
-      - system
     systemHostnameSources:
       - dns
       - os

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -125,10 +125,6 @@ presets:
     operators:
       - id: container-parser
         type: container
-      - id: add-cluster-name
-        type: add
-        field: resource["k8s.cluster.name"]
-        value: EXPR(env("K8S_CLUSTER_NAME"))
   hostMetrics:
     enabled: true
     collectionInterval: 30s

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -572,10 +572,6 @@ otelAgent:
           receivers: [otlp]
           processors: [batch]
           exporters: []
-        metrics/internal:
-          receivers: []
-          processors: [batch]
-          exporters: []
         logs:
           receivers: [otlp]
           processors: [batch]

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -211,11 +211,6 @@ presets:
     timeout: 2s
     # DO NOT CHANGE BELOW TO false, causes data duplication in case attributes mismatched.
     override: true
-    systemHostnameSources:
-      - dns
-      - os
-      # - cname
-      # - lookup
     envResourceAttributes: ""
 
 # Default values for OtelAgent


### PR DESCRIPTION
#### New Features
- Updated the Helm chart version to 0.11.13.
- Enhanced resource detection capabilities with new detectors: `env`, `k8snode`, and cloud-specific detectors.
- Introduced `otelTlsSecrets` for configuring OpenTelemetry OTLP secrets.
- Expanded configuration options for telemetry and resource monitoring, including new fields in `clusterMetrics`.
- Added the `host.name` attribute to the OpenTelemetry agent's resource attributes.
- Refined service port configurations and ingress settings for `otelAgent` and `otelDeployment`.
- Streamlined resource detection configuration by consolidating settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Helm chart version to 0.11.13.
	- Enhanced resource detection capabilities with new detectors: `env`, `k8snode`, and cloud-specific detectors.
	- Introduced `otelTlsSecrets` for configuring OpenTelemetry OTLP secrets.
	- Expanded configuration options for telemetry and resource monitoring, including new fields in `clusterMetrics`.
	- Added the `host.name` attribute to the OpenTelemetry agent's resource attributes.
	- Refined service port configurations and ingress settings for `otelAgent` and `otelDeployment`.
	- Streamlined resource detection configuration by consolidating settings.

- **Bug Fixes**
	- No specific bug fixes were mentioned in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->