### PR TITLE
Ignore noisy host metrics data points

### DIFF
--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -168,7 +168,6 @@ receivers:
 {{- $config := mustMergeOverwrite (include "opentelemetry-collector.hostMetricsConfig" .Values | fromYaml) .config }}
 {{- if $config.service.pipelines.metrics }}
 {{- $_ := set $config.service.pipelines.metrics "receivers" (append $config.service.pipelines.metrics.receivers "hostmetrics" | uniq)  }}
-{{- $_ := set $config.service.pipelines.metrics "processors" (append $config.service.pipelines.metrics.processors "filter/hostmetrics" | uniq)  }}
 {{- end }}
 {{- $config | toYaml }}
 {{- end }}
@@ -180,14 +179,8 @@ receivers:
     root_path: /hostfs
     scrapers:
     {{ range $key, $val := .Values.presets.hostMetrics.scrapers }}
-      {{ $key }}: {{ $val | toYaml }}
+      {{ $key }}: {{- $val | toYaml | nindent 8 }}
     {{ end }}
-processors:
-  filter/hostmetrics:
-    error_mode: ignore
-    metrics:
-      datapoint:
-        {{- toYaml .Values.presets.hostMetrics.excludeDatapoints | nindent 8 }}
 {{- end }}
 
 {{- define "opentelemetry-collector.applyKubeletMetricsConfig" -}}

--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -168,6 +168,7 @@ receivers:
 {{- $config := mustMergeOverwrite (include "opentelemetry-collector.hostMetricsConfig" .Values | fromYaml) .config }}
 {{- if $config.service.pipelines.metrics }}
 {{- $_ := set $config.service.pipelines.metrics "receivers" (append $config.service.pipelines.metrics.receivers "hostmetrics" | uniq)  }}
+{{- $_ := set $config.service.pipelines.metrics "processors" (append $config.service.pipelines.metrics.processors "filter/hostmetrics" | uniq)  }}
 {{- end }}
 {{- $config | toYaml }}
 {{- end }}
@@ -181,6 +182,12 @@ receivers:
     {{ range $key, $val := .Values.presets.hostMetrics.scrapers }}
       {{ $key }}: {{ $val | toYaml }}
     {{ end }}
+processors:
+  filter/hostmetrics:
+    error_mode: ignore
+    metrics:
+      datapoint:
+        {{- toYaml .Values.presets.hostMetrics.excludeDatapoints | nindent 8 }}
 {{- end }}
 
 {{- define "opentelemetry-collector.applyKubeletMetricsConfig" -}}

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -132,14 +132,72 @@ presets:
       cpu: {}
       load: {}
       memory: {}
