### PR TITLE
fix(clickhouse): use main branch for CH histogram

### DIFF
--- a/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
+++ b/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
@@ -208,7 +208,7 @@ spec:
           containers:
             - name: clickhouse
               # KEEP CLICKHOUSE-SERVER VERSION IN SYNC WITH
-              # https://github.com/SigNoz/signoz/blob/develop/deploy/docker/clickhouse-setup/docker-compose.yaml#L5
+              # https://github.com/SigNoz/signoz/blob/main/deploy/docker/clickhouse-setup/docker-compose.yaml#L5
               image: {{ template "clickhouse.image" . }}
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               command:

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -356,7 +356,7 @@ initContainers:
       - -c
       - |
         set -x
-        wget -O /tmp/histogramQuantile https://github.com/SigNoz/signoz/raw/develop/deploy/docker/clickhouse-setup/user_scripts/histogramQuantile
+        wget -O /tmp/histogramQuantile https://github.com/SigNoz/signoz/raw/main/deploy/docker/clickhouse-setup/user_scripts/histogramQuantile
         mv /tmp/histogramQuantile  /var/lib/clickhouse/user_scripts/histogramQuantile
         chmod +x /var/lib/clickhouse/user_scripts/histogramQuantile
   init:

--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.62.0
+version: 0.62.1
 appVersion: "0.64.0"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -281,7 +281,7 @@ clickhouse:
         - -c
         - |
           set -x
-          wget -O /tmp/histogramQuantile https://github.com/SigNoz/signoz/raw/develop/deploy/docker/clickhouse-setup/user_scripts/histogramQuantile
+          wget -O /tmp/histogramQuantile https://github.com/SigNoz/signoz/raw/main/deploy/docker/clickhouse-setup/user_scripts/histogramQuantile
           mv /tmp/histogramQuantile  /var/lib/clickhouse/user_scripts/histogramQuantile
           chmod +x /var/lib/clickhouse/user_scripts/histogramQuantile
     init:


### PR DESCRIPTION
#### Fixes

- use main branch for ClickHouse histogram

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configurability for ClickHouse installation with improved storage options and service metadata handling.
	- Added support for custom volume claims when persistence is not enabled.

- **Bug Fixes**
	- Updated URLs for downloading the `histogramQuantile` script to ensure the latest version is used.

- **Documentation**
	- Incremented version of the SigNoz observability platform Helm chart from 0.62.0 to 0.62.1 for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->