### PR TITLE
chore: disable writing to v2 tables and add signozclickhousemetrics to metrics pipeline

### DIFF
--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1583,7 +1583,7 @@ otelCollector:
       # ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md
       # memory_limiter: null
       signozspanmetrics/delta:
-        metrics_exporter: clickhousemetricswrite
+        metrics_exporter: clickhousemetricswrite, signozclickhousemetrics
         latency_histogram_buckets: [100us, 1ms, 2ms, 6ms, 10ms, 50ms, 100ms, 250ms, 500ms, 1000ms, 1400ms, 2000ms, 5s, 10s, 20s, 40s, 60s]
         dimensions_cache_size: 100000
         dimensions:
@@ -1610,6 +1610,10 @@ otelCollector:
         timeout: 15s
         resource_to_telemetry_conversion:
           enabled: true
+        disable_v2: true
+      signozclickhousemetrics:
+        dsn: tcp://${env:CLICKHOUSE_USER}:${env:CLICKHOUSE_PASSWORD}@${env:CLICKHOUSE_HOST}:${env:CLICKHOUSE_PORT}/${env:CLICKHOUSE_DATABASE}
+        timeout: 45s
       clickhouselogsexporter:
         dsn: tcp://${env:CLICKHOUSE_USER}:${env:CLICKHOUSE_PASSWORD}@${env:CLICKHOUSE_HOST}:${env:CLICKHOUSE_PORT}/${env:CLICKHOUSE_LOG_DATABASE}
         timeout: 10s
@@ -1635,7 +1639,7 @@ otelCollector:
         metrics:
           receivers: [otlp]
           processors: [batch]
-          exporters: [clickhousemetricswrite, metadataexporter]
+          exporters: [clickhousemetricswrite, metadataexporter, signozclickhousemetrics]
         logs:
           receivers: [otlp, httplogreceiver/heroku, httplogreceiver/json]
           processors: [batch]


### PR DESCRIPTION
Added signozclickhousemetrics exporter.


issue:  https://github.com/SigNoz/signoz/issues/7837

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new metrics exporter with enhanced connection and timeout settings for improved metrics processing.
- **Chores**
	- Updated configuration to include the new exporter in the metrics processing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->