### PR TITLE
ci(prereleaser): use GH event action type for conditional job execution

### DIFF
--- a/.github/workflows/prereleaser.yaml
+++ b/.github/workflows/prereleaser.yaml
@@ -26,7 +26,7 @@ jobs:
       GITHUB_TEAM_NAME: releaser
       GITHUB_MEMBER_NAME: ${{ github.actor }}
   charts:
-    if: ${{ always() && (needs.verify.result == 'success' || github.event.name == 'repository_dispatch') }}
+    if: ${{ always() && (needs.verify.result == 'success' || github.event.action == 'prereleaser') }}
     uses: signoz/primus.workflows/.github/workflows/releaser.yaml@main
     secrets: inherit
     needs: [verify]

--- a/.github/workflows/prereleaser.yaml
+++ b/.github/workflows/prereleaser.yaml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   verify:
+    if: ${{ github.event.action != 'prereleaser' }}
     uses: signoz/primus.workflows/.github/workflows/github-verify.yaml@main
     secrets: inherit
     with:
@@ -26,7 +27,7 @@ jobs:
       GITHUB_TEAM_NAME: releaser
       GITHUB_MEMBER_NAME: ${{ github.actor }}
   charts:
-    if: ${{ always() && (needs.verify.result == 'success' || github.event.action == 'prereleaser') }}
+    if: ${{ always() && (needs.verify.result != 'skipped' || github.event.action == 'prereleaser') }}
     uses: signoz/primus.workflows/.github/workflows/releaser.yaml@main
     secrets: inherit
     needs: [verify]


### PR DESCRIPTION
#### CI

- use event action type for fixing job execution condition for prereleaser GitHub workflow
- use `skipped` flag to get accurate GitHub job run status - this will avoid false negative job run status 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration for more precise job triggering conditions
	- Refined chart job execution criteria in the pre-release workflow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->