### PR TITLE
fix(signoz): fix alertmanager enabled clause

### DIFF
--- a/charts/signoz/templates/alertmanager/configmap.yaml
+++ b/charts/signoz/templates/alertmanager/configmap.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.alertmanager.config .Values.alertmanager.enabled -}}
+{{- if .Values.alertmanager.enabled }}
+{{- if .Values.alertmanager.config -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,4 +13,5 @@ data:
   {{ $key }}: |-
     {{- $value | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/signoz/templates/alertmanager/ingress.yaml
+++ b/charts/signoz/templates/alertmanager/ingress.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.alertmanager.ingress.enabled .Values.alertmanager.enabled -}}
+{{- if .Values.alertmanager.enabled }}
+{{- if .Values.alertmanager.ingress.enabled -}}
 {{- $fullName := include "alertmanager.fullname" . -}}
 {{- $ingressApiIsStable := eq (include "ingress.isStable" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "ingress.supportsPathType" .) "true" -}}
@@ -50,4 +51,5 @@ spec:
               {{- end }}
           {{- end }}
     {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/signoz/templates/alertmanager/pdb.yaml
+++ b/charts/signoz/templates/alertmanager/pdb.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.alertmanager.podDisruptionBudget .Values.alertmanager.enabled -}}
+{{- if .Values.alertmanager.enabled }}
+{{- if .Values.alertmanager.podDisruptionBudget -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -10,4 +11,5 @@ spec:
     matchLabels:
       {{- include "alertmanager.selectorLabels" . | nindent 6 }}
 {{ toYaml .Values.alertmanager.podDisruptionBudget | indent 2 }}
+{{- end -}}
 {{- end -}}

--- a/charts/signoz/templates/alertmanager/serviceaccount.yaml
+++ b/charts/signoz/templates/alertmanager/serviceaccount.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.alertmanager.serviceAccount.create .Values.alertmanager.enabled -}}
+{{- if .Values.alertmanager.enabled }}
+{{- if .Values.alertmanager.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,4 +11,5 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- include "signoz.imagePullSecrets" . }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
If alertmanager is disabled, we shouldn't have to define alertmanager.config or alertmanager.ingress or any of the other values in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Revised the deployment logic for the alerting system so that settings like configuration details, ingress rules, resource budgets, and service account creation are only applied after enabling the alert manager.
  - This change improves the clarity and predictability of deployments by ensuring that each setting is evaluated independently based on the master enable flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->