### PR TITLE
fix: Indentation for clickhouse instance topologySpreadConstraints

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for ClickHouse
 type: application
-version: 24.1.7
+version: 24.1.8
 appVersion: "24.1.2"
 icon: https://github.com/ClickHouse/clickhouse-docs/raw/84f38d893eb7e561c7296279d7953b6a508ec413/static/img/clickhouse-logo.svg
 sources:

--- a/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
+++ b/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
@@ -153,7 +153,7 @@ spec:
           nodeSelector: {{ toYaml .Values.nodeSelector | nindent 12 }}
           {{- end }}
           {{- with .Values.topologySpreadConstraints }}
-          topologySpreadConstraints: {{ toYaml . | nindent 8 }}
+          topologySpreadConstraints: {{ toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.securityContext.enabled }}
           securityContext: {{- omit .Values.securityContext "enabled" | toYaml | nindent 12 }}


### PR DESCRIPTION
### Summary
This PR corrects the indentation of the topologySpreadConstraints section in the configuration. (nindent 8 -> 12)

### Changes Made
Adjusted the indentation for topologySpreadConstraints to ensure it aligns correctly within the configuration structure.

### Impact
This fix will improve readability and maintainability of the configuration file, preventing potential issues with parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced cold storage configuration with detailed XML settings for S3 and GCS.
	- Added volume claim templates for better management of storage configurations.
  
- **Improvements**
	- Adjusted indentation for improved YAML structure.
	- Refined volume mounts logic for clarity based on persistence settings.
	- Updated Zookeeper node configuration for better clarity and maintainability.
	- Enhanced service template metadata with additional annotations. 

- **Version Update**
	- Updated ClickHouse Helm chart version from 24.1.7 to 24.1.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->