### PR TITLE
chore(clickhouse): use histogram-quantile release assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 ### macOS ###
 # General
 .DS_Store
+# Local
+.local/
 
 ### Helm ###
 # Chart dependencies

--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for ClickHouse
 type: application
-version: 24.1.14
+version: 24.1.15
 appVersion: "24.1.2"
 icon: https://github.com/ClickHouse/clickhouse-docs/raw/84f38d893eb7e561c7296279d7953b6a508ec413/static/img/clickhouse-logo.svg
 sources:

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -356,11 +356,12 @@ initContainers:
       - -c
       - |
         set -e
+        version="v0.0.1"
         node_os=$(uname -s | tr '[:upper:]' '[:lower:]')
         node_arch=$(uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)
         echo "Fetching histogram-binary for ${node_os}/${node_arch}"
         cd /tmp
-        wget -O histogram-quantile.tar.gz "https://github.com/SigNoz/signoz/releases/download/histogram-quantile%2Fv0.0.1/histogram-quantile_${node_os}_${node_arch}.tar.gz"
+        wget -O histogram-quantile.tar.gz "https://github.com/SigNoz/signoz/releases/download/histogram-quantile%2F${version}/histogram-quantile_${node_os}_${node_arch}.tar.gz"
         tar -xzf histogram-quantile.tar.gz
         mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
         echo "histogram-quantile installed successfully"

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -363,6 +363,7 @@ initContainers:
         cd /tmp
         wget -O histogram-quantile.tar.gz "https://github.com/SigNoz/signoz/releases/download/histogram-quantile%2F${version}/histogram-quantile_${node_os}_${node_arch}.tar.gz"
         tar -xzf histogram-quantile.tar.gz
+        chmod +x histogram-quantile
         mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
         echo "histogram-quantile installed successfully"
   init:

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -355,10 +355,15 @@ initContainers:
       - sh
       - -c
       - |
-        set -x
-        wget -O /tmp/histogramQuantile https://github.com/SigNoz/signoz/raw/main/deploy/docker/clickhouse-setup/user_scripts/histogramQuantile
-        mv /tmp/histogramQuantile  /var/lib/clickhouse/user_scripts/histogramQuantile
-        chmod +x /var/lib/clickhouse/user_scripts/histogramQuantile
+        set -e
+        node_os=$(uname -s | tr '[:upper:]' '[:lower:]')
+        node_arch=$(uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)
+        echo "Fetching histogram-binary for ${node_os}/${node_arch}"
+        cd /tmp
+        wget -O histogram-quantile.tar.gz "https://github.com/SigNoz/signoz/releases/download/histogram-quantile%2Fv0.0.1/histogram-quantile_${node_os}_${node_arch}.tar.gz"
+        tar -xzf histogram-quantile.tar.gz
+        mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
+        echo "histogram-quantile installed successfully"
   init:
     enabled: false
     image:

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -254,10 +254,15 @@ clickhouse:
         - sh
         - -c
         - |
-          set -x
-          wget -O /tmp/histogramQuantile https://github.com/SigNoz/signoz/raw/main/deploy/docker/clickhouse-setup/user_scripts/histogramQuantile
-          mv /tmp/histogramQuantile  /var/lib/clickhouse/user_scripts/histogramQuantile
-          chmod +x /var/lib/clickhouse/user_scripts/histogramQuantile
+          set -e
+          node_os=$(uname -s | tr '[:upper:]' '[:lower:]')
+          node_arch=$(uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)
+          echo "Fetching histogram-binary for ${node_os}/${node_arch}"
+          cd /tmp
+          wget -O histogram-quantile.tar.gz "https://github.com/SigNoz/signoz/releases/download/histogram-quantile%2Fv0.0.1/histogram-quantile_${node_os}_${node_arch}.tar.gz"
+          tar -xzf histogram-quantile.tar.gz
+          mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
+          echo "histogram-quantile installed successfully"
     init:
       enabled: false
       image:

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -262,6 +262,7 @@ clickhouse:
           cd /tmp
           wget -O histogram-quantile.tar.gz "https://github.com/SigNoz/signoz/releases/download/histogram-quantile%2F${version}/histogram-quantile_${node_os}_${node_arch}.tar.gz"
           tar -xzf histogram-quantile.tar.gz
+          chmod +x histogram-quantile
           mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
           echo "histogram-quantile installed successfully"
     init:

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -255,11 +255,12 @@ clickhouse:
         - -c
         - |
           set -e
+          version="v0.0.1"
           node_os=$(uname -s | tr '[:upper:]' '[:lower:]')
           node_arch=$(uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)
           echo "Fetching histogram-binary for ${node_os}/${node_arch}"
           cd /tmp
-          wget -O histogram-quantile.tar.gz "https://github.com/SigNoz/signoz/releases/download/histogram-quantile%2Fv0.0.1/histogram-quantile_${node_os}_${node_arch}.tar.gz"
+          wget -O histogram-quantile.tar.gz "https://github.com/SigNoz/signoz/releases/download/histogram-quantile%2F${version}/histogram-quantile_${node_os}_${node_arch}.tar.gz"
           tar -xzf histogram-quantile.tar.gz
           mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
           echo "histogram-quantile installed successfully"


### PR DESCRIPTION
### Chores

- clickhouse: use histogram-quantile release assets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated ClickHouse Helm chart version from 24.1.14 to 24.1.15
	- Enhanced initialization scripts for histogram quantile binary to improve compatibility across different operating systems and architectures

- **Configuration**
	- Added `.local/` to `.gitignore` to exclude local files or directories
<!-- end of auto-generated comment: release notes by coderabbit.ai -->