### PR TITLE
Update resourcedetection config

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.11.16
+version: 0.11.17
 appVersion: "0.109.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -277,8 +277,7 @@ presets:
   resourceDetection:
     enabled: true
     timeout: 2s
-    # DO NOT CHANGE BELOW TO false, causes data duplication in case attributes mismatched.
-    override: true
+    override: false
     envResourceAttributes: ""
   k8sEvents:
     enabled: true


### PR DESCRIPTION
- Recently, we got rid of `resourcedetection/internal` from both `otelAgent` and `otelDeployment`. This change created data problems for any resources that were not in the same node as the otelDeployment pod. For example, 1. `k8s.node.name` was getting replaced with the node name where deployment was running 2. The `k8s.pod.phase` has a `host.name` attribute populated by the `host.name` of the otelDeployment pod. The `otelAgent` and `otelDeploment` do very different jobs, so they shouldn't apply the same resource detection config.
- While troubleshooting, I came across the `override: true`. I asked if we know any reason for this but it doesn't seem we don't recall anything about it https://signoz-team.slack.com/archives/C02T94VFZAA/p1728970838055629. I looked at the old config generated with `override` set to `true` and it didn't make any sense https://github.com/SigNoz/charts/issues/532#issuecomment-2413220233. It is used in all the pipelines, I don't see any case where we would want to override the incoming data.


In this change, I disabled the `override` and defined new resource detection for deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration function for deployment scenarios in the OpenTelemetry Collector, enhancing resource detection configurability.

- **Bug Fixes**
	- Resolved ambiguity in the `clusterName` field within the global configuration.

- **Improvements**
	- Updated resource detection behavior by changing the `override` field to `false` for better clarity.
	- Clarified the configuration structure for `OtelAgent` and `OtelDeployment`.
	- Adjusted metrics and health check configurations for improved clarity and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->