### PR TITLE
Extend k8s attributes to be able to configure processing custom labels and annotations

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.11.18
+version: 0.11.19
 appVersion: "0.109.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -346,6 +346,10 @@ processors:
     extract:
       metadata:
         {{ toYaml .Values.presets.kubernetesAttributes.extractMetadatas | nindent 8 }}
+      annotations:
+        {{ toYaml .Values.presets.kubernetesAttributes.extractAnnotations | nindent 8 }}
+      labels:
+        {{ toYaml .Values.presets.kubernetesAttributes.extractLabels | nindent 8 }}
 {{- end }}
 
 {{- define "opentelemetry-collector.applyResourceDetectionConfig" -}}

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -275,6 +275,10 @@ presets:
       - k8s.pod.name
       - k8s.pod.uid
       - k8s.pod.start_time
+    # -- Which labels to extract from a list of metadata fields.
+    extractLabels: []
+    # -- Which annotations to extract from a list of metadata fields.
+    extractAnnotations: []
   clusterMetrics:
     enabled: true
     collectionInterval: 30s


### PR DESCRIPTION
Add the ablility to configure extracting custom labels and annotations via `k8sattributes` processor.

The values can be added the same way as existing settings for metadatas. Samples can be found in the processor [documentation here](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md#extracting-attributes-from-pod-labels-and-annotations)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced OpenTelemetry Collector configuration to support extraction of Kubernetes resource annotations and labels.
	- Added configuration options to specify which labels and annotations to extract from Kubernetes resources.

- **Improvements**
	- Expanded metadata collection capabilities for better monitoring and observability in Kubernetes environments.
	- Updated Helm chart version for `k8s-infra` to improve overall package management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->