### PR TITLE
Fix query service env vars handling for additionalEnvs (closes #578)

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.64.1
+version: 0.64.2
 appVersion: "0.66.0"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/templates/_helpers.tpl
+++ b/charts/signoz/templates/_helpers.tpl
@@ -740,3 +740,30 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Function to render environment variables 
+*/}}
+{{- define "common.renderAdditionalEnv" -}}
+{{- $dict := . -}}
+{{- $processedKeys := dict -}}
+{{- range keys . | sortAlpha }}
+{{- $val := pluck . $dict | first -}}
+{{- $key := upper . -}}
+{{- if not (hasKey $processedKeys $key) }}
+{{- $processedKeys = merge $processedKeys (dict $key true) -}}
+{{- $valueType := printf "%T" $val -}}
+{{- if eq $valueType "map[string]interface {}" }}
+- name: {{ $key }}
+{{ toYaml $val | indent 2 -}}
+{{- else if eq $valueType "string" }}
+- name: {{ $key }}
+  value: {{ $val | quote }}
+{{- else }}
+- name: {{ $key }}
+  value: {{ $val | quote }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+

--- a/charts/signoz/templates/_helpers.tpl
+++ b/charts/signoz/templates/_helpers.tpl
@@ -744,7 +744,7 @@ imagePullSecrets:
 {{/*
 Function to render environment variables 
 */}}
-{{- define "common.renderAdditionalEnv" -}}
+{{- define "signoz.renderAdditionalEnv" -}}
 {{- $dict := . -}}
 {{- $processedKeys := dict -}}
 {{- range keys . | sortAlpha }}

--- a/charts/signoz/templates/query-service/statefulset.yaml
+++ b/charts/signoz/templates/query-service/statefulset.yaml
@@ -138,19 +138,7 @@ spec:
               value: {{ quote .Values.queryService.configVars.telemetryEnabled }}
             - name: DEPLOYMENT_TYPE
               value: {{ .Values.queryService.configVars.deploymentType }}
-            {{- range $key, $val := .Values.queryService.additionalEnvs }}
-            - name: {{ $key }}
-              {{- if kindIs "map" $val }}
-              {{- if $val.value}}
-              value: {{ $val.value | quote }}
-              {{- end}}
-              {{- if $val.valueFrom }}
-              valueFrom: {{ toYaml $val.valueFrom | nindent 16 }}
-              {{- end}}
-              {{- else }}
-              value: {{ $val | quote }}
-              {{- end}}
-            {{- end }}
+            {{- include "common.renderAdditionalEnv" .Values.queryService.additionalEnvs | nindent 12 }}
             {{- if .Values.queryService.smtpVars.enabled }}
             - name: SMTP_ENABLED
               value: "true"

--- a/charts/signoz/templates/query-service/statefulset.yaml
+++ b/charts/signoz/templates/query-service/statefulset.yaml
@@ -138,7 +138,7 @@ spec:
               value: {{ quote .Values.queryService.configVars.telemetryEnabled }}
             - name: DEPLOYMENT_TYPE
               value: {{ .Values.queryService.configVars.deploymentType }}
-            {{- include "common.renderAdditionalEnv" .Values.queryService.additionalEnvs | nindent 12 }}
+            {{- include "signoz.renderAdditionalEnv" .Values.queryService.additionalEnvs | nindent 12 }}
             {{- if .Values.queryService.smtpVars.enabled }}
             - name: SMTP_ENABLED
               value: "true"

--- a/charts/signoz/templates/query-service/statefulset.yaml
+++ b/charts/signoz/templates/query-service/statefulset.yaml
@@ -140,7 +140,16 @@ spec:
               value: {{ .Values.queryService.configVars.deploymentType }}
             {{- range $key, $val := .Values.queryService.additionalEnvs }}
             - name: {{ $key }}
-              value: {{ $val | toYaml }}
+              {{- if kindIs "map" $val }}
+              {{- if $val.value}}
+              value: {{ $val.value | quote }}
+              {{- end}}
+              {{- if $val.valueFrom }}
+              valueFrom: {{ toYaml $val.valueFrom | nindent 16 }}
+              {{- end}}
+              {{- else }}
+              value: {{ $val | quote }}
+              {{- end}}
             {{- end }}
             {{- if .Values.queryService.smtpVars.enabled }}
             - name: SMTP_ENABLED

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -596,7 +596,22 @@ queryService:
     - --use-trace-new-schema=true
   # -- Additional environments to set for queryService
   additionalEnvs: {}
-  # env_key: env_value
+# Environment variables for the Query Service.
+# You can specify variables in two ways:
+# 1. Flexible structure for advanced configurations (recommended):
+#    Example:
+#      additionalEnvs:
+#        MY_KEY:
+#          value: my-value  # Direct value
+#        SECRET_KEY:
+#          valueFrom:       # Reference from a Secret or ConfigMap
+#            secretKeyRef:
+#              name: my-secret
+#              key: my-key
+# 2. Simple key-value pairs (backward-compatible):
+#    Example:
+#      additionalEnvs:
+#        MY_KEY: my-value
 
   initContainers:
     init:


### PR DESCRIPTION
This PR addresses the issue where the handling of additional environment variables (additionalEnvs) in the query service was not flexible enough. The changes allow for both backward-compatible key-value pairs and more advanced configurations, including value references from secrets and config maps.

Changes made:
- Updated statefulset.yaml to handle different structures for additionalEnvs.
- Modified values.yaml to include examples for both types of configurations.

Closes #578.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated documentation for Query Service environment variables.
	- Improved configuration guidance for environment variable settings.
	- Added support for more flexible environment variable configurations.

- **Improvements**
	- Enhanced SMTP configuration validation to prevent conflicts.
	- Introduced a new function for dynamic rendering of environment variables, improving configuration handling.

- **Version Update**
	- Updated Helm Chart version from 0.64.1 to 0.64.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->