### PR TITLE
fix(k8s-infra): use agent container root for autopilot

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.11.12
+version: 0.11.13
 appVersion: "0.109.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -182,7 +182,9 @@ receivers:
 receivers:
   hostmetrics:
     collection_interval: {{ .Values.presets.hostMetrics.collectionInterval }}
+    {{- if ne .Values.global.cloud "gcp/autogke" }}
     root_path: /hostfs
+    {{- end }}
     scrapers:
     {{ range $key, $val := .Values.presets.hostMetrics.scrapers }}
       {{ $key }}: {{ $val | toYaml }}


### PR DESCRIPTION
### Summary

Hostmetrics collection for GKE Autopilot is broken since we are unable to mount the root path `/` to the container path `/hostfs`.

Hence, for GKE Autopilot, we are reverting to the previous behaviour.

### Fixes

- use agent container root for autopilot