### PR TITLE
Allow to mount extra volumes for agent & deployment

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.11.19
+version: 0.11.20
 appVersion: "0.109.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -69,6 +69,9 @@ spec:
              - key: key.pem
                path: key.pem
         {{- end }}
+        {{- with .Values.otelAgent.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ include "otelAgent.fullname" . }}
           image: {{ include "otelAgent.image" . }}
@@ -132,6 +135,9 @@ spec:
             {{- if .Values.otelTlsSecrets.enabled }}
             - name: {{ include "k8s-infra.fullname" . }}-agent-secrets-vol
               mountPath: {{ default "/secrets" .Values.otelTlsSecrets.path }}
+            {{- end }}
+            {{- with .Values.otelAgent.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- if .Values.otelAgent.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/k8s-infra/templates/otel-deployment/deployment.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/deployment.yaml
@@ -62,6 +62,9 @@ spec:
               - key: key.pem
                 path: key.pem
         {{- end }}
+        {{- with .Values.otelDeployment.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ template "otelDeployment.fullname" . }}
           image: {{ template "otelDeployment.image" . }}
@@ -104,6 +107,9 @@ spec:
             {{- if .Values.otelTlsSecrets.enabled }}
             - name: {{ include "k8s-infra.fullname" . }}-deployment-secrets-vol
               mountPath: {{ default "/secrets" .Values.otelTlsSecrets.path }}
+            {{- end }}
+            {{- with .Values.otelDeployment.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- if .Values.otelDeployment.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -667,6 +667,23 @@ otelAgent:
           processors: [batch]
           exporters: []
 
+  # -- Additional volumes for otelAgent
+  extraVolumes: []
+  # - name: config-volume
+  #   configMap:
+  #     name: special-config
+  # - name: secret-volume
+  #   secret:
+  #     secretName: special-secret
+
+  # -- Additional volume mounts for otelAgent
+  extraVolumeMounts: []
+  # - name: config-volume
+  #   mountPath: /etc/config
+  # - name: secret-volume
+  #   mountPath: /etc/secret
+  #   readOnly: true
+
 # Default values for OtelDeployment
 otelDeployment:
   enabled: true
@@ -957,3 +974,20 @@ otelDeployment:
           receivers: []
           processors: [batch]
           exporters: []
+
+  # -- Additional volumes for otelDeployment
+  extraVolumes: []
+  # - name: config-volume
+  #   configMap:
+  #     name: special-config
+  # - name: secret-volume
+  #   secret:
+  #     secretName: special-secret
+
+  # -- Additional volume mounts for otelDeployment
+  extraVolumeMounts: []
+  # - name: config-volume
+  #   mountPath: /etc/config
+  # - name: secret-volume
+  #   mountPath: /etc/secret
+  #   readOnly: true


### PR DESCRIPTION
Fixes #587

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for custom volume configurations in OpenTelemetry agent and deployment
	- Introduced new configuration options for extra volumes and volume mounts

- **Chores**
	- Bumped Helm chart version from `0.11.19` to `0.11.20`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->