### PR TITLE
Include persistentvolumeclaims for otelAgent clusterRole resources

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.11.14
+version: 0.11.15
 appVersion: "0.109.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -388,7 +388,7 @@ otelAgent:
     rules:
       # k8sattributes processor requires these permissions
       - apiGroups: [""]
-        resources: ["pods", "namespaces", "nodes"]
+        resources: ["pods", "namespaces", "nodes", "persistentvolumeclaims"]
         verbs: ["get", "list", "watch"]
       - apiGroups: ["apps"]
         resources: ["replicasets"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the version of the `k8s-infra` Helm chart to `0.11.15`.
	- Enhanced RBAC capabilities for the `OtelAgent` by adding permission to manage persistent volume claims.

- **Bug Fixes**
	- No significant bug fixes reported in this release. 

- **Documentation**
	- Updated documentation to reflect the new version and permissions in the `values.yaml` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->