-      disk: {}
-      filesystem: {}
-      network: {}
-    excludeDatapoints:
-      - IsMatch(metric.name, "system.disk.*") and IsMatch(attributes["device"], "^(z?ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\\d+n\\d+p)\\d+$") and resource.attributes["os.type"] == "linux"
-      - IsMatch(metric.name, "system.filesystem.*") and IsMatch(attributes["mountpoint"], "^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+|var/lib/containers/storage/.+)($|/)") and resource.attributes["os.type"] == "linux"
-      - IsMatch(metric.name, "system.filesystem.*") and IsMatch(attributes["type"], "^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$") and resource.attributes["os.type"] == "linux"
-      - IsMatch(metric.name, "system.network.*") and IsMatch(attributes["device"], "^(veth.*|docker.*|br-.*|flannel.*|cali.*|cbr.*|cni.*|dummy.*|tailscale.*|lo)$") and resource.attributes["os.type"] == "linux"
+      disk:
+        exclude:
+          devices:
+            - ^ram\d+$
+            - ^zram\d+$
+            - ^loop\d+$
+            - ^fd\d+$
+            - ^hd[a-z]\d+$
+            - ^sd[a-z]\d+$
+            - ^vd[a-z]\d+$
+            - ^xvd[a-z]\d+$
+            - ^nvme\d+n\d+p\d+$
+          match_type: regexp
+      filesystem:
+        exclude_fs_types:
+          fs_types:
+            - autofs
+            - binfmt_misc
+            - bpf
+            - cgroup2?
+            - configfs
+            - debugfs
+            - devpts
+            - devtmpfs
+            - fusectl
+            - hugetlbfs
+            - iso9660
+            - mqueue
+            - nsfs
+            - overlay
+            - proc
+            - procfs
+            - pstore
+            - rpc_pipefs
+            - securityfs
+            - selinuxfs
+            - squashfs
+            - sysfs
+            - tracefs
+          match_type: strict
+        exclude_mount_points:
+          mount_points:
+            - /dev/*
+            - /proc/*
+            - /sys/*
+            - /run/credentials/*
+            - /run/k3s/containerd/*
+            - /var/lib/docker/*
+            - /var/lib/containers/storage/*
+            - /var/lib/kubelet/*
+            - /snap/*
+          match_type: regexp
+      network:
+        exclude:
+          interfaces:
+            - ^veth.*$
+            - ^docker.*$
+            - ^br-.*$
+            - ^flannel.*$
+            - ^cali.*$
+            - ^cbr.*$
+            - ^cni.*$
+            - ^dummy.*$
+            - ^tailscale.*$
+            - ^lo$
+          match_type: regexp
   kubeletMetrics:
     enabled: true
     collectionInterval: 30s

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -136,10 +136,10 @@ presets:
       filesystem: {}
       network: {}
     excludeDatapoints:
-      - 'IsMatch(name, "system.disk.*") and IsMatch(attributes["device"], "^(z?ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\\d+n\\d+p)\\d+$") and resource.attributes["os.type"] == "linux"'
-      - 'IsMatch(name, "system.filesystem.*") and IsMatch(attributes["mountpoint"], "^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+|var/lib/containers/storage/.+)($|/)") and resource.attributes["os.type"] == "linux"'
-      - 'IsMatch(name, "system.filesystem.*") and IsMatch(attributes["type"], "^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$") and resource.attributes["os.type"] == "linux"'
-      - 'IsMatch(name, "system.network.*") and IsMatch(attributes["device"], "^(veth.*|docker.*|br-.*|flannel.*|cali.*|cbr.*|cni.*|dummy.*|tailscale.*|lo)$") and resource.attributes["os.type"] == "linux"'
+      - IsMatch(metric.name, "system.disk.*") and IsMatch(attributes["device"], "^(z?ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\\d+n\\d+p)\\d+$") and resource.attributes["os.type"] == "linux"
+      - IsMatch(metric.name, "system.filesystem.*") and IsMatch(attributes["mountpoint"], "^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+|var/lib/containers/storage/.+)($|/)") and resource.attributes["os.type"] == "linux"
+      - IsMatch(metric.name, "system.filesystem.*") and IsMatch(attributes["type"], "^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$") and resource.attributes["os.type"] == "linux"
+      - IsMatch(metric.name, "system.network.*") and IsMatch(attributes["device"], "^(veth.*|docker.*|br-.*|flannel.*|cali.*|cbr.*|cni.*|dummy.*|tailscale.*|lo)$") and resource.attributes["os.type"] == "linux"
   kubeletMetrics:
     enabled: true
     collectionInterval: 30s

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -135,6 +135,11 @@ presets:
       disk: {}
       filesystem: {}
       network: {}
+    excludeDatapoints:
+      - 'IsMatch(name, "system.disk.*") and IsMatch(attributes["device"], "^(z?ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\\d+n\\d+p)\\d+$") and resource.attributes["os.type"] == "linux"'
+      - 'IsMatch(name, "system.filesystem.*") and IsMatch(attributes["mountpoint"], "^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+|var/lib/containers/storage/.+)($|/)") and resource.attributes["os.type"] == "linux"'
+      - 'IsMatch(name, "system.filesystem.*") and IsMatch(attributes["type"], "^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$") and resource.attributes["os.type"] == "linux"'
+      - 'IsMatch(name, "system.network.*") and IsMatch(attributes["device"], "^(veth.*|docker.*|br-.*|flannel.*|cali.*|cbr.*|cni.*|dummy.*|tailscale.*|lo)$") and resource.attributes["os.type"] == "linux"'
   kubeletMetrics:
     enabled: true
     collectionInterval: 30s


### PR DESCRIPTION
Fixes https://github.com/SigNoz/charts/issues/515

By default we ignore known block devices, mountpoints, file systems, and n/w devices that are  known to 
- large volume of metrics with little to no benefit; example `nvme\\d+n\\d+p` collecting every partition separately often doesn't provide additional valuable information beyond monitoring the whole disk
- be volatile; devices like loop  and z?ram are often used temporarily or for specific purposes
- be virtual and not useful; example veth.* 
- change rapidly; example `/var/lib/docker/.+`. If users need, they can separately collect docker container metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new processor for filtering host metrics.
	- Enhanced configuration for excluding specific metrics during telemetry data collection, including disk, filesystem, and network scrapers.
	- Expanded resource detection capabilities based on cloud provider settings.
	- Updated deployment environment configuration to include relevant attributes in logs, metrics, and traces.
	- Added a new receiver for cluster metrics in the metrics pipeline.

- **Bug Fixes**
	- Corrected indentation issues in the `values.yaml` file for proper YAML structure.

These changes improve the flexibility and efficiency of metrics and logs processing within the OpenTelemetry Collector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->