### PR TITLE
k8s-infra: add the missing namespace to secrets

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.12.1
+version: 0.12.2
 appVersion: "0.109.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/templates/apikey-secret.yaml
+++ b/charts/k8s-infra/templates/apikey-secret.yaml
@@ -4,6 +4,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: {{ include "k8s-infra.fullname" . }}-apikey-secret
+  namespace: {{ include "k8s-infra.namespace" . }}
   labels:
     {{- include "k8s-infra.labels" . | nindent 4 }}
   annotations:

--- a/charts/k8s-infra/templates/apikey-self-telemetry-secret.yaml
+++ b/charts/k8s-infra/templates/apikey-self-telemetry-secret.yaml
@@ -4,6 +4,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: {{ include "k8s-infra.fullname" . }}-self-telemetry-apikey-secret
+  namespace: {{ include "k8s-infra.namespace" . }}
   labels:
     {{- include "k8s-infra.labels" . | nindent 4 }}
   annotations:

--- a/charts/k8s-infra/templates/tls-secret.yaml
+++ b/charts/k8s-infra/templates/tls-secret.yaml
@@ -4,6 +4,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: {{ include "k8s-infra.fullname" . }}-tls-secrets
+  namespace: {{ include "k8s-infra.namespace" . }}
   labels:
     {{- include "k8s-infra.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
Otherwise, it can't find the `Secret`s when namespace is different from where the chart is deployed, which is common when the chart is a dependency of another chart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Secrets are now automatically assigned to designated namespaces, ensuring improved organization and consistent deployment across environments.
- **Updates**
	- Helm chart version updated from 0.12.1 to 0.12.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->