### PR TITLE
feat: enable new logs schema by default

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.53.0
+version: 0.53.1
 appVersion: "0.55.0"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -644,8 +644,8 @@ queryService:
     "helm.sh/hook-weight": "2"
 
   # -- Query-Service additional arguments for command line
-  additionalArgs: []
-    # - --prefer-delta=true
+  additionalArgs:
+    - --use-logs-new-schema=true
 
   # -- Additional environments to set for queryService
   additionalEnvs: {}
@@ -1978,6 +1978,7 @@ otelCollector:
       clickhouselogsexporter:
         dsn: tcp://${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}@${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/${CLICKHOUSE_LOG_DATABASE}
         timeout: 10s
+        use_new_schema: true
       prometheus:
         endpoint: 0.0.0.0:8889
     service:


### PR DESCRIPTION
#### Features

- enable new logs schema by default
- remove prefer delta comment from query-service


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated configuration for the query service to enable a new logging schema.
	- Added a new schema option for log handling in the OpenTelemetry collector settings.
  
- **Version Update**
	- Incremented the Helm Chart version from 0.53.0 to 0.53.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->