### PR TITLE
chore(signoz): bump SigNoz to v0.65.1, OTel Collector to v0.111.18

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: signoz
-version: 0.63.0
-appVersion: "0.65.0"
+version: 0.63.1
+appVersion: "0.65.1"
 description: SigNoz Observability Platform Helm Chart
 type: application
 home: https://signoz.io/

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -554,7 +554,7 @@ queryService:
   image:
     registry: docker.io
     repository: signoz/query-service
-    tag: 0.65.0
+    tag: 0.65.1
     pullPolicy: IfNotPresent
   # -- Image Registry Secret Names for Query-Service
   # If set, this has higher precedence than the root level or global value of imagePullSecrets.
@@ -780,7 +780,7 @@ frontend:
   image:
     registry: docker.io
     repository: signoz/frontend
-    tag: 0.65.0
+    tag: 0.65.1
     pullPolicy: IfNotPresent
   # -- Image Registry Secret Names for Frontend
   # If set, this has higher precedence than the root level or global value of imagePullSecrets.
@@ -1186,7 +1186,7 @@ schemaMigrator:
   image:
     registry: docker.io
     repository: signoz/signoz-schema-migrator
-    tag: 0.111.16
+    tag: 0.111.18
     pullPolicy: IfNotPresent
   args:
     - "--up="
@@ -1336,7 +1336,7 @@ otelCollector:
   image:
     registry: docker.io
     repository: signoz/signoz-otel-collector
-    tag: 0.111.16
+    tag: 0.111.18
     pullPolicy: IfNotPresent
   # -- Image Registry Secret Names for OtelCollector
   # If set, this has higher precedence than the root level or global value of imagePullSecrets.
@@ -1796,7 +1796,7 @@ otelCollectorMetrics:
   image:
     registry: docker.io
     repository: signoz/signoz-otel-collector
-    tag: 0.111.16
+    tag: 0.111.18
     pullPolicy: IfNotPresent
   # -- Image Registry Secret Names for OtelCollector
   # If set, this has higher precedence than the root level or global value of imagePullSecrets.


### PR DESCRIPTION
#### Summary
 - Release SigNoz v0.65.1
 - Bump SigNoz OTel Collector to v0.111.18
 - Bump SigNoz Helm chart version to v0.63.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated application and chart versions to enhance performance and stability.
	- Improved components with updated image tags for Query Service, Frontend, Schema Migrator, and Otel Collector.

- **Bug Fixes**
	- Minor bug fixes and improvements included in the updated versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->