### PR TITLE
chore(clickhouse): support custom labels and pod labels

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for ClickHouse
 type: application
-version: 24.1.8
+version: 24.1.9
 appVersion: "24.1.2"
 icon: https://github.com/ClickHouse/clickhouse-docs/raw/84f38d893eb7e561c7296279d7953b6a508ec413/static/img/clickhouse-logo.svg
 sources:

--- a/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
+++ b/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ include "clickhouse.namespace" . }}
   labels:
     {{- include "clickhouse.labels" . | nindent 4 }}
+    {{- if .Values.labels }}
+    {{- toYaml .Values.labels | nindent 4 }}
+    {{- end }}
   {{- if .Values.annotations }}
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}
@@ -131,6 +134,9 @@ spec:
         metadata:
           labels:
             {{- include "clickhouse.labels" . | nindent 12 }}
+            {{- if .Values.podLabels }}
+            {{- toYaml .Values.podLabels | nindent 12 }}
+            {{- end }}
           {{- with .Values.podAnnotations }}
           annotations:
             {{- toYaml . | nindent 12 }}

--- a/charts/clickhouse/templates/clickhouse-operator/deployment.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ include "clickhouse.namespace" . }}
   labels:
     {{- include "clickhouseOperator.labels" . | nindent 4 }}
+    {{- if .Values.clickhouseOperator.labels }}
+    {{- toYaml .Values.clickhouseOperator.labels | nindent 4 }}
+    {{- end }}
   {{- if .Values.clickhouseOperator.annotations }}
   annotations:
     {{- toYaml .Values.clickhouseOperator.annotations | nindent 4 }}
@@ -27,6 +30,9 @@ spec:
         checksum/usersd-files: {{ include (print $.Template.BasePath "/clickhouse-operator/configmaps/etc-usersd-files.yaml") . | sha256sum }}
       labels:
         {{- include "clickhouseOperator.selectorLabels" . | nindent 8 }}
+        {{- if .Values.clickhouseOperator.podLabels }}
+        {{- toYaml .Values.clickhouseOperator.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "clickhouseOperator.imagePullSecrets" . | indent 6 }}
       serviceAccountName: {{ include "clickhouseOperator.serviceAccountName" . }}

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -178,7 +178,10 @@ image:
 # If global.imagePullSecrets is set as well, it will merged.
 imagePullSecrets: []
   # - "clickhouse-pull-secret"
-
+# ClickHouse instance labels
+labels: {}
+# ClickHouse pod labels
+podLabels: {}
 # -- ClickHouse instance annotations.
 annotations: {}
 
@@ -487,9 +490,12 @@ clickhouseOperator:
     # If not set and create is true, a name is generated using the fullname template
     name:
 
+  # ClickHouse operator deployment labels
+  labels: {}
+  # ClickHouse operator pod labels
+  podLabels: {}
   # -- Clickhouse Operator deployment annotations
   annotations: {}
-
   # -- Clickhouse Operator pod(s) annotation.
   podAnnotations: {}
     # signoz.io/port: '8888'


### PR DESCRIPTION
#### Chores

- clickhouse: support custom labels and pod labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced configurability for ClickHouse installations with new options for custom labels and annotations.
	- Added conditional configurations for Zookeeper nodes and additional volumes.
	- Introduced new fields for labels and pod labels in the ClickHouse and operator configurations.
- **Bug Fixes**
	- Improved handling of external and internal Zookeeper configurations based on user-defined values.
- **Chores**
	- Updated the ClickHouse Helm chart version from 24.1.8 to 24.1.9.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->