### PR TITLE
fix: use env prefix in collector config for typecasting

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.11.17
+version: 0.11.18
 appVersion: "0.109.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -134,19 +134,19 @@ exporters:
 {{- define "opentelemetry-collector.otlpExporterConfig" -}}
 exporters:
   otlp:
-    endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+    endpoint: ${env:OTEL_EXPORTER_OTLP_ENDPOINT}
     tls:
-      insecure: ${OTEL_EXPORTER_OTLP_INSECURE}
-      insecure_skip_verify: ${OTEL_EXPORTER_OTLP_INSECURE_SKIP_VERIFY}
+      insecure: ${env:OTEL_EXPORTER_OTLP_INSECURE}
+      insecure_skip_verify: ${env:OTEL_EXPORTER_OTLP_INSECURE_SKIP_VERIFY}
       {{- if .Values.otelTlsSecrets.enabled }}
-      cert_file: ${OTEL_SECRETS_PATH}/cert.pem
-      key_file: ${OTEL_SECRETS_PATH}/key.pem
+      cert_file: ${env:OTEL_SECRETS_PATH}/cert.pem
+      key_file: ${env:OTEL_SECRETS_PATH}/key.pem
       {{- if .Values.otelTlsSecrets.ca }}
-      ca_file: ${OTEL_SECRETS_PATH}/ca.pem
+      ca_file: ${env:OTEL_SECRETS_PATH}/ca.pem
       {{- end }}
       {{- end }}
     headers:
-      "signoz-access-token": "${SIGNOZ_API_KEY}"
+      "signoz-access-token": "${env:SIGNOZ_API_KEY}"
 {{- end }}
 
 {{- define "opentelemetry-collector.applyClusterMetricsConfig" -}}

--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -53,9 +53,11 @@ spec:
         - name: varlibdockercontainers
           hostPath:
             path: /var/lib/docker/containers
+        {{- if eq .Values.presets.hostMetrics.enabled true }}
         - name: hostfs
           hostPath:
             path: /
+        {{- end }}
         {{- end }}
         {{- if .Values.otelTlsSecrets.enabled }}
         - name: {{ include "k8s-infra.fullname" . }}-agent-secrets-vol
@@ -120,10 +122,12 @@ spec:
             - name: varlibdockercontainers
               mountPath: /var/lib/docker/containers
               readOnly: true
+            {{- if eq .Values.presets.hostMetrics.enabled true }}
             - name: hostfs
               mountPath: /hostfs
               readOnly: true
               mountPropagation: HostToContainer
+            {{- end }}
             {{- end }}
             {{- if .Values.otelTlsSecrets.enabled }}
             - name: {{ include "k8s-infra.fullname" . }}-agent-secrets-vol

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -202,7 +202,7 @@ presets:
     enabled: true
     collectionInterval: 30s
     authType: serviceAccount
-    endpoint: ${K8S_HOST_IP}:10250
+    endpoint: ${env:K8S_HOST_IP}:10250
     insecureSkipVerify: true
     extraMetadataLabels:
       - container.id

--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.54.0
+version: 0.54.1
 appVersion: "0.56.0"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1968,15 +1968,15 @@ otelCollector:
         endpoint: localhost:1777
     exporters:
       clickhousetraces:
-        datasource: tcp://${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}@${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/${CLICKHOUSE_TRACE_DATABASE}
-        low_cardinal_exception_grouping: ${LOW_CARDINAL_EXCEPTION_GROUPING}
+        datasource: tcp://${env:CLICKHOUSE_USER}:${env:CLICKHOUSE_PASSWORD}@${env:CLICKHOUSE_HOST}:${env:CLICKHOUSE_PORT}/${env:CLICKHOUSE_TRACE_DATABASE}
+        low_cardinal_exception_grouping: ${env:LOW_CARDINAL_EXCEPTION_GROUPING}
       clickhousemetricswrite:
-        endpoint: tcp://${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}@${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/${CLICKHOUSE_DATABASE}
+        endpoint: tcp://${env:CLICKHOUSE_USER}:${env:CLICKHOUSE_PASSWORD}@${env:CLICKHOUSE_HOST}:${env:CLICKHOUSE_PORT}/${env:CLICKHOUSE_DATABASE}
         timeout: 15s
         resource_to_telemetry_conversion:
           enabled: true
       clickhouselogsexporter:
-        dsn: tcp://${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}@${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/${CLICKHOUSE_LOG_DATABASE}
+        dsn: tcp://${env:CLICKHOUSE_USER}:${env:CLICKHOUSE_PASSWORD}@${env:CLICKHOUSE_HOST}:${env:CLICKHOUSE_PORT}/${env:CLICKHOUSE_LOG_DATABASE}
         timeout: 10s
         use_new_schema: true
       prometheus:
@@ -2366,9 +2366,9 @@ otelCollectorMetrics:
     exporters:
       clickhousemetricswrite:
         timeout: 15s
-        endpoint: tcp://${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}@${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/${CLICKHOUSE_DATABASE}
+        endpoint: tcp://${env:CLICKHOUSE_USER}:${env:CLICKHOUSE_PASSWORD}@${env:CLICKHOUSE_HOST}:${env:CLICKHOUSE_PORT}/${env:CLICKHOUSE_DATABASE}
       clickhousemetricswrite/hostmetrics:
-        endpoint: tcp://${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}@${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}/${CLICKHOUSE_DATABASE}
+        endpoint: tcp://${env:CLICKHOUSE_USER}:${env:CLICKHOUSE_PASSWORD}@${env:CLICKHOUSE_HOST}:${env:CLICKHOUSE_PORT}/${env:CLICKHOUSE_DATABASE}
         resource_to_telemetry_conversion:
           enabled: true
     service:


### PR DESCRIPTION
#### Fixes

- use env prefix in collector config for typecasting
- only enable hostfs mount when hostmetrics is on 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced configuration flexibility by introducing environment variable references for various components, improving security and deployment adaptability.
	- Updated resource detection configurations for OpenTelemetry Collector to support AWS, GCP, and Azure.
	- Added support for accessing the host filesystem in the OpenTelemetry agent configuration.

- **Bug Fixes**
	- Incremented version numbers for `k8s-infra` and `SigNoz` Helm charts to reflect recent updates.

- **Documentation**
	- Improved comments in configuration files for clarity on environment variable usage and security implications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->