### PR TITLE
fix(schema-migrator): add --cluster-name argument from CLICKHOUSE_CLUSTER

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.65.1
+version: 0.65.2
 appVersion: "0.67.1"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/templates/query-service/statefulset.yaml
+++ b/charts/signoz/templates/query-service/statefulset.yaml
@@ -100,6 +100,8 @@ spec:
           image: {{ template "queryService.image" . }}
           imagePullPolicy: {{ .Values.queryService.image.pullPolicy }}
           args:
+            - --cluster
+            - "$(CLICKHOUSE_CLUSTER)"
             - --config=/root/config/prometheus.yml
             {{- if .Values.queryService.cache.enabled }}
             - --experimental.cache-config

--- a/charts/signoz/templates/schema-migrator/migrations-async.yaml
+++ b/charts/signoz/templates/schema-migrator/migrations-async.yaml
@@ -84,6 +84,8 @@ spec:
             {{- include "snippet.clickhouse-credentials" . | nindent 12 }}
           args:
             - async
+            - "--cluster-name"
+            - "$(CLICKHOUSE_CLUSTER)"
             - "--dsn"
             - "tcp://$(CLICKHOUSE_USER):$(CLICKHOUSE_PASSWORD)@{{ include "schemamigrator.url" . }}"
             {{- if .Values.schemaMigrator.enableReplication }}

--- a/charts/signoz/templates/schema-migrator/migrations-sync.yaml
+++ b/charts/signoz/templates/schema-migrator/migrations-sync.yaml
@@ -71,6 +71,8 @@ spec:
             {{- include "snippet.clickhouse-credentials" . | nindent 12 }}
           args:
             - sync
+            - "--cluster-name"
+            - "$(CLICKHOUSE_CLUSTER)"
             - "--dsn"
             - "tcp://$(CLICKHOUSE_USER):$(CLICKHOUSE_PASSWORD)@{{ include "schemamigrator.url" . }}"
             {{- if .Values.schemaMigrator.enableReplication }}


### PR DESCRIPTION
Fixes #573

I think `schema-migrator` should automatically set `--cluster-name` argument, since user have already set `clickhouse.cluster` or `externalClickhouse.cluster` variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Configuration Update**
	- Added `--cluster-name` argument to schema-migrator and query-service containers in Kubernetes Jobs.
	- Dynamically specifies ClickHouse cluster name using environment variable `$(CLICKHOUSE_CLUSTER)`.
- **Version Update**
	- Helm chart version updated from `0.65.1` to `0.65.2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->