### PR TITLE
chore(k8s-infra): bump k8s-infra chart version to 0.13.0

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.12.3
+version: 0.13.0
 appVersion: "0.109.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg


### PR DESCRIPTION
As requested by @grandwizard28 updating the chart version for the k8s-infra Helm chart after merging https://github.com/SigNoz/charts/pull/666