### PR TITLE
fix(signoz): fix signoz service when type set to NodePort

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.74.1
+version: 0.74.2
 appVersion: "v0.76.1"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/templates/signoz/service.yaml
+++ b/charts/signoz/templates/signoz/service.yaml
@@ -36,8 +36,8 @@ spec:
       {{- include "signoz.service.ifClusterIP" .type | indent 6 }}
       protocol: TCP
       targetPort: opamp-internal
-      {{- if eq .type "NodePort" }}
-      nodePort: ""
+      {{- if (and (eq .type "NodePort") .opampInternalNodePort) }}
+      nodePort: {{ .opampInternalNodePort }}
       {{- end }}
 {{- end }}
   selector:

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -589,12 +589,15 @@ signoz:
     internalPort: 8085
     # -- signoz OpAMP Internal port
     opampPort: 4320
-    # -- Set this to you want to force a specific nodePort for http.
+    # -- Set this if you want to force a specific nodePort for http.
     # Must be use with service.type=NodePort
     nodePort: null
-    # -- Set this to you want to force a specific nodePort for internal.
+    # -- Set this if you want to force a specific nodePort for internal.
     # Must be use with service.type=NodePort
     internalNodePort: null
+    # -- Set this if you want to force a specific nodePort for OpAMP.
+    # Must be use with service.type=NodePort
+    opampInternalNodePort: null
   # -- signoz annotations
   annotations:
   # -- signoz additional arguments for command line


### PR DESCRIPTION
fix #635 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added an option to specify a custom node port for the OpAMP service.
	- Enhanced configuration clarity for node port settings with updated comments.
	- Updated Helm chart version from 0.74.1 to 0.74.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->