### PR TITLE
feat(clickhouse): include probes and sidecar containers for ClickHouse

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,6 @@ jobs:
       - name: Add dependencies
         run: |
           helm repo add signoz https://charts.signoz.io
-          helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0

--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for ClickHouse
 type: application
-version: 24.1.10
+version: 24.1.11
 appVersion: "24.1.2"
 icon: https://github.com/ClickHouse/clickhouse-docs/raw/84f38d893eb7e561c7296279d7953b6a508ec413/static/img/clickhouse-logo.svg
 sources:

--- a/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
+++ b/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
@@ -287,10 +287,13 @@ spec:
               {{- if .Values.additionalVolumeMounts }}
                 {{- toYaml .Values.additionalVolumeMounts | nindent 16 }}
               {{- end }}
-
               {{- if .Values.resources }}
               resources: {{ toYaml .Values.resources | nindent 16 }}
               {{- end }}
+
+            {{- if .Values.extraContainers }}
+              {{- toYaml .Values.extraContainers | nindent 14 }}
+            {{- end }}
 
     serviceTemplates:
       - name: service-template

--- a/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
+++ b/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
@@ -223,6 +223,49 @@ spec:
                   containerPort: 9000
                 - name: interserver
                   containerPort: 9009
+              
+              {{- if .Values.startupProbe.enabled }}
+              startupProbe:
+                httpGet:
+                  port: {{ .Values.startupProbe.port }}
+                  path: {{ .Values.startupProbe.path }}
+                initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+                periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+                timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+                successThreshold: {{ .Values.startupProbe.successThreshold }}
+                failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+              {{- else if .Values.customStartupProbe }}
+              startupProbe:
+                {{- toYaml .Values.customStartupProbe | nindent 16 }}
+              {{- end }}
+              {{- if .Values.livenessProbe.enabled }}
+              livenessProbe:
+                httpGet:
+                  port: {{ .Values.livenessProbe.port }}
+                  path: {{ .Values.livenessProbe.path }}
+                initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+                periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+                timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+                successThreshold: {{ .Values.livenessProbe.successThreshold }}
+                failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+              {{- else if .Values.customLivenessProbe }}
+              livenessProbe:
+                {{- toYaml .Values.customLivenessProbe | nindent 16 }}
+              {{- end }}
+              {{- if .Values.readinessProbe.enabled }}
+              readinessProbe:
+                httpGet:
+                  port: {{ .Values.readinessProbe.port }}
+                  path: {{ .Values.readinessProbe.path }}
+                initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+                periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+                timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+                successThreshold: {{ .Values.readinessProbe.successThreshold }}
+                failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+              {{- else if .Values.customReadinessProbe }}
+              readinessProbe:
+                {{- toYaml .Values.customReadinessProbe | nindent 16 }}
+              {{- end }}
 
               volumeMounts:
               {{- if not .Values.persistence.enabled }}

--- a/charts/clickhouse/templates/clickhouse-operator/deployment.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/deployment.yaml
@@ -90,6 +90,48 @@ spec:
             {{- with .Values.clickhouseOperator.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              port: {{ .Values.startupProbe.port }}
+              path: {{ .Values.startupProbe.path }}
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- else if .Values.customStartupProbe }}
+          startupProbe:
+            {{- toYaml .Values.customStartupProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.livenessProbe.port }}
+              path: {{ .Values.livenessProbe.path }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- else if .Values.customLivenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.customLivenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.readinessProbe.port }}
+              path: {{ .Values.readinessProbe.path }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- else if .Values.customReadinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.customReadinessProbe | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.clickhouseOperator.resources | nindent 12 }}
 

--- a/charts/clickhouse/templates/clickhouse-operator/deployment.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/deployment.yaml
@@ -90,48 +90,6 @@ spec:
             {{- with .Values.clickhouseOperator.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- if .Values.startupProbe.enabled }}
-          startupProbe:
-            httpGet:
-              port: {{ .Values.startupProbe.port }}
-              path: {{ .Values.startupProbe.path }}
-            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.startupProbe.successThreshold }}
-            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
-          {{- else if .Values.customStartupProbe }}
-          startupProbe:
-            {{- toYaml .Values.customStartupProbe | nindent 12 }}
-          {{- end }}
-          {{- if .Values.livenessProbe.enabled }}
-          livenessProbe:
-            httpGet:
-              port: {{ .Values.livenessProbe.port }}
-              path: {{ .Values.livenessProbe.path }}
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-          {{- else if .Values.customLivenessProbe }}
-          livenessProbe:
-            {{- toYaml .Values.customLivenessProbe | nindent 12 }}
-          {{- end }}
-          {{- if .Values.readinessProbe.enabled }}
-          readinessProbe:
-            httpGet:
-              port: {{ .Values.readinessProbe.port }}
-              path: {{ .Values.readinessProbe.path }}
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
-          {{- else if .Values.customReadinessProbe }}
-          readinessProbe:
-            {{- toYaml .Values.customReadinessProbe | nindent 12 }}
-          {{- end }}
           resources:
             {{- toYaml .Values.clickhouseOperator.resources | nindent 12 }}
 

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -232,30 +232,30 @@ topologySpreadConstraints: []
 ##
 startupProbe:
   enabled: true
-  port: 13133
-  path: /
-  initialDelaySeconds: 5
-  periodSeconds: 10
-  timeoutSeconds: 5
-  failureThreshold: 6
+  port: http
+  path: /ping
+  initialDelaySeconds: 10
+  periodSeconds: 3
+  timeoutSeconds: 1
+  failureThreshold: 3
   successThreshold: 1
 livenessProbe:
   enabled: true
