### PR TITLE
Enable additional metrics for kubelet metrics receiver

### DIFF
--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -213,6 +213,12 @@ presets:
       - node
       - volume
     metrics:
+      k8s.node.cpu.usage:
+        enabled: true
+      k8s.node.uptime:
+        enabled: true
+      k8s.pod.cpu.usage:
+        enabled: true
       k8s.pod.cpu_limit_utilization:
         enabled: true
       k8s.pod.cpu_request_utilization:
@@ -220,6 +226,20 @@ presets:
       k8s.pod.memory_limit_utilization:
         enabled: true
       k8s.pod.memory_request_utilization:
+        enabled: true
+      k8s.pod.uptime:
+        enabled: true
+      container.cpu.usage:
+        enabled: true
+      k8s.container.cpu_limit_utilization:
+        enabled: true
+      k8s.container.cpu_request_utilization:
+        enabled: true
+      k8s.container.memory_limit_utilization:
+        enabled: true
+      k8s.container.memory_request_utilization:
+        enabled: true
+      container.uptime:
         enabled: true
   kubernetesAttributes:
     enabled: true


### PR DESCRIPTION
The k8s.{pod/node/container}.cpu.utilization metrics are deprecated in favor of k8s.{pod/node/container}.cpu.usage. However, they are not enabled by default. We start collecting early, so when the `.cpu. utilisation metrics are removed, we will have enough data backfilled. Add uptime and container req/limit metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced monitoring capabilities with the addition of new metrics for CPU usage and uptime across nodes and pods.

- **Bug Fixes**
	- Addressed redundancy in the `clusterName` key to prevent potential configuration conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->