### PR TITLE
Fix storage class default

### DIFF
--- a/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
+++ b/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
@@ -382,7 +382,7 @@ spec:
           resources:
             requests:
               storage: {{ .Values.persistence.size }}
-        {{- $storageClass := default .Values.persistence.storageClass .Values.global.storageClass -}}
+        {{- $storageClass := coalesce .Values.persistence.storageClass .Values.global.storageClass -}}
         {{- if $storageClass -}}
         {{- if (eq "-" $storageClass) }}
           storageClassName: ""


### PR DESCRIPTION
Solves #671. 

Global value overriding a specific value is confusing.

Relevant docs:
- [coalesce](https://helm.sh/docs/chart_template_guide/function_list/#coalesce)
- [default](https://helm.sh/docs/chart_template_guide/function_list/#default)

As a sidenote, I find `coalesce` more natural than `default` unless `default` is used with pipelines.