### PR TITLE
Release/signoz 0.56.0

### DIFF
--- a/charts/signoz/Chart.lock
+++ b/charts/signoz/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: clickhouse
   repository: https://charts.signoz.io
-  version: 24.1.7
+  version: 24.1.8
 - name: signoz-otel-gateway
   repository: https://charts.signoz.io
   version: 0.0.1
-digest: sha256:7bc2604088aaf830474129687eab26c873bcb1e3c4ca9d805066ca42bc672dd1
-generated: "2024-09-09T16:35:24.616088+05:30"
+digest: sha256:56288d3b465087baba773de1e0bfa20925623c33ae83c543e4eb691087714a45
+generated: "2024-11-08T16:13:14.329061+05:30"

--- a/charts/signoz/Chart.lock
+++ b/charts/signoz/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: clickhouse
   repository: https://charts.signoz.io
-  version: 24.1.8
+  version: 24.1.9
 - name: signoz-otel-gateway
   repository: https://charts.signoz.io
   version: 0.0.1
-digest: sha256:56288d3b465087baba773de1e0bfa20925623c33ae83c543e4eb691087714a45
-generated: "2024-11-08T16:13:14.329061+05:30"
+digest: sha256:de9b8fcbae8a0370448b18bab59ebd72e4542220177ae946af723ec3f35eb053
+generated: "2024-11-08T20:57:20.310119+05:30"

--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -22,7 +22,7 @@ dependencies:
   - name: clickhouse
     repository: https://charts.signoz.io
     condition: clickhouse.enabled
-    version: 24.1.7
+    version: 24.1.8
   - name: signoz-otel-gateway
     repository: https://charts.signoz.io
     condition: signoz-otel-gateway.enabled

--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -22,7 +22,7 @@ dependencies:
   - name: clickhouse
     repository: https://charts.signoz.io
     condition: clickhouse.enabled
-    version: 24.1.8
+    version: 24.1.9
   - name: signoz-otel-gateway
     repository: https://charts.signoz.io
     condition: signoz-otel-gateway.enabled

--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: signoz
 version: 0.55.1
-appVersion: "0.57.0"
+appVersion: "0.58.0"
 description: SigNoz Observability Platform Helm Chart
 type: application
 home: https://signoz.io/

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -71,7 +71,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `queryService.name`                      | Query Service component name                                            | `query-service`                   |
 | `queryService.image.registry`            | Query Service image registry name                                       | `docker.io`                       |
 | `queryService.image.repository`          | Container image name                                                    | `signoz/query-service`            |
-| `queryService.image.tag`                 | Container image tag                                                     | `0.57.0`                          |
+| `queryService.image.tag`                 | Container image tag                                                     | `0.58.0`                          |
 | `queryService.image.pullPolicy`          | Container pull policy                                                   | `IfNotPresent`                    |
 | `queryService.replicaCount`              | Number of query-service nodes                                           | `1`                               |
 | `queryService.initContainers.init.enabled`      | Query Service initContainer enabled                              | `true`                            |
@@ -110,7 +110,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `frontend.name`                          | Frontend component name                                                 | `frontend`                        |
 | `frontend.image.registry`                | Frontend image registry name                                            | `docker.io`                       |
 | `frontend.image.repository`              | Container image name                                                    | `signoz/frontend`                 |
-| `frontend.image.tag`                     | Container image tag                                                     | `0.57.0`                          |
+| `frontend.image.tag`                     | Container image tag                                                     | `0.58.0`                          |
 | `frontend.image.pullPolicy`              | Container pull policy                                                   | `IfNotPresent`                    |
 | `frontend.replicaCount`                  | Number of query-service nodes                                           | `1`                               |
 | `frontend.initContainers.init.enabled`   | Frontend initContainer enabled                                          | `true`                            |
@@ -195,7 +195,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `otelCollector.name`                     | Otel Collector component name                                           | `otel-collector`                  |
 | `otelCollector.image.registry`           | Otel Collector image registry name                                      | `docker.io`                       |
 | `otelCollector.image.repository`         | Container image name                                                    | `signoz/signoz-otel-collector`    |
-| `otelCollector.image.tag`                | Container image tag                                                     | `0.111.5`                         |
+| `otelCollector.image.tag`                | Container image tag                                                     | `0.111.8`                         |
 | `otelCollector.image.pullPolicy`         | Container pull policy                                                   | `IfNotPresent`                    |
 | `otelCollector.replicaCount`             | Number of otel-collector nodes                                          | `1`                               |
 | `otelCollector.service.type`             | Otel Collector service type                                             | `ClusterIP`                       |
@@ -235,7 +235,7 @@ The following table lists the configurable parameters of the `signoz` chart and 
 | `otelCollectorMetrics.name`              | Otel Collector Metrics component name                                   | `otel-collector-metrics`          |
 | `otelCollectorMetrics.image.registry`    | Otel Collector Metrics image registry name                              | `docker.io`                       |
 | `otelCollectorMetrics.image.repository`  | Container image name                                                    | `signoz/signoz-otel-collector`    |
-| `otelCollectorMetrics.image.tag`         | Container image tag                                                     | `0.111.5`                         |
+| `otelCollectorMetrics.image.tag`         | Container image tag                                                     | `0.111.8`                         |
 | `otelCollectorMetrics.image.pullPolicy`  | Container pull policy                                                   | `IfNotPresent`                    |
 | `otelCollectorMetrics.replicaCount`      | Number of otel-collector-metrics nodes                                  | `1`                               |
 | `otelCollectorMetrics.service.type`         | Otel Collector service type                                          | `ClusterIP`                       |

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -601,7 +601,7 @@ queryService:
   image:
     registry: docker.io
     repository: signoz/query-service
-    tag: 0.57.0
+    tag: 0.58.0
     pullPolicy: IfNotPresent
 
   # -- Image Registry Secret Names for Query-Service
@@ -830,7 +830,7 @@ frontend:
   image:
     registry: docker.io
     repository: signoz/frontend
-    tag: 0.57.0
+    tag: 0.58.0
     pullPolicy: IfNotPresent
 
   # -- Image Registry Secret Names for Frontend
@@ -1264,7 +1264,7 @@ schemaMigrator:
   image:
     registry: docker.io
     repository: signoz/signoz-schema-migrator
-    tag: 0.111.5
+    tag: 0.111.8
     pullPolicy: IfNotPresent
 
   args:
@@ -1422,7 +1422,7 @@ otelCollector:
   image:
     registry: docker.io
     repository: signoz/signoz-otel-collector
-    tag: 0.111.5
+    tag: 0.111.8
     pullPolicy: IfNotPresent
 
   # -- Image Registry Secret Names for OtelCollector
@@ -2050,7 +2050,7 @@ otelCollectorMetrics:
   image:
     registry: docker.io
     repository: signoz/signoz-otel-collector
-    tag: 0.111.5
+    tag: 0.111.8
     pullPolicy: IfNotPresent
 
   # -- Image Registry Secret Names for OtelCollector


### PR DESCRIPTION
### Summary

- release SigNoz v0.58.0
- bump up SigNoz OtelCollector v0.111.8
- bump up charts: clickhouse-24.1.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated application version to 0.58.0, enhancing functionality and performance.
	- Upgraded container images for key services, including `queryService`, `frontend`, `otelCollector`, and `otelCollectorMetrics`, to incorporate new features and improvements.

- **Documentation**
	- Revised README to reflect version updates for various components.

- **Chores**
	- Updated configuration files to align with the new service versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->