### PR TITLE
Feat/add secret template

### DIFF
--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -109,9 +109,13 @@ spec:
               {{- $attribs = printf "%s,%s" $attribs .Values.presets.resourceDetection.envResourceAttributes }}
               {{- end }}
               value: {{ $attribs | quote }}
-            {{- range $key, $val := .Values.otelAgent.additionalEnvs }}
+            {{- range $key, $val := .Values.otelDeployment.additionalEnvs }}
             - name: {{ $key }}
+              {{- if kindIs "map" $val }}
+              {{- toYaml $val | nindent 14 }}
+              {{- else }}
               value: {{ $val | toYaml }}
+              {{- end }}
             {{- end }}
           securityContext:
             {{- toYaml .Values.otelAgent.securityContext | nindent 12 }}

--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -109,7 +109,7 @@ spec:
               {{- $attribs = printf "%s,%s" $attribs .Values.presets.resourceDetection.envResourceAttributes }}
               {{- end }}
               value: {{ $attribs | quote }}
-            {{- range $key, $val := .Values.otelDeployment.additionalEnvs }}
+            {{- range $key, $val := .Values.otelAgent.additionalEnvs }}
             - name: {{ $key }}
               {{- if kindIs "map" $val }}
               {{- toYaml $val | nindent 14 }}

--- a/charts/k8s-infra/templates/otel-deployment/deployment.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/deployment.yaml
@@ -99,7 +99,11 @@ spec:
               value: signoz.component=$(SIGNOZ_COMPONENT),k8s.cluster.name=$(K8S_CLUSTER_NAME)
             {{- range $key, $val := .Values.otelDeployment.additionalEnvs }}
             - name: {{ $key }}
+              {{- if kindIs "map" $val }}
+              {{- toYaml $val | nindent 14 }}
+              {{- else }}
               value: {{ $val | toYaml }}
+              {{- end }}
             {{- end }}
           volumeMounts:
             - name: otel-deployment-config-vol

--- a/charts/signoz/templates/otel-collector/deployment.yaml
+++ b/charts/signoz/templates/otel-collector/deployment.yaml
@@ -120,7 +120,6 @@ spec:
             - name: LOW_CARDINAL_EXCEPTION_GROUPING
               value: {{ default "false" .Values.otelCollector.lowCardinalityExceptionGrouping | quote }}
             {{- range $key, $val := .Values.otelCollector.additionalEnvs }}
-            {{- range $key, $val := .Values.otelDeployment.additionalEnvs }}
             - name: {{ $key }}
               {{- if kindIs "map" $val }}
               {{- toYaml $val | nindent 14 }}

--- a/charts/signoz/templates/otel-collector/deployment.yaml
+++ b/charts/signoz/templates/otel-collector/deployment.yaml
@@ -120,8 +120,13 @@ spec:
             - name: LOW_CARDINAL_EXCEPTION_GROUPING
               value: {{ default "false" .Values.otelCollector.lowCardinalityExceptionGrouping | quote }}
             {{- range $key, $val := .Values.otelCollector.additionalEnvs }}
+            {{- range $key, $val := .Values.otelDeployment.additionalEnvs }}
             - name: {{ $key }}
+              {{- if kindIs "map" $val }}
+              {{- toYaml $val | nindent 14 }}
+              {{- else }}
               value: {{ $val | toYaml }}
+              {{- end }}
             {{- end }}
           volumeMounts:
             - name: otel-collector-config-vol


### PR DESCRIPTION
for GitOps practice using Helmfile, and follow [otel awss3](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/awss3exporter/README.md)

modify the template to support both simple values and complex structures:
```
  additionalEnvs:
    AWS_ACCESS_KEY_ID: 
      valueFrom:
        secretKeyRef:
          name: aws-s3-credentials
          key: access-key
    AWS_SECRET_ACCESS_KEY:
      valueFrom:
        secretKeyRef:
          name: aws-s3-credentials
          key: secret-key
```