### PR TITLE
chore(k8s-infra): remove otel collector metrics from notes

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.12.2
+version: 0.12.3
 appVersion: "0.109.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/templates/NOTES.txt
+++ b/charts/k8s-infra/templates/NOTES.txt
@@ -1,11 +1,7 @@
-
-You have just deployed K8s-Infra chart:
+You have just deployed k8s-infra chart:
 
 - otel-agent version: '{{ .Values.otelAgent.image.tag }}'
 - otel-deployment version: '{{ .Values.otelDeployment.image.tag }}'
-
-NOTE: If you enable Prometheus preset in this chart and have installed SigNoz helm chart in the same cluster,
-      please set otelCollectorMetrics.enabled to false in the signoz chart to avoid data duplication.
 
 {{- if not .Values.otelAgent.configMap.create }}
 [WARNING] otel-agent "configMap" will not be created and "otelAgent.config" will not take effect.


### PR DESCRIPTION
#### Chores

- remove otel collector metrics from notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated deployment notes to remove information about Prometheus preset and SigNoz interaction.
  - Adjusted capitalization of the chart name in deployment messages.

- **Chores**
  - Bumped Helm chart version from 0.12.2 to 0.12.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->