### PR TITLE
chore(otel-collector): remove redundant env variables

### DIFF
--- a/charts/signoz/templates/otel-collector/deployment.yaml
+++ b/charts/signoz/templates/otel-collector/deployment.yaml
@@ -117,12 +117,6 @@ spec:
           env:
             {{- include "snippet.clickhouse-env" . | nindent 12 }}
             {{- include "snippet.k8s-env" . | nindent 12 }}
-            - name: K8S_CLUSTER_NAME
-              value: {{ default .Values.global.clusterName .Values.clusterName }}
-            - name: SIGNOZ_COMPONENT
-              value: {{ default "otel-collector" .Values.otelCollector.name}}
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: signoz.component=$(SIGNOZ_COMPONENT),k8s.cluster.name=$(K8S_CLUSTER_NAME),k8s.pod.uid=$(K8S_POD_UID),k8s.pod.ip=$(K8S_POD_IP)
             - name: LOW_CARDINAL_EXCEPTION_GROUPING
               value: {{ default "false" .Values.otelCollector.lowCardinalityExceptionGrouping | quote }}
             {{- range $key, $val := .Values.otelCollector.additionalEnvs }}


### PR DESCRIPTION
#### Chores

Removing `SIGNOZ_COMPONENT`, `K8S_CLUSTER_NAME` and `OTEL_RESOURCE_ATTRIBUTES` from the otel-collector.