### PR TITLE
feat: Modify Clickhouse instance sidecar indent

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for ClickHouse
 type: application
-version: 24.1.15
+version: 24.1.16
 appVersion: "24.1.2"
 icon: https://github.com/ClickHouse/clickhouse-docs/raw/84f38d893eb7e561c7296279d7953b6a508ec413/static/img/clickhouse-logo.svg
 sources:

--- a/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
+++ b/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
@@ -347,7 +347,7 @@ spec:
             {{- end }}
 
             {{- if .Values.extraContainers }}
-              {{- toYaml .Values.extraContainers | nindent 14 }}
+              {{- toYaml .Values.extraContainers | nindent 12 }}
             {{- end }}
 
     serviceTemplates:

--- a/charts/clickhouse/tests/clickhouse-instance_sidecar_test.yaml
+++ b/charts/clickhouse/tests/clickhouse-instance_sidecar_test.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: clickhouse-instance_sidecar_test.yaml
+templates:
+  - templates/clickhouse-instance/clickhouse-instance.yaml
+release:
+  name: clickhouse
+  namespace: signoz
+tests:
+  - it: There should be 1 extra container, for a total of 2.
+    set:
+      extraContainers:
+        - name: clickhouse-backup
+          image: altinity/clickhouse-backup:latest
+          imagePullPolicy: Always
+          args:
+            - "server"
+          ports:
+            - name: backup-rest
+              containerPort: 7171
+    asserts:
+      - lengthEqual:
+          path: spec.templates.podTemplates[0].spec.containers
+          count: 2
+      - contains:
+          any: true
+          path: spec.templates.podTemplates[0].spec.containers
+          content:
+            name: clickhouse-backup
+            image: altinity/clickhouse-backup:latest
+            imagePullPolicy: Always
+            args:
+              - "server"
+            ports:
+              - name: backup-rest
+                containerPort: 7171

--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -22,7 +22,7 @@ dependencies:
   - name: clickhouse
     repository: https://charts.signoz.io
     condition: clickhouse.enabled
-    version: 24.1.15
+    version: 24.1.16
   - name: signoz-otel-gateway
     repository: https://charts.signoz.io
     condition: signoz-otel-gateway.enabled

--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -22,7 +22,7 @@ dependencies:
   - name: clickhouse
     repository: https://charts.signoz.io
     condition: clickhouse.enabled
-    version: 24.1.16
+    version: 24.1.15
   - name: signoz-otel-gateway
     repository: https://charts.signoz.io
     condition: signoz-otel-gateway.enabled


### PR DESCRIPTION
The commit e237d17 updates the indentation of the Clickhouse instance sidecar in the clickhouse-instance.yaml file. Additionally, the version of the Clickhouse chart has been bumped from 24.1.15 to 24.1.16 in the Chart.yaml.

* Fix indentation for the Clickhouse instance sidecar in the clickhouse-instance.yaml file.
* Bump Clickhouse chart version from 24.1.15 to 24.1.16.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Adjusted YAML formatting for improved output structure.
  
- **Chores**
  - Updated the chart version to the latest release.
  
- **Tests**
  - Introduced a new test suite to validate the deployment configuration for an additional container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->