### PR TITLE
feat(operator): increase statefulset.update.timeout and change onFailure policy

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for ClickHouse
 type: application
-version: 24.1.12
+version: 24.1.13
 appVersion: "24.1.2"
 icon: https://github.com/ClickHouse/clickhouse-docs/raw/84f38d893eb7e561c7296279d7953b6a508ec413/static/img/clickhouse-logo.svg
 sources:

--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-files.yaml
@@ -189,7 +189,7 @@ data:
 
           update:
             # How many seconds to wait for created/updated StatefulSet to be 'Ready'
-            timeout: 300
+            timeout: 900
             # How many seconds to wait between checks/polls for created/updated StatefulSet status
             pollInterval: 5
             # What to do in case updated StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds

--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-files.yaml
@@ -198,7 +198,7 @@ data:
             # 2. rollback - delete Pod and rollback StatefulSet to previous Generation.
             # Pod would be recreated by StatefulSet based on rollback-ed configuration
             # 3. ignore - ignore an error, pretend nothing happened and move on to the next StatefulSet
-            onFailure: rollback
+            onFailure: abort
 
         host:
           # Whether reconciler should wait for a host:


### PR DESCRIPTION
## Description
Increased the statefulset.update.timeout to 900s. Anything more than 15mins is a serious issue which needs to have admin intervention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Increased timeout for StatefulSet readiness from 300 seconds to 900 seconds.
	- Changed failure action from rollback to abort, requiring manual intervention if the StatefulSet does not reach a 'Ready' state.
- **Chores**
	- Updated Helm chart version from 24.1.12 to 24.1.13.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->