### PR TITLE
feat(operator): Support ServiceMonitor

### DIFF
--- a/charts/clickhouse/templates/clickhouse-operator/servicemonitor.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/servicemonitor.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.clickhouseOperator.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "clickhouseOperator.fullname" . }}-metrics
+  namespace: {{ include "clickhouse.namespace" . }}
+  labels:
+    {{- include "clickhouseOperator.labels" . | nindent 4 }}
+    {{- if .Values.clickhouseOperator.serviceMonitor.additionalLabels }}
+    {{- toYaml .Values.clickhouseOperator.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: {{ include "clickhouseOperator.fullname" $ }}-metrics
+  selector:
+    matchLabels:
+      {{- include "clickhouseOperator.selectorLabels" $ | nindent 4 }}
+  {{- with .Values.clickhouseOperator.serviceMonitor.interval }}
+  interval: {{ . }}
+  {{- end }}
+  {{- with .Values.clickhouseOperator.serviceMonitor.scrapeTimeout }}
+  scrapeTimeout: {{ . }}
+  {{- end }}
+  {{- with .Values.clickhouseOperator.serviceMonitor.relabelings }}
+  relabelings:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .Values.clickhouseOperator.serviceMonitor.metricRelabelings }}
+  metricRelabelings:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+{{- end }}

--- a/charts/clickhouse/templates/clickhouse-operator/servicemonitor.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/servicemonitor.yaml
@@ -12,6 +12,9 @@ metadata:
 spec:
   endpoints:
     - port: {{ include "clickhouseOperator.fullname" $ }}-metrics
+      path: /metrics
+      scheme: http
+      honorLabels: true
   selector:
     matchLabels:
       {{- include "clickhouseOperator.selectorLabels" $ | nindent 4 }}

--- a/charts/clickhouse/templates/clickhouse-operator/servicemonitor.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/servicemonitor.yaml
@@ -17,7 +17,7 @@ spec:
       honorLabels: true
   selector:
     matchLabels:
-      {{- include "clickhouseOperator.selectorLabels" $ | nindent 4 }}
+      {{- include "clickhouseOperator.selectorLabels" $ | nindent 6 }}
   {{- with .Values.clickhouseOperator.serviceMonitor.interval }}
   interval: {{ . }}
   {{- end }}
@@ -26,10 +26,10 @@ spec:
   {{- end }}
   {{- with .Values.clickhouseOperator.serviceMonitor.relabelings }}
   relabelings:
-    {{- toYaml . | nindent 8 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.clickhouseOperator.serviceMonitor.metricRelabelings }}
   metricRelabelings:
-    {{- toYaml . | nindent 8 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -762,3 +762,17 @@ clickhouseOperator:
   configs:
     # -- ClickHouse Operator confd files
     confdFiles: null
+
+  serviceMonitor:
+    # serviceMonitor.enabled -- ServiceMonitor Custom resource is created for a [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator)
+    enabled: false
+    # serviceMonitor.additionalLabels -- additional labels for service monitor
+    additionalLabels: {}
+    # serviceMonitor.interval --
+    interval: 30s
+    # serviceMonitor.scrapeTimeout -- Prometheus ServiceMonitor scrapeTimeout. If empty, Prometheus uses the global scrape timeout unless it is less than the target's scrape interval value in which the latter is used.
+    scrapeTimeout: ""
+    # serviceMonitor.relabelings -- Prometheus [RelabelConfigs] to apply to samples before scraping
+    relabelings: []
+    # serviceMonitor.metricRelabelings -- Prometheus [MetricRelabelConfigs] to apply to samples before ingestio
+    metricRelabelings: []


### PR DESCRIPTION
Fix #183 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a configurable Prometheus monitoring integration for enhanced observability of the ClickHouse operator.
  - Added new options for enabling monitoring and customizing parameters such as scrape intervals, timeouts, additional labels, and relabeling rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->