### PR TITLE
Aligned rendering of additional envs in k8s-infra with signoz chart

### DIFF
--- a/charts/k8s-infra/templates/_helpers.tpl
+++ b/charts/k8s-infra/templates/_helpers.tpl
@@ -472,3 +472,29 @@ Secret key to be used for SigNoz Self Telemetry API key.
 {{- print "signoz-apikey" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Function to render additional environment variables 
+*/}}
+{{- define "renderAdditionalEnv" -}}
+{{- $dict := . -}}
+{{- $processedKeys := dict -}}
+{{- range keys . | sortAlpha }}
+{{- $val := pluck . $dict | first -}}
+{{- $key := upper . -}}
+{{- if not (hasKey $processedKeys $key) }}
+{{- $processedKeys = merge $processedKeys (dict $key true) -}}
+{{- $valueType := printf "%T" $val -}}
+{{- if eq $valueType "map[string]interface {}" }}
+- name: {{ $key }}
+{{ toYaml $val | indent 2 -}}
+{{- else if eq $valueType "string" }}
+- name: {{ $key }}
+  value: {{ $val | quote }}
+{{- else }}
+- name: {{ $key }}
+  value: {{ $val | quote }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -109,10 +109,7 @@ spec:
               {{- $attribs = printf "%s,%s" $attribs .Values.presets.resourceDetection.envResourceAttributes }}
               {{- end }}
               value: {{ $attribs | quote }}
-            {{- range $key, $val := .Values.otelAgent.additionalEnvs }}
-            - name: {{ $key }}
-              value: {{ $val | toYaml }}
-            {{- end }}
+            {{- include "renderAdditionalEnv" .Values.otelAgent.additionalEnvs | nindent 12 }}
           securityContext:
             {{- toYaml .Values.otelAgent.securityContext | nindent 12 }}
           volumeMounts:

--- a/charts/k8s-infra/templates/otel-deployment/deployment.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/deployment.yaml
@@ -97,10 +97,7 @@ spec:
               value: {{ default "otel-deployment" .Values.otelDeployment.name }}
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: signoz.component=$(SIGNOZ_COMPONENT),k8s.cluster.name=$(K8S_CLUSTER_NAME)
-            {{- range $key, $val := .Values.otelDeployment.additionalEnvs }}
-            - name: {{ $key }}
-              value: {{ $val | toYaml }}
-            {{- end }}
+            {{- include "renderAdditionalEnv" .Values.otelDeployment.additionalEnvs | nindent 12 }}
           volumeMounts:
             - name: otel-deployment-config-vol
               mountPath: /conf

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -413,7 +413,21 @@ otelAgent:
 
   # -- Additional environments to set for OtelAgent
   additionalEnvs: {}
-    # env_key: env_value
+  # You can specify variables in two ways:
+  # 1. Flexible structure for advanced configurations (recommended):
+  #    Example:
+  #      additionalEnvs:
+  #        MY_KEY:
+  #          value: my-value  # Direct value
+  #        SECRET_KEY:
+  #          valueFrom:       # Reference from a Secret or ConfigMap
+  #            secretKeyRef:
+  #              name: my-secret
+  #              key: my-key
+  # 2. Simple key-value pairs (backward-compatible):
+  #    Example:
+  #      additionalEnvs:
+  #        MY_KEY: my-value
 
   # -- Minimum number of seconds for which a newly created Pod should be ready
   # without any of its containers crashing, for it to be considered available.
@@ -773,7 +787,21 @@ otelDeployment:
 
   # -- Additional environments to set for OtelDeployment
   additionalEnvs: {}
-    # env_key: env_value
+  # You can specify variables in two ways:
+  # 1. Flexible structure for advanced configurations (recommended):
+  #    Example:
+  #      additionalEnvs:
+  #        MY_KEY:
+  #          value: my-value  # Direct value
+  #        SECRET_KEY:
+  #          valueFrom:       # Reference from a Secret or ConfigMap
+  #            secretKeyRef:
+  #              name: my-secret
+  #              key: my-key
+  # 2. Simple key-value pairs (backward-compatible):
+  #    Example:
+  #      additionalEnvs:
+  #        MY_KEY: my-value
 
   # -- Pod-level security configuration
   podSecurityContext: {}

--- a/charts/signoz/templates/_helpers.tpl
+++ b/charts/signoz/templates/_helpers.tpl
@@ -494,7 +494,7 @@ imagePullSecrets:
 {{- end }}
 
 {{/*
-Function to render environment variables 
+Function to render additional environment variables 
 */}}
 {{- define "signoz.renderAdditionalEnv" -}}
 {{- $dict := . -}}
@@ -518,4 +518,3 @@ Function to render environment variables
 {{- end -}}
 {{- end -}}
 {{- end -}}
-


### PR DESCRIPTION
### Summary

When using the k8s-infra Helm chart, I want to be able to create environment variables which are getting it value from a secret manifest, instead of having to define my "secret" config either plain in the env variables or the otel config.

I found out there already was an existing [PR](https://github.com/SigNoz/charts/pull/627) open with requested changes, since it's not updated for a while, I've implemented the preferred approach as mentioned in that PR.

### Approach

- Copied render (helper) function from charts/signoz/templates/_helpers.tpl
- Replaced logic for rendering the additional envs in both: 
  - charts/k8s-infra/templates/otel-agent/daemonset.yaml
  - charts/k8s-infra/templates/otel-deployment/deployment.yaml
- Updated documentation in the k8s-infra values file based on the documentation in the signoz' chart 

### Test

When using helm template on the k8s-infra chart with the following config:

```yaml
otelAgent:
  additionalEnvs:
    TEST_VAR_0: value0
    TEST_VAR_1: value1
otelDeployment:
  additionalEnvs:
    TEST_VAR_2:
      valueFrom:
        secretKeyRef:
          name: my-secret
          key: testVar2Key
    TEST_VAR_3:
      valueFrom:
        secretKeyRef:
          name: my-secret
          key: testVar3Key
```

I'm getting the expected output:

![image](https://github.com/user-attachments/assets/9a723772-c4ce-4793-8ec7-b6ba67c89452)
