### PR TITLE
Bump signoz-otel-collector version

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.54.1
+version: 0.54.2
 appVersion: "0.56.0"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -195,7 +195,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `otelCollector.name`                     | Otel Collector component name                                           | `otel-collector`                  |
 | `otelCollector.image.registry`           | Otel Collector image registry name                                      | `docker.io`                       |
 | `otelCollector.image.repository`         | Container image name                                                    | `signoz/signoz-otel-collector`    |
-| `otelCollector.image.tag`                | Container image tag                                                     | `0.102.12`                         |
+| `otelCollector.image.tag`                | Container image tag                                                     | `0.111.2`                         |
 | `otelCollector.image.pullPolicy`         | Container pull policy                                                   | `IfNotPresent`                    |
 | `otelCollector.replicaCount`             | Number of otel-collector nodes                                          | `1`                               |
 | `otelCollector.service.type`             | Otel Collector service type                                             | `ClusterIP`                       |
@@ -235,7 +235,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `otelCollectorMetrics.name`              | Otel Collector Metrics component name                                   | `otel-collector-metrics`          |
 | `otelCollectorMetrics.image.registry`    | Otel Collector Metrics image registry name                              | `docker.io`                       |
 | `otelCollectorMetrics.image.repository`  | Container image name                                                    | `signoz/signoz-otel-collector`    |
-| `otelCollectorMetrics.image.tag`         | Container image tag                                                     | `0.102.12`                         |
+| `otelCollectorMetrics.image.tag`         | Container image tag                                                     | `0.111.2`                         |
 | `otelCollectorMetrics.image.pullPolicy`  | Container pull policy                                                   | `IfNotPresent`                    |
 | `otelCollectorMetrics.replicaCount`      | Number of otel-collector-metrics nodes                                  | `1`                               |
 | `otelCollectorMetrics.service.type`         | Otel Collector service type                                          | `ClusterIP`                       |

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1383,7 +1383,7 @@ otelCollector:
   image:
     registry: docker.io
     repository: signoz/signoz-otel-collector
-    tag: 0.102.12
+    tag: 0.111.2
     pullPolicy: IfNotPresent
 
   # -- Image Registry Secret Names for OtelCollector
@@ -2013,7 +2013,7 @@ otelCollectorMetrics:
   image:
     registry: docker.io
     repository: signoz/signoz-otel-collector
-    tag: 0.102.12
+    tag: 0.111.2
     pullPolicy: IfNotPresent
 
   # -- Image Registry Secret Names for OtelCollector


### PR DESCRIPTION
The latest version has a bug fix for deadlock when using kafkareceiver. The base version was incorrectly set as "0.102" but we are already "0.111".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated Helm chart version for SigNoz observability platform to 0.54.2.
	- Upgraded image tags for `otelCollector` and `otelCollectorMetrics` components to version 0.111.2.

- **Documentation**
	- Revised README to reflect updated configuration parameters for the `otelCollector` and `otelCollectorMetrics`.

- **Chores**
	- Minor formatting adjustments made in configuration files for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->