### PR TITLE
feat: add loadBalancerSourceRanges support in otel-collector service

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.64.0
+version: 0.64.1
 appVersion: "0.66.0"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/templates/otel-collector/service.yaml
+++ b/charts/signoz/templates/otel-collector/service.yaml
@@ -14,6 +14,12 @@ metadata:
 {{- end }}
 spec:
   type: {{ .service.type }}
+  {{- if .service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- range .service.loadBalancerSourceRanges }}
+    - {{ . }}
+    {{- end }}
+  {{- end }}
   ports:
     {{- include "otelCollector.portsConfig" . | indent 4 -}}
 {{- end }}

--- a/charts/signoz/templates/otel-collector/service.yaml
+++ b/charts/signoz/templates/otel-collector/service.yaml
@@ -14,7 +14,7 @@ metadata:
 {{- end }}
 spec:
   type: {{ .service.type }}
-  {{- if .service.loadBalancerSourceRanges }}
+  {{- if and (eq .service.type "LoadBalancer") .service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- range .service.loadBalancerSourceRanges }}
     - {{ . }}

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1388,6 +1388,12 @@ otelCollector:
     labels: {}
     # -- Service Type: LoadBalancer (allows external access) or NodePort (more secure, no extra cost)
     type: ClusterIP
+
+    # -- LoadBalancer Source Ranges when service type is LoadBalancer
+    # loadBalancerSourceRanges:
+    #   - "10.0.0.0/8"
+    #   - "172.16.0.0/12"
+
   # -- OtelCollector Deployment annotation.
   annotations:
   # -- OtelCollector pod(s) annotation.

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1390,10 +1390,7 @@ otelCollector:
     type: ClusterIP
 
     # -- LoadBalancer Source Ranges when service type is LoadBalancer
-    # loadBalancerSourceRanges:
-    #   - "10.0.0.0/8"
-    #   - "172.16.0.0/12"
-
+    loadBalancerSourceRanges: []
   # -- OtelCollector Deployment annotation.
   annotations:
   # -- OtelCollector pod(s) annotation.


### PR DESCRIPTION
This PR adds option for specifying `loadBalancerSourceRanges` in the `otel-collector` service configuration.
Fixes #530 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for configuring LoadBalancer source IP ranges for the OtelCollector service.
	- Provides enhanced network security controls for LoadBalancer access.
- **Updates**
	- Updated the version of the SigNoz Helm Chart from 0.64.0 to 0.64.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->