### PR TITLE
chore(clickhouse): make clickhouse-operator-metrics service as optional

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for ClickHouse
 type: application
-version: 24.1.16
+version: 24.1.17
 appVersion: "24.1.2"
 icon: https://github.com/ClickHouse/clickhouse-docs/raw/84f38d893eb7e561c7296279d7953b6a508ec413/static/img/clickhouse-logo.svg
 sources:

--- a/charts/clickhouse/templates/clickhouse-operator/service.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.clickhouseOperator.service.enabled }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -17,4 +18,5 @@ spec:
       name: {{ include "clickhouseOperator.fullname" $ }}-metrics
   selector:
     {{- include "clickhouseOperator.selectorLabels" $ | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -568,6 +568,8 @@ installCustomStorageClass: false
 ###
 ###
 clickhouseOperator:
+  service:
+    enabled: true
   # -- name of the component
   name: operator
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable or disable the ClickHouse operator service through a new flag.
* **Chores**
  * Updated the Helm chart version for ClickHouse to 24.1.17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->