-  port: 13133
-  path: /
-  initialDelaySeconds: 5
-  periodSeconds: 10
-  timeoutSeconds: 5
-  failureThreshold: 6
+  port: http
+  path: /ping
+  initialDelaySeconds: 10
+  periodSeconds: 3
+  timeoutSeconds: 1
+  failureThreshold: 3
   successThreshold: 1
 readinessProbe:
   enabled: true
-  port: 13133
-  path: /
-  initialDelaySeconds: 5
-  periodSeconds: 10
-  timeoutSeconds: 5
-  failureThreshold: 6
+  port: http
+  path: /ping
+  initialDelaySeconds: 10
+  periodSeconds: 3
+  timeoutSeconds: 1
+  failureThreshold: 3
   successThreshold: 1
 
 ## Custom startup, liveness and readiness probes

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -243,10 +243,10 @@ livenessProbe:
   enabled: true
   port: http
   path: /ping
-  initialDelaySeconds: 10
+  initialDelaySeconds: 60
   periodSeconds: 3
   timeoutSeconds: 1
-  failureThreshold: 3
+  failureThreshold: 10
   successThreshold: 1
 readinessProbe:
   enabled: true

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -227,6 +227,42 @@ affinity: {}
 # -- TopologySpreadConstraints describes how clickhouse pods ought to spread
 topologySpreadConstraints: []
 
+## Configure liveness and readiness probes.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+##
+startupProbe:
+  enabled: true
+  port: 13133
+  path: /
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+livenessProbe:
+  enabled: true
+  port: 13133
+  path: /
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+readinessProbe:
+  enabled: true
+  port: 13133
+  path: /
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+## Custom startup, liveness and readiness probes
+customStartupProbe: {}
+customLivenessProbe: {}
+customReadinessProbe: {}
+
 # -- Configure resource requests and limits. Update according to your own use
 # case as these values might not be suitable for your workload.
 # Ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -527,6 +563,42 @@ clickhouseOperator:
   affinity: {}
   # -- TopologySpreadConstraints describes how Clickhouse Operator pods ought to spread
   topologySpreadConstraints: []
+
+  ## Configure liveness and readiness probes.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  ##
+  startupProbe:
+    enabled: true
+    port: metrics
+    path: /chi
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  livenessProbe:
+    enabled: true
+    port: metrics
+    path: /chi
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  readinessProbe:
+    enabled: true
+    port: metrics
+    path: /chi
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
+  ## Custom startup, liveness and readiness probes
+  customStartupProbe: {}
+  customLivenessProbe: {}
+  customReadinessProbe: {}
 
   # -- Additional environment variables for Clickhouse Operator container.
   env: []

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -234,10 +234,10 @@ startupProbe:
   enabled: true
   port: http
   path: /ping
-  initialDelaySeconds: 10
-  periodSeconds: 3
-  timeoutSeconds: 1
-  failureThreshold: 3
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 30
   successThreshold: 1
 livenessProbe:
   enabled: true

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -476,8 +476,13 @@ files: {}
   #     <some-setting>some-value</some-setting>
   #   </clickhouse>
 
+# -- Custom volume claim templates for ClickHouse pod
+# This is only used when persistence.enabled is false
 templates:
   volumeClaimTemplates: []
+
+# -- Extra containers for ClickHouse pod
+extraContainers: []
 
 ###
 ###

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -569,42 +569,6 @@ clickhouseOperator:
   # -- TopologySpreadConstraints describes how Clickhouse Operator pods ought to spread
   topologySpreadConstraints: []
 
-  ## Configure liveness and readiness probes.
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-  ##
-  startupProbe:
-    enabled: true
-    port: metrics
-    path: /chi
-    initialDelaySeconds: 5
-    periodSeconds: 10
-    timeoutSeconds: 5
-    failureThreshold: 6
-    successThreshold: 1
-  livenessProbe:
-    enabled: true
-    port: metrics
-    path: /chi
-    initialDelaySeconds: 5
-    periodSeconds: 10
-    timeoutSeconds: 5
-    failureThreshold: 6
-    successThreshold: 1
-  readinessProbe:
-    enabled: true
-    port: metrics
-    path: /chi
-    initialDelaySeconds: 5
-    periodSeconds: 10
-    timeoutSeconds: 5
-    failureThreshold: 6
-    successThreshold: 1
-
-  ## Custom startup, liveness and readiness probes
-  customStartupProbe: {}
-  customLivenessProbe: {}
-  customReadinessProbe: {}
-
   # -- Additional environment variables for Clickhouse Operator container.
   env: []
     #  - name: SAMPLE_ENV

--- a/ct.yaml
+++ b/ct.yaml
@@ -10,4 +10,3 @@ check-version-increment: false
 helm-extra-args: --timeout 5m
 chart-repos:
   - signoz=https://charts.signoz.io
-  - bitnami=https://charts.bitnami.com/bitnami


### PR DESCRIPTION
#### Features

- include probes for ClickHouse operator and CHI pods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added health check capabilities with `startupProbe`, `livenessProbe`, and `readinessProbe` configurations for improved monitoring of the ClickHouse installation.
	- Introduced placeholders for custom probe configurations.

- **Bug Fixes**
	- Removed the Bitnami Helm repository from the release workflow and configuration files.

- **Chores**
	- Updated the ClickHouse Helm chart version from `24.1.10` to `24.1.11`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->