### PR TITLE
fix: consolidate env variables and implement helm chart docs

### DIFF
--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -27,5 +27,6 @@ jobs:
       - name: Check if docs are different
         run: |
           make chart-docs CHARTS=charts/signoz,charts/k8s-infra
+          git diff
           git diff --compact-summary --exit-code || (echo; echo "Unexpected difference in Docs. Run make chart-docs locally and commit."; exit 1)
 

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -18,17 +18,19 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+          cache: true
 
-      - name: Download Helm Docs Tool
+      - name: Download helm-docs
         run: |
           go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.11.0
 
       - name: Check if docs are different
         run: |
           make chart-docs CHARTS=charts/signoz,charts/k8s-infra
-          if [ ! -z "$(git status --porcelain)" ]; then
+          if git diff --compact-summary --exit-code; then
+            echo -e 'Documentation up to date'
+          else
             echo -e 'Documentation outdated! (Run make chart-docs locally and commit)'
             exit 1
-          else
-            echo -e 'Documentation up to date'
           fi
+

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -27,10 +27,5 @@ jobs:
       - name: Check if docs are different
         run: |
           make chart-docs CHARTS=charts/signoz,charts/k8s-infra
-          if git diff --compact-summary --exit-code; then
-            echo -e 'Documentation up to date'
-          else
-            echo -e 'Documentation outdated! (Run make chart-docs locally and commit)'
-            exit 1
-          fi
+          git diff --compact-summary --exit-code || (echo; echo "Unexpected difference in Docs. Run make chart-docs locally and commit."; exit 1)
 

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -1,0 +1,38 @@
+
+
+name: "Generate Helm Docs"
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  helm-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: go-install
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Download Helm Docs Tool
+        run: |
+          go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.11.0
+
+      - name: Generate Helm Docs
+        run: |
+          make chart-docs CHARTS=charts/signoz,charts/k8s-infra
+
+      - name: Check if docs are different
+        run: |
+          make chart-docs CHARTS=charts/signoz,charts/k8s-infra
+          if [ ! -z "$(git status --porcelain)" ]; then
+            echo -e 'Documentation outdated! (Run make chart-docs locally and commit)'
+            exit 1
+          else
+            echo -e 'Documentation up to date'
+          fi

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -23,10 +23,6 @@ jobs:
         run: |
           go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.11.0
 
-      - name: Generate Helm Docs
-        run: |
-          make chart-docs CHARTS=charts/signoz,charts/k8s-infra
-
       - name: Check if docs are different
         run: |
           make chart-docs CHARTS=charts/signoz,charts/k8s-infra

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -27,6 +27,5 @@ jobs:
       - name: Check if docs are different
         run: |
           make chart-docs CHARTS=charts/signoz,charts/k8s-infra
-          git diff
           git diff --compact-summary --exit-code || (echo; echo "Unexpected difference in Docs. Run make chart-docs locally and commit."; exit 1)
 

--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,7 @@ dev-install: local-setup
 re-install: delete install
 
 purge: delete delete-namespace
+
+# generate docs for the chart with respective templates in ./helm-docs
+chart-docs:
+	helm-docs --chart-search-root=charts --template-files=README.md.gotmpl --chart-to-generate=charts/signoz,charts/k8s-infra --sort-values-order=file

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,6 @@ purge: delete delete-namespace
 # Usage: make chart-docs CHARTS=chart1,chart2
 # Example: make chart-docs CHARTS=charts/signoz,charts/k8s-infra
 CHARTS ?= charts/signoz,charts/k8s-infra
-
+HELM_DOCS = go run github.com/norwoodj/helm-docs/cmd/helm-docs@v1.11.0
 chart-docs:
-	helm-docs --chart-search-root=charts --template-files=README.md.gotmpl --chart-to-generate=$(CHARTS) --sort-values-order=file
+	$(HELM_DOCS) --chart-search-root=charts --template-files=README.md.gotmpl --chart-to-generate=$(CHARTS) --sort-values-order=file

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,11 @@ re-install: delete install
 
 purge: delete delete-namespace
 
-# generate docs for the chart with respective templates in ./helm-docs
+# generate docs for the signoz and k8s-infra chart with respective templates
+# generate docs for specified charts with respective templates
+# Usage: make chart-docs CHARTS=chart1,chart2
+# Example: make chart-docs CHARTS=charts/signoz,charts/k8s-infra
+CHARTS ?= charts/signoz,charts/k8s-infra
+
 chart-docs:
-	helm-docs --chart-search-root=charts --template-files=README.md.gotmpl --chart-to-generate=charts/signoz,charts/k8s-infra --sort-values-order=file
+	helm-docs --chart-search-root=charts --template-files=README.md.gotmpl --chart-to-generate=$(CHARTS) --sort-values-order=file

--- a/charts/k8s-infra/README.md
+++ b/charts/k8s-infra/README.md
@@ -62,7 +62,7 @@ Sometimes everything doesn't get properly removed. If that happens try deleting 
 kubectl delete namespace platform
 ```
 
-<h2> Configuration </h2>
+## Configuration
 
 <table>
 	<thead>

--- a/charts/k8s-infra/README.md
+++ b/charts/k8s-infra/README.md
@@ -16,8 +16,9 @@ helm install -n platform --create-namespace "my-release" signoz/k8s-infra
 
 ### Introduction
 
-This chart bootstraps [SigNoz](https://signoz.io) cluster deployment on a
-Kubernetes cluster using [Helm](https://helm.sh) package manager.
+The `k8s-infra` chart provides Kubernetes infrastructure observability by deploying OpenTelemetry components and related resources using the [Helm](https://helm.sh) package manager.
+
+It enables collection of metrics, logs, and events from your Kubernetes cluster, making it easier to monitor and troubleshoot your infrastructure with SigNoz.
 
 ### Prerequisites
 
@@ -33,7 +34,7 @@ helm repo add signoz https://charts.signoz.io
 helm -n platform --create-namespace install "my-release" signoz/k8s-infra
 ```
 
-These commands deploy SigNoz on the Kubernetes cluster in the default configuration.
+These commands deploy K8s-infra on the Kubernetes cluster in the default configuration.
 The [Configuration](#configuration) section lists the parameters that can be configured during installation:
 
 > **Tip**: List all releases using `helm list`

--- a/charts/k8s-infra/README.md
+++ b/charts/k8s-infra/README.md
@@ -3,9 +3,7 @@
 
 ![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.109.0](https://img.shields.io/badge/AppVersion-0.109.0-informational?style=flat-square)
 
-SigNoz is an open-source APM. It helps developers monitor their applications & troubleshoot problems,
-an open-source alternative to DataDog, NewRelic, etc. Open source Application Performance Monitoring (APM)
-& Observability tool.
+SigNoz is an open-source observability platform native to OpenTelemetry with logs, traces and metrics in a single application. An open-source alternative to DataDog, NewRelic, etc. 🔥 🖥. 👉 Open source Application Performance Monitoring (APM) & Observability tool
 
 ### TL;DR;
 
@@ -66,7 +64,7 @@ kubectl delete namespace platform
 
 <h2> Configuration </h2>
 
-<table height="400px" >
+<table>
 	<thead>
 		<th>Key</th>
 		<th>Type</th>
@@ -78,10 +76,7 @@ kubectl delete namespace platform
 			<td id="global--imageRegistry"><a href="./values.yaml#L4">global.imageRegistry</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Overrides the Docker registry globally for all images</td>
@@ -90,10 +85,7 @@ null
 			<td id="global--imagePullSecrets"><a href="./values.yaml#L6">global.imagePullSecrets</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Global Image Pull Secrets</td>
@@ -102,10 +94,7 @@ null
 			<td id="global--storageClass"><a href="./values.yaml#L8">global.storageClass</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Overrides the storage class for all PVC with persistence enabled.</td>
@@ -114,10 +103,7 @@ null
 			<td id="global--clusterDomain"><a href="./values.yaml#L11">global.clusterDomain</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"cluster.local"
-</pre>
+				<div style="max-width: 300px;"><code>"cluster.local"</code>
 </div>
 			</td>
 			<td>Kubernetes cluster domain It is used only when components are installed in different namespace</td>
@@ -126,10 +112,7 @@ null
 			<td id="global--clusterName"><a href="./values.yaml#L14">global.clusterName</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Kubernetes cluster name It is used to attached to telemetry data via resource detection processor</td>
@@ -138,10 +121,7 @@ null
 			<td id="global--deploymentEnvironment"><a href="./values.yaml#L16">global.deploymentEnvironment</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Deployment environment to be attached to telemetry data</td>
@@ -150,10 +130,7 @@ null
 			<td id="global--cloud"><a href="./values.yaml#L19">global.cloud</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"other"
-</pre>
+				<div style="max-width: 300px;"><code>"other"</code>
 </div>
 			</td>
 			<td>Kubernetes cluster cloud provider along with distribution if any. example: `aws`, `azure`, `gcp`, `gcp/autogke`, `azure`, and `other`</td>
@@ -162,10 +139,7 @@ null
 			<td id="nameOverride"><a href="./values.yaml#L22">nameOverride</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>K8s infra chart name override</td>
@@ -174,10 +148,7 @@ null
 			<td id="fullnameOverride"><a href="./values.yaml#L25">fullnameOverride</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>K8s infra chart full name override</td>
@@ -186,10 +157,7 @@ null
 			<td id="enabled"><a href="./values.yaml#L28">enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Whether to enable K8s infra chart</td>
@@ -198,10 +166,7 @@ true
 			<td id="clusterName"><a href="./values.yaml#L31">clusterName</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Name of the K8s cluster. Used by OtelCollectors to attach in telemetry data.</td>
@@ -210,10 +175,7 @@ true
 			<td id="otelCollectorEndpoint"><a href="./values.yaml#L38">otelCollectorEndpoint</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Endpoint/IP Address of the SigNoz or any other OpenTelemetry backend. Set it to `ingest.signoz.io:4317` for SigNoz SaaS.  If set to null and the chart is installed as dependency, it will attempt to autogenerate the endpoint of SigNoz OtelCollector.</td>
@@ -222,10 +184,7 @@ null
 			<td id="otelInsecure"><a href="./values.yaml#L42">otelInsecure</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Whether the OTLP endpoint is insecure. Set this to false, in case of secure OTLP endpoint.</td>
@@ -234,10 +193,7 @@ true
 			<td id="insecureSkipVerify"><a href="./values.yaml#L45">insecureSkipVerify</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Whether to skip verifying the certificate.</td>
@@ -246,10 +202,7 @@ false
 			<td id="signozApiKey"><a href="./values.yaml#L48">signozApiKey</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>API key of SigNoz SaaS</td>
@@ -258,10 +211,7 @@ false
 			<td id="apiKeyExistingSecretName"><a href="./values.yaml#L50">apiKeyExistingSecretName</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Existing secret name to be used for API key.</td>
@@ -270,10 +220,7 @@ false
 			<td id="apiKeyExistingSecretKey"><a href="./values.yaml#L52">apiKeyExistingSecretKey</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Existing secret key to be used for API key.</td>
@@ -282,10 +229,7 @@ false
 			<td id="otelTlsSecrets--enabled"><a href="./values.yaml#L57">otelTlsSecrets.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Whether to enable OpenTelemetry OTLP secrets</td>
@@ -294,10 +238,7 @@ false
 			<td id="otelTlsSecrets--path"><a href="./values.yaml#L60">otelTlsSecrets.path</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"/secrets"
-</pre>
+				<div style="max-width: 300px;"><code>"/secrets"</code>
 </div>
 			</td>
 			<td>Path for the secrets volume</td>
@@ -306,10 +247,7 @@ false
 			<td id="otelTlsSecrets--existingSecretName"><a href="./values.yaml#L64">otelTlsSecrets.existingSecretName</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Name of the existing secret with TLS certificate, key and CA to be used. Files in the secret must be named `cert.pem`, `key.pem` and `ca.pem`.</td>
@@ -318,10 +256,7 @@ null
 			<td id="otelTlsSecrets--certificate"><a href="./values.yaml#L67">otelTlsSecrets.certificate</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"\u003cINCLUDE_CERTIFICATE_HERE\u003e\n"
-</pre>
+				<div style="max-width: 300px;"><code>"\u003cINCLUDE_CERTIFICATE_HERE\u003e\n"</code>
 </div>
 			</td>
 			<td>TLS certificate to be included in the secret</td>
@@ -330,10 +265,7 @@ null
 			<td id="otelTlsSecrets--key"><a href="./values.yaml#L71">otelTlsSecrets.key</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"\u003cINCLUDE_PRIVATE_KEY_HERE\u003e\n"
-</pre>
+				<div style="max-width: 300px;"><code>"\u003cINCLUDE_PRIVATE_KEY_HERE\u003e\n"</code>
 </div>
 			</td>
 			<td>TLS private key to be included in the secret</td>
@@ -342,10 +274,7 @@ null
 			<td id="otelTlsSecrets--ca"><a href="./values.yaml#L75">otelTlsSecrets.ca</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>TLS certificate authority (CA) certificate to be included in the secret</td>
@@ -354,10 +283,7 @@ null
 			<td id="namespace"><a href="./values.yaml#L79">namespace</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Which namespace to install k8s-infra components. By default installed to the namespace same as the chart.</td>
@@ -366,9 +292,7 @@ null
 			<td id="presets"><a href="./values.yaml#L82">presets</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{
+				<div style="max-width: 300px;"><code>{
   "clusterMetrics": {
     "allocatableTypesToReport": [
       "cpu",
@@ -685,8 +609,7 @@ null
       "enabled": false
     }
   }
-}
-</pre>
+}</code>
 </div>
 			</td>
 			<td>Presets to easily set up OtelCollector configurations.</td>
@@ -695,10 +618,7 @@ null
 			<td id="presets--selfTelemetry--signozApiKey"><a href="./values.yaml#L101">presets.selfTelemetry.signozApiKey</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>API key of SigNoz SaaS</td>
@@ -707,10 +627,7 @@ null
 			<td id="presets--selfTelemetry--apiKeyExistingSecretName"><a href="./values.yaml#L103">presets.selfTelemetry.apiKeyExistingSecretName</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Existing secret name to be used for API key.</td>
@@ -719,10 +636,7 @@ null
 			<td id="presets--selfTelemetry--apiKeyExistingSecretKey"><a href="./values.yaml#L105">presets.selfTelemetry.apiKeyExistingSecretKey</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Existing secret key to be used for API key.</td>
@@ -731,10 +645,7 @@ null
 			<td id="presets--kubernetesAttributes--passthrough"><a href="./values.yaml#L267">presets.kubernetesAttributes.passthrough</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Whether to detect the IP address of agents and add it as an attribute to all telemetry resources. If set to true, Agents will not make any k8s API calls, do any discovery of pods or extract any metadata.</td>
@@ -743,12 +654,9 @@ false
 			<td id="presets--kubernetesAttributes--filter"><a href="./values.yaml#L270">presets.kubernetesAttributes.filter</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{
+				<div style="max-width: 300px;"><code>{
   "node_from_env_var": "K8S_NODE_NAME"
-}
-</pre>
+}</code>
 </div>
 			</td>
 			<td>Filters can be used to limit each OpenTelemetry agent to query pods based on specific selector to only dramatically reducing resource requirements for very large clusters.</td>
@@ -757,10 +665,7 @@ false
 			<td id="presets--kubernetesAttributes--filter--node_from_env_var"><a href="./values.yaml#L272">presets.kubernetesAttributes.filter.node_from_env_var</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"K8S_NODE_NAME"
-</pre>
+				<div style="max-width: 300px;"><code>"K8S_NODE_NAME"</code>
 </div>
 			</td>
 			<td>Restrict each OpenTelemetry agent to query pods running on the same node</td>
@@ -769,9 +674,7 @@ false
 			<td id="presets--kubernetesAttributes--podAssociation"><a href="./values.yaml#L275">presets.kubernetesAttributes.podAssociation</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[
+				<div style="max-width: 300px;"><code>[
   {
     "sources": [
       {
@@ -795,8 +698,7 @@ false
       }
     ]
   }
-]
-</pre>
+]</code>
 </div>
 			</td>
 			<td>Pod Association section allows to define rules for tagging spans, metrics, and logs with Pod metadata.</td>
@@ -805,9 +707,7 @@ false
 			<td id="presets--kubernetesAttributes--extractMetadatas"><a href="./values.yaml#L285">presets.kubernetesAttributes.extractMetadatas</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[
+				<div style="max-width: 300px;"><code>[
   "k8s.namespace.name",
   "k8s.deployment.name",
   "k8s.statefulset.name",
@@ -819,8 +719,7 @@ false
   "k8s.pod.name",
   "k8s.pod.uid",
   "k8s.pod.start_time"
-]
-</pre>
+]</code>
 </div>
 			</td>
 			<td>Which pod/namespace metadata to extract from a list of default metadata fields.</td>
@@ -829,10 +728,7 @@ false
 			<td id="presets--kubernetesAttributes--extractLabels"><a href="./values.yaml#L298">presets.kubernetesAttributes.extractLabels</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Which labels to extract from a list of metadata fields.</td>
@@ -841,10 +737,7 @@ false
 			<td id="presets--kubernetesAttributes--extractAnnotations"><a href="./values.yaml#L300">presets.kubernetesAttributes.extractAnnotations</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Which annotations to extract from a list of metadata fields.</td>
@@ -853,10 +746,7 @@ false
 			<td id="presets--prometheus--enabled"><a href="./values.yaml#L333">presets.prometheus.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Whether to enable metrics scraping using pod annotation</td>
@@ -865,10 +755,7 @@ false
 			<td id="presets--prometheus--annotationsPrefix"><a href="./values.yaml#L335">presets.prometheus.annotationsPrefix</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"signoz.io"
-</pre>
+				<div style="max-width: 300px;"><code>"signoz.io"</code>
 </div>
 			</td>
 			<td>Prefix for the pod annotations to be used for metrics scraping</td>
@@ -877,10 +764,7 @@ false
 			<td id="presets--prometheus--scrapeInterval"><a href="./values.yaml#L337">presets.prometheus.scrapeInterval</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"60s"
-</pre>
+				<div style="max-width: 300px;"><code>"60s"</code>
 </div>
 			</td>
 			<td>How often to scrape metrics</td>
@@ -889,10 +773,7 @@ false
 			<td id="presets--prometheus--namespaceScoped"><a href="./values.yaml#L339">presets.prometheus.namespaceScoped</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Whether to only scrape metrics from pods in the same namespace</td>
@@ -901,10 +782,7 @@ false
 			<td id="presets--prometheus--namespaces"><a href="./values.yaml#L341">presets.prometheus.namespaces</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>If set, only scrape metrics from pods in the specified namespaces</td>
@@ -913,10 +791,7 @@ false
 			<td id="presets--prometheus--includePodLabel"><a href="./values.yaml#L344">presets.prometheus.includePodLabel</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>This will include all pod labels in the metrics, could potentially cause performance issues with large number of pods with many labels</td>
@@ -925,10 +800,7 @@ false
 			<td id="presets--prometheus--includeContainerName"><a href="./values.yaml#L348">presets.prometheus.includeContainerName</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>This is not recommended in case of multiple containers or init containers in a pod Since it will create multiple timeseries for the same pod metrics with different container names containers with `-init` suffix in the name will be ignored</td>
@@ -937,10 +809,7 @@ false
 			<td id="presets--k8sEvents--namespaces"><a href="./values.yaml#L359">presets.k8sEvents.namespaces</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>List of namespaces to watch for events. all namespaces by default</td>
@@ -949,10 +818,7 @@ false
 			<td id="otelAgent--enabled"><a href="./values.yaml#L363">otelAgent.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td></td>
@@ -961,10 +827,7 @@ true
 			<td id="otelAgent--name"><a href="./values.yaml#L364">otelAgent.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"otel-agent"
-</pre>
+				<div style="max-width: 300px;"><code>"otel-agent"</code>
 </div>
 			</td>
 			<td></td>
@@ -973,10 +836,7 @@ true
 			<td id="otelAgent--image--registry"><a href="./values.yaml#L366">otelAgent.image.registry</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"docker.io"
-</pre>
+				<div style="max-width: 300px;"><code>"docker.io"</code>
 </div>
 			</td>
 			<td></td>
@@ -985,10 +845,7 @@ true
 			<td id="otelAgent--image--repository"><a href="./values.yaml#L367">otelAgent.image.repository</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"otel/opentelemetry-collector-contrib"
-</pre>
+				<div style="max-width: 300px;"><code>"otel/opentelemetry-collector-contrib"</code>
 </div>
 			</td>
 			<td></td>
@@ -997,10 +854,7 @@ true
 			<td id="otelAgent--image--tag"><a href="./values.yaml#L368">otelAgent.image.tag</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"0.109.0"
-</pre>
+				<div style="max-width: 300px;"><code>"0.109.0"</code>
 </div>
 			</td>
 			<td></td>
@@ -1009,10 +863,7 @@ true
 			<td id="otelAgent--image--pullPolicy"><a href="./values.yaml#L369">otelAgent.image.pullPolicy</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"IfNotPresent"
-</pre>
+				<div style="max-width: 300px;"><code>"IfNotPresent"</code>
 </div>
 			</td>
 			<td></td>
@@ -1021,10 +872,7 @@ true
 			<td id="otelAgent--imagePullSecrets"><a href="./values.yaml#L373">otelAgent.imagePullSecrets</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Image Registry Secret Names for OtelAgent. If global.imagePullSecrets is set as well, it will merged.</td>
@@ -1033,10 +881,7 @@ true
 			<td id="otelAgent--command--name"><a href="./values.yaml#L379">otelAgent.command.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"/otelcol-contrib"
-</pre>
+				<div style="max-width: 300px;"><code>"/otelcol-contrib"</code>
 </div>
 			</td>
 			<td>OtelAgent command name</td>
@@ -1045,10 +890,7 @@ true
 			<td id="otelAgent--command--extraArgs"><a href="./values.yaml#L381">otelAgent.command.extraArgs</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>OtelAgent command extra arguments</td>
@@ -1057,10 +899,7 @@ true
 			<td id="otelAgent--configMap--create"><a href="./values.yaml#L385">otelAgent.configMap.create</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Specifies whether a configMap should be created (true by default)</td>
@@ -1069,10 +908,7 @@ true
 			<td id="otelAgent--service--annotations"><a href="./values.yaml#L390">otelAgent.service.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Annotations to use by service associated to OtelAgent</td>
@@ -1081,10 +917,7 @@ true
 			<td id="otelAgent--service--type"><a href="./values.yaml#L392">otelAgent.service.type</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"ClusterIP"
-</pre>
+				<div style="max-width: 300px;"><code>"ClusterIP"</code>
 </div>
 			</td>
 			<td>Service Type: LoadBalancer (allows external access) or NodePort (more secure, no extra cost)</td>
@@ -1093,10 +926,7 @@ true
 			<td id="otelAgent--service--internalTrafficPolicy"><a href="./values.yaml#L395">otelAgent.service.internalTrafficPolicy</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"Local"
-</pre>
+				<div style="max-width: 300px;"><code>"Local"</code>
 </div>
 			</td>
 			<td></td>
@@ -1105,10 +935,7 @@ true
 			<td id="otelAgent--serviceAccount--create"><a href="./values.yaml#L399">otelAgent.serviceAccount.create</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td></td>
@@ -1117,10 +944,7 @@ true
 			<td id="otelAgent--serviceAccount--annotations"><a href="./values.yaml#L401">otelAgent.serviceAccount.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td></td>
@@ -1129,10 +953,7 @@ true
 			<td id="otelAgent--serviceAccount--name"><a href="./values.yaml#L404">otelAgent.serviceAccount.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td></td>
@@ -1141,10 +962,7 @@ null
 			<td id="otelAgent--annotations"><a href="./values.yaml#L407">otelAgent.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>OtelAgent daemonset annotation.</td>
@@ -1153,10 +971,7 @@ null
 			<td id="otelAgent--podAnnotations"><a href="./values.yaml#L409">otelAgent.podAnnotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>OtelAgent pod(s) annotation.</td>
@@ -1165,10 +980,7 @@ null
 			<td id="otelAgent--additionalEnvs"><a href="./values.yaml#L415">otelAgent.additionalEnvs</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Additional environments to set for OtelAgent</td>
@@ -1177,10 +989,7 @@ null
 			<td id="otelAgent--minReadySeconds"><a href="./values.yaml#L434">otelAgent.minReadySeconds</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-5
-</pre>
+				<div style="max-width: 300px;"><code>5</code>
 </div>
 			</td>
 			<td>Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available.</td>
@@ -1189,10 +998,7 @@ null
 			<td id="otelAgent--clusterRole--create"><a href="./values.yaml#L439">otelAgent.clusterRole.create</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Specifies whether a clusterRole should be created</td>
@@ -1201,10 +1007,7 @@ true
 			<td id="otelAgent--clusterRole--annotations"><a href="./values.yaml#L441">otelAgent.clusterRole.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Annotations to add to the clusterRole</td>
@@ -1213,10 +1016,7 @@ true
 			<td id="otelAgent--clusterRole--name"><a href="./values.yaml#L444">otelAgent.clusterRole.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>The name of the clusterRole to use. If not set and create is true, a name is generated using the fullname template</td>
@@ -1225,10 +1025,7 @@ true
 			<td id="otelAgent--clusterRole--rules"><a href="./values.yaml#L448">otelAgent.clusterRole.rules</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="">
-See `values.yaml` for defaults
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>A set of rules as documented here. ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/</td>
@@ -1237,10 +1034,7 @@ See `values.yaml` for defaults
 			<td id="otelAgent--clusterRole--clusterRoleBinding--annotations"><a href="./values.yaml#L480">otelAgent.clusterRole.clusterRoleBinding.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td></td>
@@ -1249,10 +1043,7 @@ See `values.yaml` for defaults
 			<td id="otelAgent--clusterRole--clusterRoleBinding--name"><a href="./values.yaml#L483">otelAgent.clusterRole.clusterRoleBinding.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td></td>
@@ -1261,10 +1052,7 @@ See `values.yaml` for defaults
 			<td id="otelAgent--ports--otlp--enabled"><a href="./values.yaml#L489">otelAgent.ports.otlp.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Whether to enable service port for OTLP gRPC</td>
@@ -1273,10 +1061,7 @@ true
 			<td id="otelAgent--ports--otlp--containerPort"><a href="./values.yaml#L491">otelAgent.ports.otlp.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-4317
-</pre>
+				<div style="max-width: 300px;"><code>4317</code>
 </div>
 			</td>
 			<td>Container port for OTLP gRPC</td>
@@ -1285,10 +1070,7 @@ true
 			<td id="otelAgent--ports--otlp--servicePort"><a href="./values.yaml#L493">otelAgent.ports.otlp.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-4317
-</pre>
+				<div style="max-width: 300px;"><code>4317</code>
 </div>
 			</td>
 			<td>Service port for OTLP gRPC</td>
@@ -1297,10 +1079,7 @@ true
 			<td id="otelAgent--ports--otlp--nodePort"><a href="./values.yaml#L495">otelAgent.ports.otlp.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for OTLP gRPC</td>
@@ -1309,10 +1088,7 @@ true
 			<td id="otelAgent--ports--otlp--hostPort"><a href="./values.yaml#L497">otelAgent.ports.otlp.hostPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-4317
-</pre>
+				<div style="max-width: 300px;"><code>4317</code>
 </div>
 			</td>
 			<td>Host port for OTLP gRPC</td>
@@ -1321,10 +1097,7 @@ true
 			<td id="otelAgent--ports--otlp--protocol"><a href="./values.yaml#L499">otelAgent.ports.otlp.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for OTLP gRPC</td>
@@ -1333,10 +1106,7 @@ true
 			<td id="otelAgent--ports--otlp-http--enabled"><a href="./values.yaml#L502">otelAgent.ports.otlp-http.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Whether to enable service port for OTLP HTTP</td>
@@ -1345,10 +1115,7 @@ true
 			<td id="otelAgent--ports--otlp-http--containerPort"><a href="./values.yaml#L504">otelAgent.ports.otlp-http.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-4318
-</pre>
+				<div style="max-width: 300px;"><code>4318</code>
 </div>
 			</td>
 			<td>Container port for OTLP HTTP</td>
@@ -1357,10 +1124,7 @@ true
 			<td id="otelAgent--ports--otlp-http--servicePort"><a href="./values.yaml#L506">otelAgent.ports.otlp-http.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-4318
-</pre>
+				<div style="max-width: 300px;"><code>4318</code>
 </div>
 			</td>
 			<td>Service port for OTLP HTTP</td>
@@ -1369,10 +1133,7 @@ true
 			<td id="otelAgent--ports--otlp-http--nodePort"><a href="./values.yaml#L508">otelAgent.ports.otlp-http.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for OTLP HTTP</td>
@@ -1381,10 +1142,7 @@ true
 			<td id="otelAgent--ports--otlp-http--hostPort"><a href="./values.yaml#L510">otelAgent.ports.otlp-http.hostPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-4318
-</pre>
+				<div style="max-width: 300px;"><code>4318</code>
 </div>
 			</td>
 			<td>Host port for OTLP HTTP</td>
@@ -1393,10 +1151,7 @@ true
 			<td id="otelAgent--ports--otlp-http--protocol"><a href="./values.yaml#L512">otelAgent.ports.otlp-http.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for OTLP HTTP</td>
@@ -1405,10 +1160,7 @@ true
 			<td id="otelAgent--ports--zipkin--enabled"><a href="./values.yaml#L515">otelAgent.ports.zipkin.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Whether to enable service port for Zipkin</td>
@@ -1417,10 +1169,7 @@ false
 			<td id="otelAgent--ports--zipkin--containerPort"><a href="./values.yaml#L517">otelAgent.ports.zipkin.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-9411
-</pre>
+				<div style="max-width: 300px;"><code>9411</code>
 </div>
 			</td>
 			<td>Container port for Zipkin</td>
@@ -1429,10 +1178,7 @@ false
 			<td id="otelAgent--ports--zipkin--servicePort"><a href="./values.yaml#L519">otelAgent.ports.zipkin.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-9411
-</pre>
+				<div style="max-width: 300px;"><code>9411</code>
 </div>
 			</td>
 			<td>Service port for Zipkin</td>
@@ -1441,10 +1187,7 @@ false
 			<td id="otelAgent--ports--zipkin--nodePort"><a href="./values.yaml#L521">otelAgent.ports.zipkin.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for Zipkin</td>
@@ -1453,10 +1196,7 @@ false
 			<td id="otelAgent--ports--zipkin--hostPort"><a href="./values.yaml#L523">otelAgent.ports.zipkin.hostPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-9411
-</pre>
+				<div style="max-width: 300px;"><code>9411</code>
 </div>
 			</td>
 			<td>Host port for Zipkin</td>
@@ -1465,10 +1205,7 @@ false
 			<td id="otelAgent--ports--zipkin--protocol"><a href="./values.yaml#L525">otelAgent.ports.zipkin.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for Zipkin</td>
@@ -1477,10 +1214,7 @@ false
 			<td id="otelAgent--ports--metrics--enabled"><a href="./values.yaml#L528">otelAgent.ports.metrics.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Whether to enable service port for internal metrics</td>
@@ -1489,10 +1223,7 @@ true
 			<td id="otelAgent--ports--metrics--containerPort"><a href="./values.yaml#L530">otelAgent.ports.metrics.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-8888
-</pre>
+				<div style="max-width: 300px;"><code>8888</code>
 </div>
 			</td>
 			<td>Container port for internal metrics</td>
@@ -1501,10 +1232,7 @@ true
 			<td id="otelAgent--ports--metrics--servicePort"><a href="./values.yaml#L532">otelAgent.ports.metrics.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-8888
-</pre>
+				<div style="max-width: 300px;"><code>8888</code>
 </div>
 			</td>
 			<td>Service port for internal metrics</td>
@@ -1513,10 +1241,7 @@ true
 			<td id="otelAgent--ports--metrics--nodePort"><a href="./values.yaml#L534">otelAgent.ports.metrics.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for internal metrics</td>
@@ -1525,10 +1250,7 @@ true
 			<td id="otelAgent--ports--metrics--hostPort"><a href="./values.yaml#L536">otelAgent.ports.metrics.hostPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-8888
-</pre>
+				<div style="max-width: 300px;"><code>8888</code>
 </div>
 			</td>
 			<td>Host port for internal metrics</td>
@@ -1537,10 +1259,7 @@ true
 			<td id="otelAgent--ports--metrics--protocol"><a href="./values.yaml#L538">otelAgent.ports.metrics.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for internal metrics</td>
@@ -1549,10 +1268,7 @@ true
 			<td id="otelAgent--ports--zpages--enabled"><a href="./values.yaml#L541">otelAgent.ports.zpages.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Whether to enable service port for ZPages</td>
@@ -1561,10 +1277,7 @@ false
 			<td id="otelAgent--ports--zpages--containerPort"><a href="./values.yaml#L543">otelAgent.ports.zpages.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-55679
-</pre>
+				<div style="max-width: 300px;"><code>55679</code>
 </div>
 			</td>
 			<td>Container port for Zpages</td>
@@ -1573,10 +1286,7 @@ false
 			<td id="otelAgent--ports--zpages--servicePort"><a href="./values.yaml#L545">otelAgent.ports.zpages.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-55679
-</pre>
+				<div style="max-width: 300px;"><code>55679</code>
 </div>
 			</td>
 			<td>Service port for Zpages</td>
@@ -1585,10 +1295,7 @@ false
 			<td id="otelAgent--ports--zpages--nodePort"><a href="./values.yaml#L547">otelAgent.ports.zpages.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for Zpages</td>
@@ -1597,10 +1304,7 @@ false
 			<td id="otelAgent--ports--zpages--hostPort"><a href="./values.yaml#L549">otelAgent.ports.zpages.hostPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-55679
-</pre>
+				<div style="max-width: 300px;"><code>55679</code>
 </div>
 			</td>
 			<td>Host port for Zpages</td>
@@ -1609,10 +1313,7 @@ false
 			<td id="otelAgent--ports--zpages--protocol"><a href="./values.yaml#L551">otelAgent.ports.zpages.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for Zpages</td>
@@ -1621,10 +1322,7 @@ false
 			<td id="otelAgent--ports--health-check--enabled"><a href="./values.yaml#L554">otelAgent.ports.health-check.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Whether to enable service port for health check</td>
@@ -1633,10 +1331,7 @@ true
 			<td id="otelAgent--ports--health-check--containerPort"><a href="./values.yaml#L556">otelAgent.ports.health-check.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-13133
-</pre>
+				<div style="max-width: 300px;"><code>13133</code>
 </div>
 			</td>
 			<td>Container port for health check</td>
@@ -1645,10 +1340,7 @@ true
 			<td id="otelAgent--ports--health-check--servicePort"><a href="./values.yaml#L558">otelAgent.ports.health-check.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-13133
-</pre>
+				<div style="max-width: 300px;"><code>13133</code>
 </div>
 			</td>
 			<td>Service port for health check</td>
@@ -1657,10 +1349,7 @@ true
 			<td id="otelAgent--ports--health-check--nodePort"><a href="./values.yaml#L560">otelAgent.ports.health-check.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for health check</td>
@@ -1669,10 +1358,7 @@ true
 			<td id="otelAgent--ports--health-check--hostPort"><a href="./values.yaml#L562">otelAgent.ports.health-check.hostPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-13133
-</pre>
+				<div style="max-width: 300px;"><code>13133</code>
 </div>
 			</td>
 			<td>Host port for health check</td>
@@ -1681,10 +1367,7 @@ true
 			<td id="otelAgent--ports--health-check--protocol"><a href="./values.yaml#L564">otelAgent.ports.health-check.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for health check</td>
@@ -1693,10 +1376,7 @@ true
 			<td id="otelAgent--ports--pprof--enabled"><a href="./values.yaml#L567">otelAgent.ports.pprof.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Whether to enable service port for pprof</td>
@@ -1705,10 +1385,7 @@ false
 			<td id="otelAgent--ports--pprof--containerPort"><a href="./values.yaml#L569">otelAgent.ports.pprof.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1777
-</pre>
+				<div style="max-width: 300px;"><code>1777</code>
 </div>
 			</td>
 			<td>Container port for pprof</td>
@@ -1717,10 +1394,7 @@ false
 			<td id="otelAgent--ports--pprof--servicePort"><a href="./values.yaml#L571">otelAgent.ports.pprof.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1777
-</pre>
+				<div style="max-width: 300px;"><code>1777</code>
 </div>
 			</td>
 			<td>Service port for pprof</td>
@@ -1729,10 +1403,7 @@ false
 			<td id="otelAgent--ports--pprof--nodePort"><a href="./values.yaml#L573">otelAgent.ports.pprof.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for pprof</td>
@@ -1741,10 +1412,7 @@ false
 			<td id="otelAgent--ports--pprof--hostPort"><a href="./values.yaml#L575">otelAgent.ports.pprof.hostPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1777
-</pre>
+				<div style="max-width: 300px;"><code>1777</code>
 </div>
 			</td>
 			<td>Host port for pprof</td>
@@ -1753,10 +1421,7 @@ false
 			<td id="otelAgent--ports--pprof--protocol"><a href="./values.yaml#L577">otelAgent.ports.pprof.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for pprof</td>
@@ -1765,9 +1430,7 @@ false
 			<td id="otelAgent--livenessProbe"><a href="./values.yaml#L581">otelAgent.livenessProbe</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{
+				<div style="max-width: 300px;"><code>{
   "enabled": true,
   "failureThreshold": 6,
   "initialDelaySeconds": 10,
@@ -1776,8 +1439,7 @@ false
   "port": 13133,
   "successThreshold": 1,
   "timeoutSeconds": 5
-}
-</pre>
+}</code>
 </div>
 			</td>
 			<td>Configure liveness probe. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command</td>
@@ -1786,9 +1448,7 @@ false
 			<td id="otelAgent--readinessProbe"><a href="./values.yaml#L593">otelAgent.readinessProbe</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{
+				<div style="max-width: 300px;"><code>{
   "enabled": true,
   "failureThreshold": 6,
   "initialDelaySeconds": 10,
@@ -1797,8 +1457,7 @@ false
   "port": 13133,
   "successThreshold": 1,
   "timeoutSeconds": 5
-}
-</pre>
+}</code>
 </div>
 			</td>
 			<td>Configure readiness probe. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes</td>
@@ -1807,10 +1466,7 @@ false
 			<td id="otelAgent--customLivenessProbe"><a href="./values.yaml#L604">otelAgent.customLivenessProbe</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Custom liveness probe</td>
@@ -1819,10 +1475,7 @@ false
 			<td id="otelAgent--customReadinessProbe"><a href="./values.yaml#L606">otelAgent.customReadinessProbe</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Custom readiness probe</td>
@@ -1831,10 +1484,7 @@ false
 			<td id="otelAgent--ingress--enabled"><a href="./values.yaml#L610">otelAgent.ingress.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Enable ingress for OtelAgent</td>
@@ -1843,10 +1493,7 @@ false
 			<td id="otelAgent--ingress--className"><a href="./values.yaml#L612">otelAgent.ingress.className</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Ingress Class Name to be used to identify ingress controllers</td>
@@ -1855,10 +1502,7 @@ false
 			<td id="otelAgent--ingress--annotations"><a href="./values.yaml#L614">otelAgent.ingress.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Annotations to OtelAgent Ingress</td>
@@ -1867,9 +1511,7 @@ false
 			<td id="otelAgent--ingress--hosts"><a href="./values.yaml#L621">otelAgent.ingress.hosts</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[
+				<div style="max-width: 300px;"><code>[
   {
     "host": "otel-agent.domain.com",
     "paths": [
@@ -1880,8 +1522,7 @@ false
       }
     ]
   }
-]
-</pre>
+]</code>
 </div>
 			</td>
 			<td>OtelAgent Ingress Host names with their path details</td>
@@ -1890,10 +1531,7 @@ false
 			<td id="otelAgent--ingress--tls"><a href="./values.yaml#L628">otelAgent.ingress.tls</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>OtelAgent Ingress TLS</td>
@@ -1902,10 +1540,7 @@ false
 			<td id="otelAgent--resources"><a href="./values.yaml#L637">otelAgent.resources</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="">
-See `values.yaml` for defaults
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Configure resource requests and limits. Update according to your own use case as these values might not be suitable for your workload. ref: http://kubernetes.io/docs/user-guide/compute-resources/</td>
@@ -1914,10 +1549,7 @@ See `values.yaml` for defaults
 			<td id="otelAgent--priorityClassName"><a href="./values.yaml#L646">otelAgent.priorityClassName</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>OtelAgent priority class name</td>
@@ -1926,10 +1558,7 @@ See `values.yaml` for defaults
 			<td id="otelAgent--nodeSelector"><a href="./values.yaml#L649">otelAgent.nodeSelector</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>OtelAgent node selector</td>
@@ -1938,14 +1567,11 @@ See `values.yaml` for defaults
 			<td id="otelAgent--tolerations"><a href="./values.yaml#L652">otelAgent.tolerations</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[
+				<div style="max-width: 300px;"><code>[
   {
     "operator": "Exists"
   }
-]
-</pre>
+]</code>
 </div>
 			</td>
 			<td>Toleration labels for OtelAgent pod assignment</td>
@@ -1954,10 +1580,7 @@ See `values.yaml` for defaults
 			<td id="otelAgent--affinity"><a href="./values.yaml#L656">otelAgent.affinity</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Affinity settings for OtelAgent pod</td>
@@ -1966,10 +1589,7 @@ See `values.yaml` for defaults
 			<td id="otelAgent--podSecurityContext"><a href="./values.yaml#L659">otelAgent.podSecurityContext</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Pod-level security configuration</td>
@@ -1978,10 +1598,7 @@ See `values.yaml` for defaults
 			<td id="otelAgent--securityContext"><a href="./values.yaml#L663">otelAgent.securityContext</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Container security configuration</td>
@@ -1990,10 +1607,7 @@ See `values.yaml` for defaults
 			<td id="otelAgent--config"><a href="./values.yaml#L673">otelAgent.config</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="">
-See `values.yaml` for defaults
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Configurations for OtelAgent</td>
@@ -2002,10 +1616,7 @@ See `values.yaml` for defaults
 			<td id="otelAgent--extraVolumes"><a href="./values.yaml#L722">otelAgent.extraVolumes</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Additional volumes for otelAgent</td>
@@ -2014,10 +1625,7 @@ See `values.yaml` for defaults
 			<td id="otelAgent--extraVolumeMounts"><a href="./values.yaml#L731">otelAgent.extraVolumeMounts</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Additional volume mounts for otelAgent</td>
@@ -2026,10 +1634,7 @@ See `values.yaml` for defaults
 			<td id="otelDeployment--enabled"><a href="./values.yaml#L740">otelDeployment.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td></td>
@@ -2038,10 +1643,7 @@ true
 			<td id="otelDeployment--name"><a href="./values.yaml#L741">otelDeployment.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"otel-deployment"
-</pre>
+				<div style="max-width: 300px;"><code>"otel-deployment"</code>
 </div>
 			</td>
 			<td></td>
@@ -2050,10 +1652,7 @@ true
 			<td id="otelDeployment--image--registry"><a href="./values.yaml#L743">otelDeployment.image.registry</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"docker.io"
-</pre>
+				<div style="max-width: 300px;"><code>"docker.io"</code>
 </div>
 			</td>
 			<td></td>
@@ -2062,10 +1661,7 @@ true
 			<td id="otelDeployment--image--repository"><a href="./values.yaml#L744">otelDeployment.image.repository</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"otel/opentelemetry-collector-contrib"
-</pre>
+				<div style="max-width: 300px;"><code>"otel/opentelemetry-collector-contrib"</code>
 </div>
 			</td>
 			<td></td>
@@ -2074,10 +1670,7 @@ true
 			<td id="otelDeployment--image--tag"><a href="./values.yaml#L745">otelDeployment.image.tag</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"0.109.0"
-</pre>
+				<div style="max-width: 300px;"><code>"0.109.0"</code>
 </div>
 			</td>
 			<td></td>
@@ -2086,10 +1679,7 @@ true
 			<td id="otelDeployment--image--pullPolicy"><a href="./values.yaml#L746">otelDeployment.image.pullPolicy</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"IfNotPresent"
-</pre>
+				<div style="max-width: 300px;"><code>"IfNotPresent"</code>
 </div>
 			</td>
 			<td></td>
@@ -2098,10 +1688,7 @@ true
 			<td id="otelDeployment--imagePullSecrets"><a href="./values.yaml#L750">otelDeployment.imagePullSecrets</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Image Registry Secret Names for OtelDeployment. If global.imagePullSecrets is set as well, it will merged.</td>
@@ -2110,10 +1697,7 @@ true
 			<td id="otelDeployment--command--name"><a href="./values.yaml#L756">otelDeployment.command.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"/otelcol-contrib"
-</pre>
+				<div style="max-width: 300px;"><code>"/otelcol-contrib"</code>
 </div>
 			</td>
 			<td>OtelDeployment command name</td>
@@ -2122,10 +1706,7 @@ true
 			<td id="otelDeployment--command--extraArgs"><a href="./values.yaml#L758">otelDeployment.command.extraArgs</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>OtelDeployment command extra arguments</td>
@@ -2134,10 +1715,7 @@ true
 			<td id="otelDeployment--configMap--create"><a href="./values.yaml#L762">otelDeployment.configMap.create</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Specifies whether a configMap should be created (true by default)</td>
@@ -2146,10 +1724,7 @@ true
 			<td id="otelDeployment--service--annotations"><a href="./values.yaml#L767">otelDeployment.service.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Annotations to use by service associated to OtelDeployment</td>
@@ -2158,10 +1733,7 @@ true
 			<td id="otelDeployment--service--type"><a href="./values.yaml#L769">otelDeployment.service.type</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"ClusterIP"
-</pre>
+				<div style="max-width: 300px;"><code>"ClusterIP"</code>
 </div>
 			</td>
 			<td>Service Type: LoadBalancer (allows external access) or NodePort (more secure, no extra cost)</td>
@@ -2170,10 +1742,7 @@ true
 			<td id="otelDeployment--serviceAccount--create"><a href="./values.yaml#L773">otelDeployment.serviceAccount.create</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td></td>
@@ -2182,10 +1751,7 @@ true
 			<td id="otelDeployment--serviceAccount--annotations"><a href="./values.yaml#L775">otelDeployment.serviceAccount.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td></td>
@@ -2194,10 +1760,7 @@ true
 			<td id="otelDeployment--serviceAccount--name"><a href="./values.yaml#L778">otelDeployment.serviceAccount.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td></td>
@@ -2206,10 +1769,7 @@ null
 			<td id="otelDeployment--annotations"><a href="./values.yaml#L781">otelDeployment.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>OtelDeployment deployment annotation.</td>
@@ -2218,10 +1778,7 @@ null
 			<td id="otelDeployment--podAnnotations"><a href="./values.yaml#L783">otelDeployment.podAnnotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>OtelDeployment pod(s) annotation.</td>
@@ -2230,10 +1787,7 @@ null
 			<td id="otelDeployment--additionalEnvs"><a href="./values.yaml#L789">otelDeployment.additionalEnvs</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Additional environments to set for OtelDeployment</td>
@@ -2242,10 +1796,7 @@ null
 			<td id="otelDeployment--podSecurityContext"><a href="./values.yaml#L807">otelDeployment.podSecurityContext</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Pod-level security configuration</td>
@@ -2254,10 +1805,7 @@ null
 			<td id="otelDeployment--securityContext"><a href="./values.yaml#L811">otelDeployment.securityContext</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Container security configuration</td>
@@ -2266,10 +1814,7 @@ null
 			<td id="otelDeployment--minReadySeconds"><a href="./values.yaml#L821">otelDeployment.minReadySeconds</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-5
-</pre>
+				<div style="max-width: 300px;"><code>5</code>
 </div>
 			</td>
 			<td>Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available.</td>
@@ -2278,10 +1823,7 @@ null
 			<td id="otelDeployment--progressDeadlineSeconds"><a href="./values.yaml#L825">otelDeployment.progressDeadlineSeconds</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-120
-</pre>
+				<div style="max-width: 300px;"><code>120</code>
 </div>
 			</td>
 			<td>Number of seconds to wait for the OtelDeployment to progress before the system reports back that the OtelDeployment has failed.</td>
@@ -2290,10 +1832,7 @@ null
 			<td id="otelDeployment--ports--metrics--enabled"><a href="./values.yaml#L831">otelDeployment.ports.metrics.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Whether to enable service port for internal metrics</td>
@@ -2302,10 +1841,7 @@ false
 			<td id="otelDeployment--ports--metrics--containerPort"><a href="./values.yaml#L833">otelDeployment.ports.metrics.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-8888
-</pre>
+				<div style="max-width: 300px;"><code>8888</code>
 </div>
 			</td>
 			<td>Container port for internal metrics</td>
@@ -2314,10 +1850,7 @@ false
 			<td id="otelDeployment--ports--metrics--servicePort"><a href="./values.yaml#L835">otelDeployment.ports.metrics.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-8888
-</pre>
+				<div style="max-width: 300px;"><code>8888</code>
 </div>
 			</td>
 			<td>Service port for internal metrics</td>
@@ -2326,10 +1859,7 @@ false
 			<td id="otelDeployment--ports--metrics--nodePort"><a href="./values.yaml#L837">otelDeployment.ports.metrics.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for internal metrics</td>
@@ -2338,10 +1868,7 @@ false
 			<td id="otelDeployment--ports--metrics--protocol"><a href="./values.yaml#L839">otelDeployment.ports.metrics.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for internal metrics</td>
@@ -2350,10 +1877,7 @@ false
 			<td id="otelDeployment--ports--zpages--enabled"><a href="./values.yaml#L842">otelDeployment.ports.zpages.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Whether to enable service port for ZPages</td>
@@ -2362,10 +1886,7 @@ false
 			<td id="otelDeployment--ports--zpages--containerPort"><a href="./values.yaml#L844">otelDeployment.ports.zpages.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-55679
-</pre>
+				<div style="max-width: 300px;"><code>55679</code>
 </div>
 			</td>
 			<td>Container port for Zpages</td>
@@ -2374,10 +1895,7 @@ false
 			<td id="otelDeployment--ports--zpages--servicePort"><a href="./values.yaml#L846">otelDeployment.ports.zpages.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-55679
-</pre>
+				<div style="max-width: 300px;"><code>55679</code>
 </div>
 			</td>
 			<td>Service port for Zpages</td>
@@ -2386,10 +1904,7 @@ false
 			<td id="otelDeployment--ports--zpages--nodePort"><a href="./values.yaml#L848">otelDeployment.ports.zpages.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for Zpages</td>
@@ -2398,10 +1913,7 @@ false
 			<td id="otelDeployment--ports--zpages--protocol"><a href="./values.yaml#L850">otelDeployment.ports.zpages.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for Zpages</td>
@@ -2410,10 +1922,7 @@ false
 			<td id="otelDeployment--ports--health-check--enabled"><a href="./values.yaml#L853">otelDeployment.ports.health-check.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Whether to enable service port for health check</td>
@@ -2422,10 +1931,7 @@ true
 			<td id="otelDeployment--ports--health-check--containerPort"><a href="./values.yaml#L855">otelDeployment.ports.health-check.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-13133
-</pre>
+				<div style="max-width: 300px;"><code>13133</code>
 </div>
 			</td>
 			<td>Container port for health check</td>
@@ -2434,10 +1940,7 @@ true
 			<td id="otelDeployment--ports--health-check--servicePort"><a href="./values.yaml#L857">otelDeployment.ports.health-check.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-13133
-</pre>
+				<div style="max-width: 300px;"><code>13133</code>
 </div>
 			</td>
 			<td>Service port for health check</td>
@@ -2446,10 +1949,7 @@ true
 			<td id="otelDeployment--ports--health-check--nodePort"><a href="./values.yaml#L859">otelDeployment.ports.health-check.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for health check</td>
@@ -2458,10 +1958,7 @@ true
 			<td id="otelDeployment--ports--health-check--protocol"><a href="./values.yaml#L861">otelDeployment.ports.health-check.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for health check</td>
@@ -2470,10 +1967,7 @@ true
 			<td id="otelDeployment--ports--pprof--enabled"><a href="./values.yaml#L864">otelDeployment.ports.pprof.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Whether to enable service port for pprof</td>
@@ -2482,10 +1976,7 @@ false
 			<td id="otelDeployment--ports--pprof--containerPort"><a href="./values.yaml#L866">otelDeployment.ports.pprof.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1777
-</pre>
+				<div style="max-width: 300px;"><code>1777</code>
 </div>
 			</td>
 			<td>Container port for pprof</td>
@@ -2494,10 +1985,7 @@ false
 			<td id="otelDeployment--ports--pprof--servicePort"><a href="./values.yaml#L868">otelDeployment.ports.pprof.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1777
-</pre>
+				<div style="max-width: 300px;"><code>1777</code>
 </div>
 			</td>
 			<td>Service port for pprof</td>
@@ -2506,10 +1994,7 @@ false
 			<td id="otelDeployment--ports--pprof--nodePort"><a href="./values.yaml#L870">otelDeployment.ports.pprof.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for pprof</td>
@@ -2518,10 +2003,7 @@ false
 			<td id="otelDeployment--ports--pprof--protocol"><a href="./values.yaml#L872">otelDeployment.ports.pprof.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for pprof</td>
@@ -2530,9 +2012,7 @@ false
 			<td id="otelDeployment--livenessProbe"><a href="./values.yaml#L876">otelDeployment.livenessProbe</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{
+				<div style="max-width: 300px;"><code>{
   "enabled": true,
   "failureThreshold": 6,
   "initialDelaySeconds": 10,
@@ -2541,8 +2021,7 @@ false
   "port": 13133,
   "successThreshold": 1,
   "timeoutSeconds": 5
-}
-</pre>
+}</code>
 </div>
 			</td>
 			<td>Configure liveness probe. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command</td>
@@ -2551,9 +2030,7 @@ false
 			<td id="otelDeployment--readinessProbe"><a href="./values.yaml#L888">otelDeployment.readinessProbe</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{
+				<div style="max-width: 300px;"><code>{
   "enabled": true,
   "failureThreshold": 6,
   "initialDelaySeconds": 10,
@@ -2562,8 +2039,7 @@ false
   "port": 13133,
   "successThreshold": 1,
   "timeoutSeconds": 5
-}
-</pre>
+}</code>
 </div>
 			</td>
 			<td>Configure readiness probe. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes</td>
@@ -2572,10 +2048,7 @@ false
 			<td id="otelDeployment--customLivenessProbe"><a href="./values.yaml#L899">otelDeployment.customLivenessProbe</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Custom liveness probe</td>
@@ -2584,10 +2057,7 @@ false
 			<td id="otelDeployment--customReadinessProbe"><a href="./values.yaml#L902">otelDeployment.customReadinessProbe</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Custom readiness probe</td>
@@ -2596,10 +2066,7 @@ false
 			<td id="otelDeployment--ingress--enabled"><a href="./values.yaml#L906">otelDeployment.ingress.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Enable ingress for OtelDeployment</td>
@@ -2608,10 +2075,7 @@ false
 			<td id="otelDeployment--ingress--className"><a href="./values.yaml#L908">otelDeployment.ingress.className</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Ingress Class Name to be used to identify ingress controllers</td>
@@ -2620,10 +2084,7 @@ false
 			<td id="otelDeployment--ingress--annotations"><a href="./values.yaml#L910">otelDeployment.ingress.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Annotations to OtelDeployment Ingress</td>
@@ -2632,9 +2093,7 @@ false
 			<td id="otelDeployment--ingress--hosts"><a href="./values.yaml#L917">otelDeployment.ingress.hosts</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[
+				<div style="max-width: 300px;"><code>[
   {
     "host": "otel-deployment.domain.com",
     "paths": [
@@ -2645,8 +2104,7 @@ false
       }
     ]
   }
-]
-</pre>
+]</code>
 </div>
 			</td>
 			<td>OtelDeployment Ingress Host names with their path details</td>
@@ -2655,10 +2113,7 @@ false
 			<td id="otelDeployment--ingress--tls"><a href="./values.yaml#L924">otelDeployment.ingress.tls</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>OtelDeployment Ingress TLS</td>
@@ -2667,10 +2122,7 @@ false
 			<td id="otelDeployment--resources"><a href="./values.yaml#L933">otelDeployment.resources</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="">
-See `values.yaml` for defaults
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Configure resource requests and limits. Update according to your own use case as these values might not be suitable for your workload. ref: http://kubernetes.io/docs/user-guide/compute-resources/</td>
@@ -2679,10 +2131,7 @@ See `values.yaml` for defaults
 			<td id="otelDeployment--priorityClassName"><a href="./values.yaml#L942">otelDeployment.priorityClassName</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>OtelDeployment priority class name</td>
@@ -2691,10 +2140,7 @@ See `values.yaml` for defaults
 			<td id="otelDeployment--nodeSelector"><a href="./values.yaml#L945">otelDeployment.nodeSelector</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>OtelDeployment node selector</td>
@@ -2703,10 +2149,7 @@ See `values.yaml` for defaults
 			<td id="otelDeployment--tolerations"><a href="./values.yaml#L948">otelDeployment.tolerations</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Toleration labels for OtelDeployment pod assignment</td>
@@ -2715,10 +2158,7 @@ See `values.yaml` for defaults
 			<td id="otelDeployment--affinity"><a href="./values.yaml#L951">otelDeployment.affinity</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Affinity settings for OtelDeployment pod</td>
@@ -2727,10 +2167,7 @@ See `values.yaml` for defaults
 			<td id="otelDeployment--topologySpreadConstraints"><a href="./values.yaml#L954">otelDeployment.topologySpreadConstraints</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>TopologySpreadConstraints describes how OtelDeployment pods ought to spread</td>
@@ -2739,10 +2176,7 @@ See `values.yaml` for defaults
 			<td id="otelDeployment--clusterRole--create"><a href="./values.yaml#L959">otelDeployment.clusterRole.create</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Specifies whether a clusterRole should be created</td>
@@ -2751,10 +2185,7 @@ true
 			<td id="otelDeployment--clusterRole--annotations"><a href="./values.yaml#L961">otelDeployment.clusterRole.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Annotations to add to the clusterRole</td>
@@ -2763,10 +2194,7 @@ true
 			<td id="otelDeployment--clusterRole--name"><a href="./values.yaml#L964">otelDeployment.clusterRole.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>The name of the clusterRole to use. If not set and create is true, a name is generated using the fullname template</td>
@@ -2775,10 +2203,7 @@ true
 			<td id="otelDeployment--clusterRole--rules"><a href="./values.yaml#L968">otelDeployment.clusterRole.rules</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="">
-See `values.yaml` for defaults
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>A set of rules as documented here. ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/</td>
@@ -2787,10 +2212,7 @@ See `values.yaml` for defaults
 			<td id="otelDeployment--clusterRole--clusterRoleBinding--annotations"><a href="./values.yaml#L999">otelDeployment.clusterRole.clusterRoleBinding.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Annotations to add to the clusterRoleBinding</td>
@@ -2799,10 +2221,7 @@ See `values.yaml` for defaults
 			<td id="otelDeployment--clusterRole--clusterRoleBinding--name"><a href="./values.yaml#L1002">otelDeployment.clusterRole.clusterRoleBinding.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>The name of the clusterRoleBinding to use. If not set and create is true, a name is generated using the fullname template</td>
@@ -2811,10 +2230,7 @@ See `values.yaml` for defaults
 			<td id="otelDeployment--config"><a href="./values.yaml#L1006">otelDeployment.config</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="">
-See `values.yaml` for defaults
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Configurations for OtelDeployment</td>
@@ -2823,10 +2239,7 @@ See `values.yaml` for defaults
 			<td id="otelDeployment--extraVolumes"><a href="./values.yaml#L1048">otelDeployment.extraVolumes</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Additional volumes for otelDeployment</td>
@@ -2835,10 +2248,7 @@ See `values.yaml` for defaults
 			<td id="otelDeployment--extraVolumeMounts"><a href="./values.yaml#L1057">otelDeployment.extraVolumeMounts</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Additional volume mounts for otelDeployment</td>

--- a/charts/k8s-infra/README.md
+++ b/charts/k8s-infra/README.md
@@ -1,0 +1,2847 @@
+
+# SigNoz
+
+![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.109.0](https://img.shields.io/badge/AppVersion-0.109.0-informational?style=flat-square)
+
+SigNoz is an open-source APM. It helps developers monitor their applications & troubleshoot problems,
+an open-source alternative to DataDog, NewRelic, etc. Open source Application Performance Monitoring (APM)
+& Observability tool.
+
+### TL;DR;
+
+```sh
+helm repo add signoz https://charts.signoz.io
+helm install -n platform --create-namespace "my-release" signoz/k8s-infra
+```
+
+### Introduction
+
+This chart bootstraps [SigNoz](https://signoz.io) cluster deployment on a
+Kubernetes cluster using [Helm](https://helm.sh) package manager.
+
+### Prerequisites
+
+- Kubernetes 1.16+
+- Helm 3.0+
+
+### Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+helm repo add signoz https://charts.signoz.io
+helm -n platform --create-namespace install "my-release" signoz/k8s-infra
+```
+
+These commands deploy SigNoz on the Kubernetes cluster in the default configuration.
+The [Configuration](#configuration) section lists the parameters that can be configured during installation:
+
+> **Tip**: List all releases using `helm list`
+
+### Uninstalling the chart
+
+To uninstall/delete the `my-release` resources:
+
+```bash
+helm -n platform uninstall "my-release"
+```
+
+See the [Helm docs](https://helm.sh/docs/helm/helm_uninstall/) for documentation on the helm uninstall command.
+
+The command above removes all the Kubernetes components associated
+with the chart and deletes the release.
+
+Deletion of the StatefulSet doesn't cascade to deleting associated PVCs. To delete them:
+
+```bash
+kubectl -n platform delete pvc --selector app.kubernetes.io/instance=my-release
+```
+
+Sometimes everything doesn't get properly removed. If that happens try deleting the namespace:
+
+```bash
+kubectl delete namespace platform
+```
+
+## Values
+
+<table height="400px" >
+	<thead>
+		<th>Key</th>
+		<th>Type</th>
+		<th>Default</th>
+		<th>Description</th>
+	</thead>
+	<tbody>
+		<tr>
+			<td id="global--imageRegistry"><a href="./values.yaml#L4">global.imageRegistry</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td>Overrides the Docker registry globally for all images</td>
+		</tr>
+		<tr>
+			<td id="global--imagePullSecrets"><a href="./values.yaml#L6">global.imagePullSecrets</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Global Image Pull Secrets</td>
+		</tr>
+		<tr>
+			<td id="global--storageClass"><a href="./values.yaml#L8">global.storageClass</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td>Overrides the storage class for all PVC with persistence enabled.</td>
+		</tr>
+		<tr>
+			<td id="global--clusterDomain"><a href="./values.yaml#L11">global.clusterDomain</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"cluster.local"
+</pre>
+</div>
+			</td>
+			<td>Kubernetes cluster domain It is used only when components are installed in different namespace</td>
+		</tr>
+		<tr>
+			<td id="global--clusterName"><a href="./values.yaml#L14">global.clusterName</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Kubernetes cluster name It is used to attached to telemetry data via resource detection processor</td>
+		</tr>
+		<tr>
+			<td id="global--deploymentEnvironment"><a href="./values.yaml#L16">global.deploymentEnvironment</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Deployment environment to be attached to telemetry data</td>
+		</tr>
+		<tr>
+			<td id="global--cloud"><a href="./values.yaml#L19">global.cloud</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"other"
+</pre>
+</div>
+			</td>
+			<td>Kubernetes cluster cloud provider along with distribution if any. example: `aws`, `azure`, `gcp`, `gcp/autogke`, `azure`, and `other`</td>
+		</tr>
+		<tr>
+			<td id="nameOverride"><a href="./values.yaml#L22">nameOverride</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>K8s infra chart name override</td>
+		</tr>
+		<tr>
+			<td id="fullnameOverride"><a href="./values.yaml#L25">fullnameOverride</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>K8s infra chart full name override</td>
+		</tr>
+		<tr>
+			<td id="enabled"><a href="./values.yaml#L28">enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Whether to enable K8s infra chart</td>
+		</tr>
+		<tr>
+			<td id="clusterName"><a href="./values.yaml#L31">clusterName</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Name of the K8s cluster. Used by OtelCollectors to attach in telemetry data.</td>
+		</tr>
+		<tr>
+			<td id="otelCollectorEndpoint"><a href="./values.yaml#L38">otelCollectorEndpoint</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td>Endpoint/IP Address of the SigNoz or any other OpenTelemetry backend. Set it to `ingest.signoz.io:4317` for SigNoz SaaS.  If set to null and the chart is installed as dependency, it will attempt to autogenerate the endpoint of SigNoz OtelCollector.</td>
+		</tr>
+		<tr>
+			<td id="otelInsecure"><a href="./values.yaml#L42">otelInsecure</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Whether the OTLP endpoint is insecure. Set this to false, in case of secure OTLP endpoint.</td>
+		</tr>
+		<tr>
+			<td id="insecureSkipVerify"><a href="./values.yaml#L45">insecureSkipVerify</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Whether to skip verifying the certificate.</td>
+		</tr>
+		<tr>
+			<td id="signozApiKey"><a href="./values.yaml#L48">signozApiKey</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>API key of SigNoz SaaS</td>
+		</tr>
+		<tr>
+			<td id="apiKeyExistingSecretName"><a href="./values.yaml#L50">apiKeyExistingSecretName</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Existing secret name to be used for API key.</td>
+		</tr>
+		<tr>
+			<td id="apiKeyExistingSecretKey"><a href="./values.yaml#L52">apiKeyExistingSecretKey</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Existing secret key to be used for API key.</td>
+		</tr>
+		<tr>
+			<td id="otelTlsSecrets--enabled"><a href="./values.yaml#L57">otelTlsSecrets.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Whether to enable OpenTelemetry OTLP secrets</td>
+		</tr>
+		<tr>
+			<td id="otelTlsSecrets--path"><a href="./values.yaml#L60">otelTlsSecrets.path</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"/secrets"
+</pre>
+</div>
+			</td>
+			<td>Path for the secrets volume</td>
+		</tr>
+		<tr>
+			<td id="otelTlsSecrets--existingSecretName"><a href="./values.yaml#L64">otelTlsSecrets.existingSecretName</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td>Name of the existing secret with TLS certificate, key and CA to be used. Files in the secret must be named `cert.pem`, `key.pem` and `ca.pem`.</td>
+		</tr>
+		<tr>
+			<td id="otelTlsSecrets--certificate"><a href="./values.yaml#L67">otelTlsSecrets.certificate</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"\u003cINCLUDE_CERTIFICATE_HERE\u003e\n"
+</pre>
+</div>
+			</td>
+			<td>TLS certificate to be included in the secret</td>
+		</tr>
+		<tr>
+			<td id="otelTlsSecrets--key"><a href="./values.yaml#L71">otelTlsSecrets.key</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"\u003cINCLUDE_PRIVATE_KEY_HERE\u003e\n"
+</pre>
+</div>
+			</td>
+			<td>TLS private key to be included in the secret</td>
+		</tr>
+		<tr>
+			<td id="otelTlsSecrets--ca"><a href="./values.yaml#L75">otelTlsSecrets.ca</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>TLS certificate authority (CA) certificate to be included in the secret</td>
+		</tr>
+		<tr>
+			<td id="namespace"><a href="./values.yaml#L79">namespace</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Which namespace to install k8s-infra components. By default installed to the namespace same as the chart.</td>
+		</tr>
+		<tr>
+			<td id="presets"><a href="./values.yaml#L82">presets</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{
+  "clusterMetrics": {
+    "allocatableTypesToReport": [
+      "cpu",
+      "memory"
+    ],
+    "collectionInterval": "30s",
+    "enabled": true,
+    "metrics": {
+      "k8s.node.condition": {
+        "enabled": true
+      },
+      "k8s.pod.status_reason": {
+        "enabled": true
+      }
+    },
+    "nodeConditionsToReport": [
+      "Ready",
+      "MemoryPressure",
+      "DiskPressure",
+      "PIDPressure",
+      "NetworkUnavailable"
+    ],
+    "resourceAttributes": {
+      "container.runtime": {
+        "enabled": true
+      },
+      "container.runtime.version": {
+        "enabled": true
+      },
+      "k8s.container.status.last_terminated_reason": {
+        "enabled": true
+      },
+      "k8s.kubelet.version": {
+        "enabled": true
+      },
+      "k8s.pod.qos_class": {
+        "enabled": true
+      }
+    }
+  },
+  "hostMetrics": {
+    "collectionInterval": "30s",
+    "enabled": true,
+    "scrapers": {
+      "cpu": {},
+      "disk": {
+        "exclude": {
+          "devices": [
+            "^ram\\d+$",
+            "^zram\\d+$",
+            "^loop\\d+$",
+            "^fd\\d+$",
+            "^hd[a-z]\\d+$",
+            "^sd[a-z]\\d+$",
+            "^vd[a-z]\\d+$",
+            "^xvd[a-z]\\d+$",
+            "^nvme\\d+n\\d+p\\d+$"
+          ],
+          "match_type": "regexp"
+        }
+      },
+      "filesystem": {
+        "exclude_fs_types": {
+          "fs_types": [
+            "autofs",
+            "binfmt_misc",
+            "bpf",
+            "cgroup2?",
+            "configfs",
+            "debugfs",
+            "devpts",
+            "devtmpfs",
+            "fusectl",
+            "hugetlbfs",
+            "iso9660",
+            "mqueue",
+            "nsfs",
+            "overlay",
+            "proc",
+            "procfs",
+            "pstore",
+            "rpc_pipefs",
+            "securityfs",
+            "selinuxfs",
+            "squashfs",
+            "sysfs",
+            "tracefs"
+          ],
+          "match_type": "strict"
+        },
+        "exclude_mount_points": {
+          "match_type": "regexp",
+          "mount_points": [
+            "/dev/*",
+            "/proc/*",
+            "/sys/*",
+            "/run/credentials/*",
+            "/run/k3s/containerd/*",
+            "/var/lib/docker/*",
+            "/var/lib/containers/storage/*",
+            "/var/lib/kubelet/*",
+            "/snap/*"
+          ]
+        }
+      },
+      "load": {},
+      "memory": {},
+      "network": {
+        "exclude": {
+          "interfaces": [
+            "^veth.*$",
+            "^docker.*$",
+            "^br-.*$",
+            "^flannel.*$",
+            "^cali.*$",
+            "^cbr.*$",
+            "^cni.*$",
+            "^dummy.*$",
+            "^tailscale.*$",
+            "^lo$"
+          ],
+          "match_type": "regexp"
+        }
+      }
+    }
+  },
+  "k8sEvents": {
+    "authType": "serviceAccount",
+    "enabled": true,
+    "namespaces": []
+  },
+  "kubeletMetrics": {
+    "authType": "serviceAccount",
+    "collectionInterval": "30s",
+    "enabled": true,
+    "endpoint": "${env:K8S_HOST_IP}:10250",
+    "extraMetadataLabels": [
+      "container.id",
+      "k8s.volume.type"
+    ],
+    "insecureSkipVerify": true,
+    "metricGroups": [
+      "container",
+      "pod",
+      "node",
+      "volume"
+    ],
+    "metrics": {
+      "container.cpu.usage": {
+        "enabled": true
+      },
+      "container.uptime": {
+        "enabled": true
+      },
+      "k8s.container.cpu_limit_utilization": {
+        "enabled": true
+      },
+      "k8s.container.cpu_request_utilization": {
+        "enabled": true
+      },
+      "k8s.container.memory_limit_utilization": {
+        "enabled": true
+      },
+      "k8s.container.memory_request_utilization": {
+        "enabled": true
+      },
+      "k8s.node.cpu.usage": {
+        "enabled": true
+      },
+      "k8s.node.uptime": {
+        "enabled": true
+      },
+      "k8s.pod.cpu.usage": {
+        "enabled": true
+      },
+      "k8s.pod.cpu_limit_utilization": {
+        "enabled": true
+      },
+      "k8s.pod.cpu_request_utilization": {
+        "enabled": true
+      },
+      "k8s.pod.memory_limit_utilization": {
+        "enabled": true
+      },
+      "k8s.pod.memory_request_utilization": {
+        "enabled": true
+      },
+      "k8s.pod.uptime": {
+        "enabled": true
+      }
+    }
+  },
+  "kubernetesAttributes": {
+    "enabled": true,
+    "extractAnnotations": [],
+    "extractLabels": [],
+    "extractMetadatas": [
+      "k8s.namespace.name",
+      "k8s.deployment.name",
+      "k8s.statefulset.name",
+      "k8s.daemonset.name",
+      "k8s.cronjob.name",
+      "k8s.job.name",
+      "k8s.node.name",
+      "k8s.node.uid",
+      "k8s.pod.name",
+      "k8s.pod.uid",
+      "k8s.pod.start_time"
+    ],
+    "filter": {
+      "node_from_env_var": "K8S_NODE_NAME"
+    },
+    "passthrough": false,
+    "podAssociation": [
+      {
+        "sources": [
+          {
+            "from": "resource_attribute",
+            "name": "k8s.pod.ip"
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "from": "resource_attribute",
+            "name": "k8s.pod.uid"
+          }
+        ]
+      },
+      {
+        "sources": [
+          {
+            "from": "connection"
+          }
+        ]
+      }
+    ]
+  },
+  "loggingExporter": {
+    "enabled": false,
+    "samplingInitial": 2,
+    "samplingThereafter": 500,
+    "verbosity": "basic"
+  },
+  "logsCollection": {
+    "blacklist": {
+      "additionalExclude": [],
+      "containers": [],
+      "enabled": true,
+      "namespaces": [
+        "kube-system"
+      ],
+      "pods": [
+        "hotrod",
+        "locust"
+      ],
+      "signozLogs": true
+    },
+    "enabled": true,
+    "include": [
+      "/var/log/pods/*/*/*.log"
+    ],
+    "includeFileName": false,
+    "includeFilePath": true,
+    "operators": [
+      {
+        "id": "container-parser",
+        "type": "container"
+      }
+    ],
+    "startAt": "end",
+    "whitelist": {
+      "additionalInclude": [],
+      "containers": [],
+      "enabled": false,
+      "namespaces": [],
+      "pods": [],
+      "signozLogs": true
+    }
+  },
+  "otlpExporter": {
+    "enabled": true
+  },
+  "prometheus": {
+    "annotationsPrefix": "signoz.io",
+    "enabled": false,
+    "includeContainerName": false,
+    "includePodLabel": false,
+    "namespaceScoped": false,
+    "namespaces": [],
+    "scrapeInterval": "60s"
+  },
+  "resourceDetection": {
+    "enabled": true,
+    "envResourceAttributes": "",
+    "override": false,
+    "timeout": "2s"
+  },
+  "selfTelemetry": {
+    "apiKeyExistingSecretKey": "",
+    "apiKeyExistingSecretName": "",
+    "endpoint": "",
+    "insecure": true,
+    "insecureSkipVerify": true,
+    "logs": {
+      "enabled": false
+    },
+    "metrics": {
+      "enabled": false
+    },
+    "signozApiKey": "",
+    "traces": {
+      "enabled": false
+    }
+  }
+}
+</pre>
+</div>
+			</td>
+			<td>Presets to easily set up OtelCollector configurations.</td>
+		</tr>
+		<tr>
+			<td id="presets--selfTelemetry--signozApiKey"><a href="./values.yaml#L101">presets.selfTelemetry.signozApiKey</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>API key of SigNoz SaaS</td>
+		</tr>
+		<tr>
+			<td id="presets--selfTelemetry--apiKeyExistingSecretName"><a href="./values.yaml#L103">presets.selfTelemetry.apiKeyExistingSecretName</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Existing secret name to be used for API key.</td>
+		</tr>
+		<tr>
+			<td id="presets--selfTelemetry--apiKeyExistingSecretKey"><a href="./values.yaml#L105">presets.selfTelemetry.apiKeyExistingSecretKey</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Existing secret key to be used for API key.</td>
+		</tr>
+		<tr>
+			<td id="presets--kubernetesAttributes--passthrough"><a href="./values.yaml#L267">presets.kubernetesAttributes.passthrough</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Whether to detect the IP address of agents and add it as an attribute to all telemetry resources. If set to true, Agents will not make any k8s API calls, do any discovery of pods or extract any metadata.</td>
+		</tr>
+		<tr>
+			<td id="presets--kubernetesAttributes--filter"><a href="./values.yaml#L270">presets.kubernetesAttributes.filter</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{
+  "node_from_env_var": "K8S_NODE_NAME"
+}
+</pre>
+</div>
+			</td>
+			<td>Filters can be used to limit each OpenTelemetry agent to query pods based on specific selector to only dramatically reducing resource requirements for very large clusters.</td>
+		</tr>
+		<tr>
+			<td id="presets--kubernetesAttributes--filter--node_from_env_var"><a href="./values.yaml#L272">presets.kubernetesAttributes.filter.node_from_env_var</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"K8S_NODE_NAME"
+</pre>
+</div>
+			</td>
+			<td>Restrict each OpenTelemetry agent to query pods running on the same node</td>
+		</tr>
+		<tr>
+			<td id="presets--kubernetesAttributes--podAssociation"><a href="./values.yaml#L275">presets.kubernetesAttributes.podAssociation</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[
+  {
+    "sources": [
+      {
+        "from": "resource_attribute",
+        "name": "k8s.pod.ip"
+      }
+    ]
+  },
+  {
+    "sources": [
+      {
+        "from": "resource_attribute",
+        "name": "k8s.pod.uid"
+      }
+    ]
+  },
+  {
+    "sources": [
+      {
+        "from": "connection"
+      }
+    ]
+  }
+]
+</pre>
+</div>
+			</td>
+			<td>Pod Association section allows to define rules for tagging spans, metrics, and logs with Pod metadata.</td>
+		</tr>
+		<tr>
+			<td id="presets--kubernetesAttributes--extractMetadatas"><a href="./values.yaml#L285">presets.kubernetesAttributes.extractMetadatas</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[
+  "k8s.namespace.name",
+  "k8s.deployment.name",
+  "k8s.statefulset.name",
+  "k8s.daemonset.name",
+  "k8s.cronjob.name",
+  "k8s.job.name",
+  "k8s.node.name",
+  "k8s.node.uid",
+  "k8s.pod.name",
+  "k8s.pod.uid",
+  "k8s.pod.start_time"
+]
+</pre>
+</div>
+			</td>
+			<td>Which pod/namespace metadata to extract from a list of default metadata fields.</td>
+		</tr>
+		<tr>
+			<td id="presets--kubernetesAttributes--extractLabels"><a href="./values.yaml#L298">presets.kubernetesAttributes.extractLabels</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Which labels to extract from a list of metadata fields.</td>
+		</tr>
+		<tr>
+			<td id="presets--kubernetesAttributes--extractAnnotations"><a href="./values.yaml#L300">presets.kubernetesAttributes.extractAnnotations</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Which annotations to extract from a list of metadata fields.</td>
+		</tr>
+		<tr>
+			<td id="presets--prometheus--enabled"><a href="./values.yaml#L333">presets.prometheus.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Whether to enable metrics scraping using pod annotation</td>
+		</tr>
+		<tr>
+			<td id="presets--prometheus--annotationsPrefix"><a href="./values.yaml#L335">presets.prometheus.annotationsPrefix</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"signoz.io"
+</pre>
+</div>
+			</td>
+			<td>Prefix for the pod annotations to be used for metrics scraping</td>
+		</tr>
+		<tr>
+			<td id="presets--prometheus--scrapeInterval"><a href="./values.yaml#L337">presets.prometheus.scrapeInterval</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"60s"
+</pre>
+</div>
+			</td>
+			<td>How often to scrape metrics</td>
+		</tr>
+		<tr>
+			<td id="presets--prometheus--namespaceScoped"><a href="./values.yaml#L339">presets.prometheus.namespaceScoped</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Whether to only scrape metrics from pods in the same namespace</td>
+		</tr>
+		<tr>
+			<td id="presets--prometheus--namespaces"><a href="./values.yaml#L341">presets.prometheus.namespaces</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>If set, only scrape metrics from pods in the specified namespaces</td>
+		</tr>
+		<tr>
+			<td id="presets--prometheus--includePodLabel"><a href="./values.yaml#L344">presets.prometheus.includePodLabel</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>This will include all pod labels in the metrics, could potentially cause performance issues with large number of pods with many labels</td>
+		</tr>
+		<tr>
+			<td id="presets--prometheus--includeContainerName"><a href="./values.yaml#L348">presets.prometheus.includeContainerName</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>This is not recommended in case of multiple containers or init containers in a pod Since it will create multiple timeseries for the same pod metrics with different container names containers with `-init` suffix in the name will be ignored</td>
+		</tr>
+		<tr>
+			<td id="presets--k8sEvents--namespaces"><a href="./values.yaml#L359">presets.k8sEvents.namespaces</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>List of namespaces to watch for events. all namespaces by default</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--enabled"><a href="./values.yaml#L363">otelAgent.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelAgent--name"><a href="./values.yaml#L364">otelAgent.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"otel-agent"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelAgent--image--registry"><a href="./values.yaml#L366">otelAgent.image.registry</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"docker.io"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelAgent--image--repository"><a href="./values.yaml#L367">otelAgent.image.repository</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"otel/opentelemetry-collector-contrib"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelAgent--image--tag"><a href="./values.yaml#L368">otelAgent.image.tag</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"0.109.0"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelAgent--image--pullPolicy"><a href="./values.yaml#L369">otelAgent.image.pullPolicy</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"IfNotPresent"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelAgent--imagePullSecrets"><a href="./values.yaml#L373">otelAgent.imagePullSecrets</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Image Registry Secret Names for OtelAgent. If global.imagePullSecrets is set as well, it will merged.</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--command--name"><a href="./values.yaml#L379">otelAgent.command.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"/otelcol-contrib"
+</pre>
+</div>
+			</td>
+			<td>OtelAgent command name</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--command--extraArgs"><a href="./values.yaml#L381">otelAgent.command.extraArgs</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>OtelAgent command extra arguments</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--configMap--create"><a href="./values.yaml#L385">otelAgent.configMap.create</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Specifies whether a configMap should be created (true by default)</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--service--annotations"><a href="./values.yaml#L390">otelAgent.service.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Annotations to use by service associated to OtelAgent</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--service--type"><a href="./values.yaml#L392">otelAgent.service.type</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"ClusterIP"
+</pre>
+</div>
+			</td>
+			<td>Service Type: LoadBalancer (allows external access) or NodePort (more secure, no extra cost)</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--service--internalTrafficPolicy"><a href="./values.yaml#L395">otelAgent.service.internalTrafficPolicy</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"Local"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelAgent--serviceAccount--create"><a href="./values.yaml#L399">otelAgent.serviceAccount.create</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelAgent--serviceAccount--annotations"><a href="./values.yaml#L401">otelAgent.serviceAccount.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelAgent--serviceAccount--name"><a href="./values.yaml#L404">otelAgent.serviceAccount.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelAgent--annotations"><a href="./values.yaml#L407">otelAgent.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>OtelAgent daemonset annotation.</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--podAnnotations"><a href="./values.yaml#L409">otelAgent.podAnnotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>OtelAgent pod(s) annotation.</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--additionalEnvs"><a href="./values.yaml#L415">otelAgent.additionalEnvs</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Additional environments to set for OtelAgent</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--minReadySeconds"><a href="./values.yaml#L434">otelAgent.minReadySeconds</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+5
+</pre>
+</div>
+			</td>
+			<td>Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available.</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--clusterRole--create"><a href="./values.yaml#L439">otelAgent.clusterRole.create</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Specifies whether a clusterRole should be created</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--clusterRole--annotations"><a href="./values.yaml#L441">otelAgent.clusterRole.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Annotations to add to the clusterRole</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--clusterRole--name"><a href="./values.yaml#L444">otelAgent.clusterRole.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>The name of the clusterRole to use. If not set and create is true, a name is generated using the fullname template</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--clusterRole--rules"><a href="./values.yaml#L448">otelAgent.clusterRole.rules</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="">
+See `values.yaml` for defaults
+</pre>
+</div>
+			</td>
+			<td>A set of rules as documented here. ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--clusterRole--clusterRoleBinding--annotations"><a href="./values.yaml#L480">otelAgent.clusterRole.clusterRoleBinding.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelAgent--clusterRole--clusterRoleBinding--name"><a href="./values.yaml#L483">otelAgent.clusterRole.clusterRoleBinding.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--otlp--enabled"><a href="./values.yaml#L489">otelAgent.ports.otlp.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for OTLP gRPC</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--otlp--containerPort"><a href="./values.yaml#L491">otelAgent.ports.otlp.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+4317
+</pre>
+</div>
+			</td>
+			<td>Container port for OTLP gRPC</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--otlp--servicePort"><a href="./values.yaml#L493">otelAgent.ports.otlp.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+4317
+</pre>
+</div>
+			</td>
+			<td>Service port for OTLP gRPC</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--otlp--nodePort"><a href="./values.yaml#L495">otelAgent.ports.otlp.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for OTLP gRPC</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--otlp--hostPort"><a href="./values.yaml#L497">otelAgent.ports.otlp.hostPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+4317
+</pre>
+</div>
+			</td>
+			<td>Host port for OTLP gRPC</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--otlp--protocol"><a href="./values.yaml#L499">otelAgent.ports.otlp.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for OTLP gRPC</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--otlp-http--enabled"><a href="./values.yaml#L502">otelAgent.ports.otlp-http.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for OTLP HTTP</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--otlp-http--containerPort"><a href="./values.yaml#L504">otelAgent.ports.otlp-http.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+4318
+</pre>
+</div>
+			</td>
+			<td>Container port for OTLP HTTP</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--otlp-http--servicePort"><a href="./values.yaml#L506">otelAgent.ports.otlp-http.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+4318
+</pre>
+</div>
+			</td>
+			<td>Service port for OTLP HTTP</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--otlp-http--nodePort"><a href="./values.yaml#L508">otelAgent.ports.otlp-http.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for OTLP HTTP</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--otlp-http--hostPort"><a href="./values.yaml#L510">otelAgent.ports.otlp-http.hostPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+4318
+</pre>
+</div>
+			</td>
+			<td>Host port for OTLP HTTP</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--otlp-http--protocol"><a href="./values.yaml#L512">otelAgent.ports.otlp-http.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for OTLP HTTP</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--zipkin--enabled"><a href="./values.yaml#L515">otelAgent.ports.zipkin.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for Zipkin</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--zipkin--containerPort"><a href="./values.yaml#L517">otelAgent.ports.zipkin.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+9411
+</pre>
+</div>
+			</td>
+			<td>Container port for Zipkin</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--zipkin--servicePort"><a href="./values.yaml#L519">otelAgent.ports.zipkin.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+9411
+</pre>
+</div>
+			</td>
+			<td>Service port for Zipkin</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--zipkin--nodePort"><a href="./values.yaml#L521">otelAgent.ports.zipkin.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for Zipkin</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--zipkin--hostPort"><a href="./values.yaml#L523">otelAgent.ports.zipkin.hostPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+9411
+</pre>
+</div>
+			</td>
+			<td>Host port for Zipkin</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--zipkin--protocol"><a href="./values.yaml#L525">otelAgent.ports.zipkin.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for Zipkin</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--metrics--enabled"><a href="./values.yaml#L528">otelAgent.ports.metrics.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for internal metrics</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--metrics--containerPort"><a href="./values.yaml#L530">otelAgent.ports.metrics.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+8888
+</pre>
+</div>
+			</td>
+			<td>Container port for internal metrics</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--metrics--servicePort"><a href="./values.yaml#L532">otelAgent.ports.metrics.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+8888
+</pre>
+</div>
+			</td>
+			<td>Service port for internal metrics</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--metrics--nodePort"><a href="./values.yaml#L534">otelAgent.ports.metrics.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for internal metrics</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--metrics--hostPort"><a href="./values.yaml#L536">otelAgent.ports.metrics.hostPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+8888
+</pre>
+</div>
+			</td>
+			<td>Host port for internal metrics</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--metrics--protocol"><a href="./values.yaml#L538">otelAgent.ports.metrics.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for internal metrics</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--zpages--enabled"><a href="./values.yaml#L541">otelAgent.ports.zpages.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for ZPages</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--zpages--containerPort"><a href="./values.yaml#L543">otelAgent.ports.zpages.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+55679
+</pre>
+</div>
+			</td>
+			<td>Container port for Zpages</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--zpages--servicePort"><a href="./values.yaml#L545">otelAgent.ports.zpages.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+55679
+</pre>
+</div>
+			</td>
+			<td>Service port for Zpages</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--zpages--nodePort"><a href="./values.yaml#L547">otelAgent.ports.zpages.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for Zpages</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--zpages--hostPort"><a href="./values.yaml#L549">otelAgent.ports.zpages.hostPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+55679
+</pre>
+</div>
+			</td>
+			<td>Host port for Zpages</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--zpages--protocol"><a href="./values.yaml#L551">otelAgent.ports.zpages.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for Zpages</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--health-check--enabled"><a href="./values.yaml#L554">otelAgent.ports.health-check.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for health check</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--health-check--containerPort"><a href="./values.yaml#L556">otelAgent.ports.health-check.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+13133
+</pre>
+</div>
+			</td>
+			<td>Container port for health check</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--health-check--servicePort"><a href="./values.yaml#L558">otelAgent.ports.health-check.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+13133
+</pre>
+</div>
+			</td>
+			<td>Service port for health check</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--health-check--nodePort"><a href="./values.yaml#L560">otelAgent.ports.health-check.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for health check</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--health-check--hostPort"><a href="./values.yaml#L562">otelAgent.ports.health-check.hostPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+13133
+</pre>
+</div>
+			</td>
+			<td>Host port for health check</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--health-check--protocol"><a href="./values.yaml#L564">otelAgent.ports.health-check.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for health check</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--pprof--enabled"><a href="./values.yaml#L567">otelAgent.ports.pprof.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for pprof</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--pprof--containerPort"><a href="./values.yaml#L569">otelAgent.ports.pprof.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1777
+</pre>
+</div>
+			</td>
+			<td>Container port for pprof</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--pprof--servicePort"><a href="./values.yaml#L571">otelAgent.ports.pprof.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1777
+</pre>
+</div>
+			</td>
+			<td>Service port for pprof</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--pprof--nodePort"><a href="./values.yaml#L573">otelAgent.ports.pprof.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for pprof</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--pprof--hostPort"><a href="./values.yaml#L575">otelAgent.ports.pprof.hostPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1777
+</pre>
+</div>
+			</td>
+			<td>Host port for pprof</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ports--pprof--protocol"><a href="./values.yaml#L577">otelAgent.ports.pprof.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for pprof</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--livenessProbe"><a href="./values.yaml#L581">otelAgent.livenessProbe</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{
+  "enabled": true,
+  "failureThreshold": 6,
+  "initialDelaySeconds": 10,
+  "path": "/",
+  "periodSeconds": 10,
+  "port": 13133,
+  "successThreshold": 1,
+  "timeoutSeconds": 5
+}
+</pre>
+</div>
+			</td>
+			<td>Configure liveness probe. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--readinessProbe"><a href="./values.yaml#L593">otelAgent.readinessProbe</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{
+  "enabled": true,
+  "failureThreshold": 6,
+  "initialDelaySeconds": 10,
+  "path": "/",
+  "periodSeconds": 10,
+  "port": 13133,
+  "successThreshold": 1,
+  "timeoutSeconds": 5
+}
+</pre>
+</div>
+			</td>
+			<td>Configure readiness probe. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--customLivenessProbe"><a href="./values.yaml#L604">otelAgent.customLivenessProbe</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Custom liveness probe</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--customReadinessProbe"><a href="./values.yaml#L606">otelAgent.customReadinessProbe</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Custom readiness probe</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ingress--enabled"><a href="./values.yaml#L610">otelAgent.ingress.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Enable ingress for OtelAgent</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ingress--className"><a href="./values.yaml#L612">otelAgent.ingress.className</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Ingress Class Name to be used to identify ingress controllers</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ingress--annotations"><a href="./values.yaml#L614">otelAgent.ingress.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Annotations to OtelAgent Ingress</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ingress--hosts"><a href="./values.yaml#L621">otelAgent.ingress.hosts</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[
+  {
+    "host": "otel-agent.domain.com",
+    "paths": [
+      {
+        "path": "/",
+        "pathType": "ImplementationSpecific",
+        "port": 4317
+      }
+    ]
+  }
+]
+</pre>
+</div>
+			</td>
+			<td>OtelAgent Ingress Host names with their path details</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--ingress--tls"><a href="./values.yaml#L628">otelAgent.ingress.tls</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>OtelAgent Ingress TLS</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--resources"><a href="./values.yaml#L637">otelAgent.resources</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="">
+See `values.yaml` for defaults
+</pre>
+</div>
+			</td>
+			<td>Configure resource requests and limits. Update according to your own use case as these values might not be suitable for your workload. ref: http://kubernetes.io/docs/user-guide/compute-resources/</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--priorityClassName"><a href="./values.yaml#L646">otelAgent.priorityClassName</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>OtelAgent priority class name</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--nodeSelector"><a href="./values.yaml#L649">otelAgent.nodeSelector</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>OtelAgent node selector</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--tolerations"><a href="./values.yaml#L652">otelAgent.tolerations</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[
+  {
+    "operator": "Exists"
+  }
+]
+</pre>
+</div>
+			</td>
+			<td>Toleration labels for OtelAgent pod assignment</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--affinity"><a href="./values.yaml#L656">otelAgent.affinity</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Affinity settings for OtelAgent pod</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--podSecurityContext"><a href="./values.yaml#L659">otelAgent.podSecurityContext</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Pod-level security configuration</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--securityContext"><a href="./values.yaml#L663">otelAgent.securityContext</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Container security configuration</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--config"><a href="./values.yaml#L673">otelAgent.config</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="">
+See `values.yaml` for defaults
+</pre>
+</div>
+			</td>
+			<td>Configurations for OtelAgent</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--extraVolumes"><a href="./values.yaml#L722">otelAgent.extraVolumes</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Additional volumes for otelAgent</td>
+		</tr>
+		<tr>
+			<td id="otelAgent--extraVolumeMounts"><a href="./values.yaml#L731">otelAgent.extraVolumeMounts</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Additional volume mounts for otelAgent</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--enabled"><a href="./values.yaml#L740">otelDeployment.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--name"><a href="./values.yaml#L741">otelDeployment.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"otel-deployment"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--image--registry"><a href="./values.yaml#L743">otelDeployment.image.registry</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"docker.io"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--image--repository"><a href="./values.yaml#L744">otelDeployment.image.repository</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"otel/opentelemetry-collector-contrib"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--image--tag"><a href="./values.yaml#L745">otelDeployment.image.tag</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"0.109.0"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--image--pullPolicy"><a href="./values.yaml#L746">otelDeployment.image.pullPolicy</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"IfNotPresent"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--imagePullSecrets"><a href="./values.yaml#L750">otelDeployment.imagePullSecrets</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Image Registry Secret Names for OtelDeployment. If global.imagePullSecrets is set as well, it will merged.</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--command--name"><a href="./values.yaml#L756">otelDeployment.command.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"/otelcol-contrib"
+</pre>
+</div>
+			</td>
+			<td>OtelDeployment command name</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--command--extraArgs"><a href="./values.yaml#L758">otelDeployment.command.extraArgs</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>OtelDeployment command extra arguments</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--configMap--create"><a href="./values.yaml#L762">otelDeployment.configMap.create</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Specifies whether a configMap should be created (true by default)</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--service--annotations"><a href="./values.yaml#L767">otelDeployment.service.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Annotations to use by service associated to OtelDeployment</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--service--type"><a href="./values.yaml#L769">otelDeployment.service.type</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"ClusterIP"
+</pre>
+</div>
+			</td>
+			<td>Service Type: LoadBalancer (allows external access) or NodePort (more secure, no extra cost)</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--serviceAccount--create"><a href="./values.yaml#L773">otelDeployment.serviceAccount.create</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--serviceAccount--annotations"><a href="./values.yaml#L775">otelDeployment.serviceAccount.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--serviceAccount--name"><a href="./values.yaml#L778">otelDeployment.serviceAccount.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--annotations"><a href="./values.yaml#L781">otelDeployment.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>OtelDeployment deployment annotation.</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--podAnnotations"><a href="./values.yaml#L783">otelDeployment.podAnnotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>OtelDeployment pod(s) annotation.</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--additionalEnvs"><a href="./values.yaml#L789">otelDeployment.additionalEnvs</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Additional environments to set for OtelDeployment</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--podSecurityContext"><a href="./values.yaml#L807">otelDeployment.podSecurityContext</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Pod-level security configuration</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--securityContext"><a href="./values.yaml#L811">otelDeployment.securityContext</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Container security configuration</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--minReadySeconds"><a href="./values.yaml#L821">otelDeployment.minReadySeconds</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+5
+</pre>
+</div>
+			</td>
+			<td>Minimum number of seconds for which a newly created Pod should be ready without any of its containers crashing, for it to be considered available.</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--progressDeadlineSeconds"><a href="./values.yaml#L825">otelDeployment.progressDeadlineSeconds</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+120
+</pre>
+</div>
+			</td>
+			<td>Number of seconds to wait for the OtelDeployment to progress before the system reports back that the OtelDeployment has failed.</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--metrics--enabled"><a href="./values.yaml#L831">otelDeployment.ports.metrics.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for internal metrics</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--metrics--containerPort"><a href="./values.yaml#L833">otelDeployment.ports.metrics.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+8888
+</pre>
+</div>
+			</td>
+			<td>Container port for internal metrics</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--metrics--servicePort"><a href="./values.yaml#L835">otelDeployment.ports.metrics.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+8888
+</pre>
+</div>
+			</td>
+			<td>Service port for internal metrics</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--metrics--nodePort"><a href="./values.yaml#L837">otelDeployment.ports.metrics.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for internal metrics</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--metrics--protocol"><a href="./values.yaml#L839">otelDeployment.ports.metrics.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for internal metrics</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--zpages--enabled"><a href="./values.yaml#L842">otelDeployment.ports.zpages.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for ZPages</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--zpages--containerPort"><a href="./values.yaml#L844">otelDeployment.ports.zpages.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+55679
+</pre>
+</div>
+			</td>
+			<td>Container port for Zpages</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--zpages--servicePort"><a href="./values.yaml#L846">otelDeployment.ports.zpages.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+55679
+</pre>
+</div>
+			</td>
+			<td>Service port for Zpages</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--zpages--nodePort"><a href="./values.yaml#L848">otelDeployment.ports.zpages.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for Zpages</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--zpages--protocol"><a href="./values.yaml#L850">otelDeployment.ports.zpages.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for Zpages</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--health-check--enabled"><a href="./values.yaml#L853">otelDeployment.ports.health-check.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for health check</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--health-check--containerPort"><a href="./values.yaml#L855">otelDeployment.ports.health-check.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+13133
+</pre>
+</div>
+			</td>
+			<td>Container port for health check</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--health-check--servicePort"><a href="./values.yaml#L857">otelDeployment.ports.health-check.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+13133
+</pre>
+</div>
+			</td>
+			<td>Service port for health check</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--health-check--nodePort"><a href="./values.yaml#L859">otelDeployment.ports.health-check.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for health check</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--health-check--protocol"><a href="./values.yaml#L861">otelDeployment.ports.health-check.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for health check</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--pprof--enabled"><a href="./values.yaml#L864">otelDeployment.ports.pprof.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for pprof</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--pprof--containerPort"><a href="./values.yaml#L866">otelDeployment.ports.pprof.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1777
+</pre>
+</div>
+			</td>
+			<td>Container port for pprof</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--pprof--servicePort"><a href="./values.yaml#L868">otelDeployment.ports.pprof.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1777
+</pre>
+</div>
+			</td>
+			<td>Service port for pprof</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--pprof--nodePort"><a href="./values.yaml#L870">otelDeployment.ports.pprof.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for pprof</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ports--pprof--protocol"><a href="./values.yaml#L872">otelDeployment.ports.pprof.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for pprof</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--livenessProbe"><a href="./values.yaml#L876">otelDeployment.livenessProbe</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{
+  "enabled": true,
+  "failureThreshold": 6,
+  "initialDelaySeconds": 10,
+  "path": "/",
+  "periodSeconds": 10,
+  "port": 13133,
+  "successThreshold": 1,
+  "timeoutSeconds": 5
+}
+</pre>
+</div>
+			</td>
+			<td>Configure liveness probe. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--readinessProbe"><a href="./values.yaml#L888">otelDeployment.readinessProbe</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{
+  "enabled": true,
+  "failureThreshold": 6,
+  "initialDelaySeconds": 10,
+  "path": "/",
+  "periodSeconds": 10,
+  "port": 13133,
+  "successThreshold": 1,
+  "timeoutSeconds": 5
+}
+</pre>
+</div>
+			</td>
+			<td>Configure readiness probe. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--customLivenessProbe"><a href="./values.yaml#L899">otelDeployment.customLivenessProbe</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Custom liveness probe</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--customReadinessProbe"><a href="./values.yaml#L902">otelDeployment.customReadinessProbe</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Custom readiness probe</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ingress--enabled"><a href="./values.yaml#L906">otelDeployment.ingress.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Enable ingress for OtelDeployment</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ingress--className"><a href="./values.yaml#L908">otelDeployment.ingress.className</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Ingress Class Name to be used to identify ingress controllers</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ingress--annotations"><a href="./values.yaml#L910">otelDeployment.ingress.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Annotations to OtelDeployment Ingress</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ingress--hosts"><a href="./values.yaml#L917">otelDeployment.ingress.hosts</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[
+  {
+    "host": "otel-deployment.domain.com",
+    "paths": [
+      {
+        "path": "/",
+        "pathType": "ImplementationSpecific",
+        "port": 13133
+      }
+    ]
+  }
+]
+</pre>
+</div>
+			</td>
+			<td>OtelDeployment Ingress Host names with their path details</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--ingress--tls"><a href="./values.yaml#L924">otelDeployment.ingress.tls</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>OtelDeployment Ingress TLS</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--resources"><a href="./values.yaml#L933">otelDeployment.resources</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="">
+See `values.yaml` for defaults
+</pre>
+</div>
+			</td>
+			<td>Configure resource requests and limits. Update according to your own use case as these values might not be suitable for your workload. ref: http://kubernetes.io/docs/user-guide/compute-resources/</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--priorityClassName"><a href="./values.yaml#L942">otelDeployment.priorityClassName</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>OtelDeployment priority class name</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--nodeSelector"><a href="./values.yaml#L945">otelDeployment.nodeSelector</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>OtelDeployment node selector</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--tolerations"><a href="./values.yaml#L948">otelDeployment.tolerations</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Toleration labels for OtelDeployment pod assignment</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--affinity"><a href="./values.yaml#L951">otelDeployment.affinity</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Affinity settings for OtelDeployment pod</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--topologySpreadConstraints"><a href="./values.yaml#L954">otelDeployment.topologySpreadConstraints</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>TopologySpreadConstraints describes how OtelDeployment pods ought to spread</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--clusterRole--create"><a href="./values.yaml#L959">otelDeployment.clusterRole.create</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Specifies whether a clusterRole should be created</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--clusterRole--annotations"><a href="./values.yaml#L961">otelDeployment.clusterRole.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Annotations to add to the clusterRole</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--clusterRole--name"><a href="./values.yaml#L964">otelDeployment.clusterRole.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>The name of the clusterRole to use. If not set and create is true, a name is generated using the fullname template</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--clusterRole--rules"><a href="./values.yaml#L968">otelDeployment.clusterRole.rules</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="">
+See `values.yaml` for defaults
+</pre>
+</div>
+			</td>
+			<td>A set of rules as documented here. ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--clusterRole--clusterRoleBinding--annotations"><a href="./values.yaml#L999">otelDeployment.clusterRole.clusterRoleBinding.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Annotations to add to the clusterRoleBinding</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--clusterRole--clusterRoleBinding--name"><a href="./values.yaml#L1002">otelDeployment.clusterRole.clusterRoleBinding.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>The name of the clusterRoleBinding to use. If not set and create is true, a name is generated using the fullname template</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--config"><a href="./values.yaml#L1006">otelDeployment.config</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="">
+See `values.yaml` for defaults
+</pre>
+</div>
+			</td>
+			<td>Configurations for OtelDeployment</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--extraVolumes"><a href="./values.yaml#L1048">otelDeployment.extraVolumes</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Additional volumes for otelDeployment</td>
+		</tr>
+		<tr>
+			<td id="otelDeployment--extraVolumeMounts"><a href="./values.yaml#L1057">otelDeployment.extraVolumeMounts</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Additional volume mounts for otelDeployment</td>
+		</tr>
+	</tbody>
+</table>
+

--- a/charts/k8s-infra/README.md
+++ b/charts/k8s-infra/README.md
@@ -64,7 +64,7 @@ Sometimes everything doesn't get properly removed. If that happens try deleting 
 kubectl delete namespace platform
 ```
 
-## Values
+<h2> Configuration </h2>
 
 <table height="400px" >
 	<thead>

--- a/charts/k8s-infra/README.md.gotmpl
+++ b/charts/k8s-infra/README.md.gotmpl
@@ -89,7 +89,7 @@ kubectl delete namespace platform
 {{end}}
 
 {{ define "chart.valuesTableHtml" }}
-<table height="400px" >
+<table>
 	<thead>
 		<th>Key</th>
 		<th>Type</th>

--- a/charts/k8s-infra/README.md.gotmpl
+++ b/charts/k8s-infra/README.md.gotmpl
@@ -16,8 +16,9 @@ helm install -n platform --create-namespace "my-release" signoz/{{ template "cha
 
 ### Introduction
 
-This chart bootstraps [SigNoz](https://signoz.io) cluster deployment on a
-Kubernetes cluster using [Helm](https://helm.sh) package manager.
+The `k8s-infra` chart provides Kubernetes infrastructure observability by deploying OpenTelemetry components and related resources using the [Helm](https://helm.sh) package manager. 
+
+It enables collection of metrics, logs, and events from your Kubernetes cluster, making it easier to monitor and troubleshoot your infrastructure with SigNoz.
 
 ### Prerequisites
 
@@ -30,10 +31,10 @@ To install the chart with the release name `my-release`:
 
 ```bash
 helm repo add signoz https://charts.signoz.io
-helm -n platform --create-namespace install "my-release" signoz/{{ template "chart.name" .}}
+helm -n platform --create-namespace install "my-release" signoz/k8s-infra
 ```
 
-These commands deploy SigNoz on the Kubernetes cluster in the default configuration.
+These commands deploy K8s-infra on the Kubernetes cluster in the default configuration.
 The [Configuration](#configuration) section lists the parameters that can be configured during installation:
 
 > **Tip**: List all releases using `helm list`
@@ -62,6 +63,7 @@ Sometimes everything doesn't get properly removed. If that happens try deleting 
 ```bash
 kubectl delete namespace platform
 ```
+
 
 {{ define "chart.valueDefaultColumnRender" }}
 {{- $defaultValue := (default .Default .AutoDefault)  -}}

--- a/charts/k8s-infra/README.md.gotmpl
+++ b/charts/k8s-infra/README.md.gotmpl
@@ -3,9 +3,7 @@
 
 {{ template "chart.badgesSection" . }}
 
-SigNoz is an open-source APM. It helps developers monitor their applications & troubleshoot problems,
-an open-source alternative to DataDog, NewRelic, etc. Open source Application Performance Monitoring (APM)
-& Observability tool.
+SigNoz is an open-source observability platform native to OpenTelemetry with logs, traces and metrics in a single application. An open-source alternative to DataDog, NewRelic, etc. 🔥 🖥. 👉 Open source Application Performance Monitoring (APM) & Observability tool
 
 ### TL;DR;
 
@@ -66,22 +64,11 @@ kubectl delete namespace platform
 
 
 {{ define "chart.valueDefaultColumnRender" }}
-{{- $defaultValue := (default .Default .AutoDefault)  -}}
-{{- $notationType := .NotationType }}
-{{- if (and (hasPrefix "`" $defaultValue) (hasSuffix "`" $defaultValue) ) -}}
-{{- $defaultValue = (toPrettyJson (fromJson (trimAll "`" (default .Default .AutoDefault) ) ) ) -}}
-{{- $notationType = "json" }}
+{{- $defaultValue := (default .Default .AutoDefault) -}}
+{{- if (and (hasPrefix "" $defaultValue) (hasSuffix "" $defaultValue) ) -}}
+{{- $defaultValue = (toPrettyJson (fromJson (trimAll "`" $defaultValue) ) ) -}}
 {{- end -}}
-{{- if (eq $notationType "tpl" ) }}
-<pre lang="{{ $notationType }}">
-{{ .Key }}: |
-{{- $defaultValue | nindent 2 }}
-</pre>
-{{- else }}
-<pre lang="{{ $notationType }}">
-{{ $defaultValue }}
-</pre>
-{{- end }}
+<code>{{ $defaultValue }}</code>
 {{ end }}
 
 {{define "chart.valuesHeader"}}

--- a/charts/k8s-infra/README.md.gotmpl
+++ b/charts/k8s-infra/README.md.gotmpl
@@ -84,6 +84,9 @@ kubectl delete namespace platform
 {{- end }}
 {{ end }}
 
+{{define "chart.valuesHeader"}}
+<h2> Configuration </h2>
+{{end}}
 
 {{ define "chart.valuesTableHtml" }}
 <table height="400px" >

--- a/charts/k8s-infra/README.md.gotmpl
+++ b/charts/k8s-infra/README.md.gotmpl
@@ -72,7 +72,7 @@ kubectl delete namespace platform
 {{ end }}
 
 {{define "chart.valuesHeader"}}
-<h2> Configuration </h2>
+## Configuration
 {{end}}
 
 {{ define "chart.valuesTableHtml" }}

--- a/charts/k8s-infra/README.md.gotmpl
+++ b/charts/k8s-infra/README.md.gotmpl
@@ -1,0 +1,110 @@
+
+# SigNoz
+
+{{ template "chart.badgesSection" . }}
+
+SigNoz is an open-source APM. It helps developers monitor their applications & troubleshoot problems,
+an open-source alternative to DataDog, NewRelic, etc. Open source Application Performance Monitoring (APM)
+& Observability tool.
+
+### TL;DR;
+
+```sh
+helm repo add signoz https://charts.signoz.io
+helm install -n platform --create-namespace "my-release" signoz/{{ template "chart.name" .}}
+```
+
+### Introduction
+
+This chart bootstraps [SigNoz](https://signoz.io) cluster deployment on a
+Kubernetes cluster using [Helm](https://helm.sh) package manager.
+
+### Prerequisites
+
+- Kubernetes 1.16+
+- Helm 3.0+
+
+### Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+helm repo add signoz https://charts.signoz.io
+helm -n platform --create-namespace install "my-release" signoz/{{ template "chart.name" .}}
+```
+
+These commands deploy SigNoz on the Kubernetes cluster in the default configuration.
+The [Configuration](#configuration) section lists the parameters that can be configured during installation:
+
+> **Tip**: List all releases using `helm list`
+
+### Uninstalling the chart
+
+To uninstall/delete the `my-release` resources:
+
+```bash
+helm -n platform uninstall "my-release"
+```
+
+See the [Helm docs](https://helm.sh/docs/helm/helm_uninstall/) for documentation on the helm uninstall command.
+
+The command above removes all the Kubernetes components associated
+with the chart and deletes the release.
+
+Deletion of the StatefulSet doesn't cascade to deleting associated PVCs. To delete them:
+
+```bash
+kubectl -n platform delete pvc --selector app.kubernetes.io/instance=my-release
+```
+
+Sometimes everything doesn't get properly removed. If that happens try deleting the namespace:
+
+```bash
+kubectl delete namespace platform
+```
+
+{{ define "chart.valueDefaultColumnRender" }}
+{{- $defaultValue := (default .Default .AutoDefault)  -}}
+{{- $notationType := .NotationType }}
+{{- if (and (hasPrefix "`" $defaultValue) (hasSuffix "`" $defaultValue) ) -}}
+{{- $defaultValue = (toPrettyJson (fromJson (trimAll "`" (default .Default .AutoDefault) ) ) ) -}}
+{{- $notationType = "json" }}
+{{- end -}}
+{{- if (eq $notationType "tpl" ) }}
+<pre lang="{{ $notationType }}">
+{{ .Key }}: |
+{{- $defaultValue | nindent 2 }}
+</pre>
+{{- else }}
+<pre lang="{{ $notationType }}">
+{{ $defaultValue }}
+</pre>
+{{- end }}
+{{ end }}
+
+
+{{ define "chart.valuesTableHtml" }}
+<table height="400px" >
+	<thead>
+		<th>Key</th>
+		<th>Type</th>
+		<th>Default</th>
+		<th>Description</th>
+	</thead>
+	<tbody>
+	{{- range .Values }}
+		<tr>
+			<td id="{{ .Key | replace "." "--" }}"><a href="./values.yaml#L{{ .LineNumber }}">{{ .Key }}</a></td>
+			<td>{{.Type}}</td>
+			<td>
+				<div style="max-width: 300px;">{{ template "chart.valueDefaultColumnRender" . }}</div>
+			</td>
+			<td>{{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }}</td>
+		</tr>
+	{{- end }}
+	</tbody>
+</table>
+{{ end }}
+
+{{ template "chart.valuesSectionHtml" . }}
+

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -75,11 +75,11 @@ Both configuration options must now be specified under `signoz.env` instead.
 ```yaml
 signoz:
   configVars:
-   storage: clickhouse
+    storage: clickhouse
   smtpVars:
     existingSecret:
-     name: my-secret-name
-     hostKey: my-smtp-host-key
+      name: my-secret-name
+      hostKey: my-smtp-host-key
 ```
 
 **After:**
@@ -88,10 +88,10 @@ signoz:
   env:
     storage: clickhouse
     smtp_port:
-     valueFrom:
-      secretKeyRef:
-      name: my-secret-name
-      key: my-smtp-host-key
+      valueFrom:
+        secretKeyRef:
+          name: my-secret-name
+          key: my-smtp-host-key
 ```
 
 ## Configuration

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -3,9 +3,7 @@
 
 ![Version: 0.86.0](https://img.shields.io/badge/Version-0.86.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.89.0](https://img.shields.io/badge/AppVersion-v0.89.0-informational?style=flat-square)
 
-SigNoz is an open-source APM. It helps developers monitor their applications & troubleshoot problems,
-an open-source alternative to DataDog, NewRelic, etc. Open source Application Performance Monitoring (APM)
-& Observability tool.
+SigNoz is an open-source observability platform native to OpenTelemetry with logs, traces and metrics in a single application. An open-source alternative to DataDog, NewRelic, etc. 🔥 🖥. 👉 Open source Application Performance Monitoring (APM) & Observability tool
 
 ### TL;DR;
 
@@ -98,7 +96,7 @@ signoz:
 
 <h2> Configuration </h2>
 
-<table height="400px" >
+<table>
 	<thead>
 		<th>Key</th>
 		<th>Type</th>
@@ -110,10 +108,7 @@ signoz:
 			<td id="global--imageRegistry"><a href="./values.yaml#L4">global.imageRegistry</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Overrides the Image registry globally</td>
@@ -122,10 +117,7 @@ null
 			<td id="global--imagePullSecrets"><a href="./values.yaml#L6">global.imagePullSecrets</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Global Image Pull Secrets</td>
@@ -134,10 +126,7 @@ null
 			<td id="global--storageClass"><a href="./values.yaml#L10">global.storageClass</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Overrides the storage class for all PVC with persistence enabled. If not set, the default storage class is used. If set to "-", storageClassName: "", which disables dynamic provisioning</td>
@@ -146,10 +135,7 @@ null
 			<td id="global--clusterDomain"><a href="./values.yaml#L13">global.clusterDomain</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"cluster.local"
-</pre>
+				<div style="max-width: 300px;"><code>"cluster.local"</code>
 </div>
 			</td>
 			<td>Kubernetes cluster domain It is used only when components are installed in different namespace</td>
@@ -158,10 +144,7 @@ null
 			<td id="global--clusterName"><a href="./values.yaml#L16">global.clusterName</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Kubernetes cluster name It is used to attached to telemetry data via resource detection processor</td>
@@ -170,10 +153,7 @@ null
 			<td id="global--cloud"><a href="./values.yaml#L21">global.cloud</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"other"
-</pre>
+				<div style="max-width: 300px;"><code>"other"</code>
 </div>
 			</td>
 			<td>Kubernetes cluster cloud provider along with distribution if any. example: `aws`, `azure`, `gcp`, `gcp/autogke`, `hcloud`, `other` Based on the cloud, storage class for the persistent volume is selected. When set to 'aws' or 'gcp' along with `installCustomStorageClass` enabled, then new expandible storage class is created.</td>
@@ -182,10 +162,7 @@ null
 			<td id="nameOverride"><a href="./values.yaml#L23">nameOverride</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>SigNoz chart name override</td>
@@ -194,10 +171,7 @@ null
 			<td id="fullnameOverride"><a href="./values.yaml#L25">fullnameOverride</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>SigNoz chart full name override</td>
@@ -206,10 +180,7 @@ null
 			<td id="clusterName"><a href="./values.yaml#L27">clusterName</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Name of the K8s cluster. Used by SigNoz OtelCollectors to attach in telemetry data.</td>
@@ -218,10 +189,7 @@ null
 			<td id="imagePullSecrets"><a href="./values.yaml#L31">imagePullSecrets</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Image Registry Secret Names for all SigNoz components. If global.imagePullSecrets is set as well, it will merged. However, this has lower precedence than the imagePullSecrets at inner component level.</td>
@@ -230,10 +198,7 @@ null
 			<td id="externalClickhouse--host"><a href="./values.yaml#L532">externalClickhouse.host</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Host of the external cluster.</td>
@@ -242,10 +207,7 @@ null
 			<td id="externalClickhouse--cluster"><a href="./values.yaml#L534">externalClickhouse.cluster</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"cluster"
-</pre>
+				<div style="max-width: 300px;"><code>"cluster"</code>
 </div>
 			</td>
 			<td>Name of the external cluster to run DDL queries on.</td>
@@ -254,10 +216,7 @@ null
 			<td id="externalClickhouse--database"><a href="./values.yaml#L536">externalClickhouse.database</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"signoz_metrics"
-</pre>
+				<div style="max-width: 300px;"><code>"signoz_metrics"</code>
 </div>
 			</td>
 			<td>Database name for the external cluster</td>
@@ -266,10 +225,7 @@ null
 			<td id="externalClickhouse--traceDatabase"><a href="./values.yaml#L538">externalClickhouse.traceDatabase</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"signoz_traces"
-</pre>
+				<div style="max-width: 300px;"><code>"signoz_traces"</code>
 </div>
 			</td>
 			<td>Clickhouse trace database (SigNoz Traces)</td>
@@ -278,10 +234,7 @@ null
 			<td id="externalClickhouse--logDatabase"><a href="./values.yaml#L540">externalClickhouse.logDatabase</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"signoz_logs"
-</pre>
+				<div style="max-width: 300px;"><code>"signoz_logs"</code>
 </div>
 			</td>
 			<td>Clickhouse log database (SigNoz Logs)</td>
@@ -290,10 +243,7 @@ null
 			<td id="externalClickhouse--user"><a href="./values.yaml#L542">externalClickhouse.user</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>User name for the external cluster to connect to the external cluster as</td>
@@ -302,10 +252,7 @@ null
 			<td id="externalClickhouse--password"><a href="./values.yaml#L544">externalClickhouse.password</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Password for the cluster. Ignored if externalClickhouse.existingSecret is set</td>
@@ -314,10 +261,7 @@ null
 			<td id="externalClickhouse--existingSecret"><a href="./values.yaml#L546">externalClickhouse.existingSecret</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Name of an existing Kubernetes secret object containing the password</td>
@@ -326,10 +270,7 @@ null
 			<td id="externalClickhouse--existingSecretPasswordKey"><a href="./values.yaml#L548">externalClickhouse.existingSecretPasswordKey</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Name of the key pointing to the password in your Kubernetes secret</td>
@@ -338,10 +279,7 @@ null
 			<td id="externalClickhouse--secure"><a href="./values.yaml#L550">externalClickhouse.secure</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Whether to use TLS connection connecting to ClickHouse</td>
@@ -350,10 +288,7 @@ false
 			<td id="externalClickhouse--verify"><a href="./values.yaml#L552">externalClickhouse.verify</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Whether to verify TLS connection connecting to ClickHouse</td>
@@ -362,10 +297,7 @@ false
 			<td id="externalClickhouse--httpPort"><a href="./values.yaml#L554">externalClickhouse.httpPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-8123
-</pre>
+				<div style="max-width: 300px;"><code>8123</code>
 </div>
 			</td>
 			<td>HTTP port of Clickhouse</td>
@@ -374,10 +306,7 @@ false
 			<td id="externalClickhouse--tcpPort"><a href="./values.yaml#L556">externalClickhouse.tcpPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-9000
-</pre>
+				<div style="max-width: 300px;"><code>9000</code>
 </div>
 			</td>
 			<td>TCP port of Clickhouse</td>
@@ -386,10 +315,7 @@ false
 			<td id="signoz--name"><a href="./values.yaml#L559">signoz.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"signoz"
-</pre>
+				<div style="max-width: 300px;"><code>"signoz"</code>
 </div>
 			</td>
 			<td></td>
@@ -398,10 +324,7 @@ false
 			<td id="signoz--replicaCount"><a href="./values.yaml#L560">signoz.replicaCount</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1
-</pre>
+				<div style="max-width: 300px;"><code>1</code>
 </div>
 			</td>
 			<td></td>
@@ -410,10 +333,7 @@ false
 			<td id="signoz--image--registry"><a href="./values.yaml#L562">signoz.image.registry</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"docker.io"
-</pre>
+				<div style="max-width: 300px;"><code>"docker.io"</code>
 </div>
 			</td>
 			<td></td>
@@ -422,10 +342,7 @@ false
 			<td id="signoz--image--repository"><a href="./values.yaml#L563">signoz.image.repository</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"signoz/signoz"
-</pre>
+				<div style="max-width: 300px;"><code>"signoz/signoz"</code>
 </div>
 			</td>
 			<td></td>
@@ -434,10 +351,7 @@ false
 			<td id="signoz--image--tag"><a href="./values.yaml#L564">signoz.image.tag</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"v0.89.0"
-</pre>
+				<div style="max-width: 300px;"><code>"v0.89.0"</code>
 </div>
 			</td>
 			<td></td>
@@ -446,10 +360,7 @@ false
 			<td id="signoz--image--pullPolicy"><a href="./values.yaml#L565">signoz.image.pullPolicy</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"IfNotPresent"
-</pre>
+				<div style="max-width: 300px;"><code>"IfNotPresent"</code>
 </div>
 			</td>
 			<td></td>
@@ -458,10 +369,7 @@ false
 			<td id="signoz--imagePullSecrets"><a href="./values.yaml#L568">signoz.imagePullSecrets</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Image Registry Secret Names for signoz If set, this has higher precedence than the root level or global value of imagePullSecrets.</td>
@@ -470,10 +378,7 @@ false
 			<td id="signoz--serviceAccount--create"><a href="./values.yaml#L572">signoz.serviceAccount.create</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td></td>
@@ -482,10 +387,7 @@ true
 			<td id="signoz--serviceAccount--annotations"><a href="./values.yaml#L574">signoz.serviceAccount.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td></td>
@@ -494,10 +396,7 @@ true
 			<td id="signoz--serviceAccount--name"><a href="./values.yaml#L577">signoz.serviceAccount.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td></td>
@@ -506,10 +405,7 @@ null
 			<td id="signoz--service--annotations"><a href="./values.yaml#L581">signoz.service.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Annotations to use by service associated to signoz</td>
@@ -518,10 +414,7 @@ null
 			<td id="signoz--service--labels"><a href="./values.yaml#L583">signoz.service.labels</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Labels to use by service associated to signoz</td>
@@ -530,10 +423,7 @@ null
 			<td id="signoz--service--type"><a href="./values.yaml#L585">signoz.service.type</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"ClusterIP"
-</pre>
+				<div style="max-width: 300px;"><code>"ClusterIP"</code>
 </div>
 			</td>
 			<td>Service Type: LoadBalancer (allows external access) or NodePort (more secure, no extra cost)</td>
@@ -542,10 +432,7 @@ null
 			<td id="signoz--service--port"><a href="./values.yaml#L587">signoz.service.port</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-8080
-</pre>
+				<div style="max-width: 300px;"><code>8080</code>
 </div>
 			</td>
 			<td>signoz HTTP port</td>
@@ -554,10 +441,7 @@ null
 			<td id="signoz--service--internalPort"><a href="./values.yaml#L589">signoz.service.internalPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-8085
-</pre>
+				<div style="max-width: 300px;"><code>8085</code>
 </div>
 			</td>
 			<td>signoz Internal port</td>
@@ -566,10 +450,7 @@ null
 			<td id="signoz--service--opampPort"><a href="./values.yaml#L591">signoz.service.opampPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-4320
-</pre>
+				<div style="max-width: 300px;"><code>4320</code>
 </div>
 			</td>
 			<td>signoz OpAMP Internal port</td>
@@ -578,10 +459,7 @@ null
 			<td id="signoz--service--nodePort"><a href="./values.yaml#L594">signoz.service.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Set this if you want to force a specific nodePort for http. Must be use with service.type=NodePort</td>
@@ -590,10 +468,7 @@ null
 			<td id="signoz--service--internalNodePort"><a href="./values.yaml#L597">signoz.service.internalNodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Set this if you want to force a specific nodePort for internal. Must be use with service.type=NodePort</td>
@@ -602,10 +477,7 @@ null
 			<td id="signoz--service--opampInternalNodePort"><a href="./values.yaml#L600">signoz.service.opampInternalNodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Set this if you want to force a specific nodePort for OpAMP. Must be use with service.type=NodePort</td>
@@ -614,10 +486,7 @@ null
 			<td id="signoz--annotations"><a href="./values.yaml#L602">signoz.annotations</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>signoz annotations</td>
@@ -626,10 +495,7 @@ null
 			<td id="signoz--additionalArgs"><a href="./values.yaml#L604">signoz.additionalArgs</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>signoz additional arguments for command line</td>
@@ -638,10 +504,7 @@ null
 			<td id="signoz--env--storage"><a href="./values.yaml#L622">signoz.env.storage</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"clickhouse"
-</pre>
+				<div style="max-width: 300px;"><code>"clickhouse"</code>
 </div>
 			</td>
 			<td></td>
@@ -650,10 +513,7 @@ null
 			<td id="signoz--env--godebug"><a href="./values.yaml#L623">signoz.env.godebug</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"netdns=go"
-</pre>
+				<div style="max-width: 300px;"><code>"netdns=go"</code>
 </div>
 			</td>
 			<td></td>
@@ -662,10 +522,7 @@ null
 			<td id="signoz--env--telemetry_enabled"><a href="./values.yaml#L624">signoz.env.telemetry_enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td></td>
@@ -674,10 +531,7 @@ true
 			<td id="signoz--env--deployment_type"><a href="./values.yaml#L625">signoz.env.deployment_type</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"kubernetes-helm"
-</pre>
+				<div style="max-width: 300px;"><code>"kubernetes-helm"</code>
 </div>
 			</td>
 			<td></td>
@@ -686,10 +540,7 @@ true
 			<td id="signoz--env--dot_metrics_enabled"><a href="./values.yaml#L626">signoz.env.dot_metrics_enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td></td>
@@ -698,10 +549,7 @@ true
 			<td id="signoz--env--signoz_alertmanager_provider"><a href="./values.yaml#L627">signoz.env.signoz_alertmanager_provider</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"signoz"
-</pre>
+				<div style="max-width: 300px;"><code>"signoz"</code>
 </div>
 			</td>
 			<td></td>
@@ -710,10 +558,7 @@ true
 			<td id="signoz--env--smtp_enabled"><a href="./values.yaml#L634">signoz.env.smtp_enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Enable SMTP for user invitations. Sets `SMTP_ENABLED` to true when enabled.</td>
@@ -722,10 +567,7 @@ false
 			<td id="signoz--initContainers--init--enabled"><a href="./values.yaml#L638">signoz.initContainers.init.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td></td>
@@ -734,10 +576,7 @@ true
 			<td id="signoz--initContainers--init--image--registry"><a href="./values.yaml#L640">signoz.initContainers.init.image.registry</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"docker.io"
-</pre>
+				<div style="max-width: 300px;"><code>"docker.io"</code>
 </div>
 			</td>
 			<td></td>
@@ -746,10 +585,7 @@ true
 			<td id="signoz--initContainers--init--image--repository"><a href="./values.yaml#L641">signoz.initContainers.init.image.repository</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"busybox"
-</pre>
+				<div style="max-width: 300px;"><code>"busybox"</code>
 </div>
 			</td>
 			<td></td>
@@ -758,10 +594,7 @@ true
 			<td id="signoz--initContainers--init--image--tag"><a href="./values.yaml#L642">signoz.initContainers.init.image.tag</a></td>
 			<td>float</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1.35
-</pre>
+				<div style="max-width: 300px;"><code>1.35</code>
 </div>
 			</td>
 			<td></td>
@@ -770,10 +603,7 @@ true
 			<td id="signoz--initContainers--init--image--pullPolicy"><a href="./values.yaml#L643">signoz.initContainers.init.image.pullPolicy</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"IfNotPresent"
-</pre>
+				<div style="max-width: 300px;"><code>"IfNotPresent"</code>
 </div>
 			</td>
 			<td></td>
@@ -782,10 +612,7 @@ true
 			<td id="signoz--initContainers--init--command--delay"><a href="./values.yaml#L645">signoz.initContainers.init.command.delay</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-5
-</pre>
+				<div style="max-width: 300px;"><code>5</code>
 </div>
 			</td>
 			<td></td>
@@ -794,10 +621,7 @@ true
 			<td id="signoz--initContainers--init--command--endpoint"><a href="./values.yaml#L646">signoz.initContainers.init.command.endpoint</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"/ping"
-</pre>
+				<div style="max-width: 300px;"><code>"/ping"</code>
 </div>
 			</td>
 			<td></td>
@@ -806,10 +630,7 @@ true
 			<td id="signoz--initContainers--init--command--waitMessage"><a href="./values.yaml#L647">signoz.initContainers.init.command.waitMessage</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"waiting for clickhouseDB"
-</pre>
+				<div style="max-width: 300px;"><code>"waiting for clickhouseDB"</code>
 </div>
 			</td>
 			<td></td>
@@ -818,10 +639,7 @@ true
 			<td id="signoz--initContainers--init--command--doneMessage"><a href="./values.yaml#L648">signoz.initContainers.init.command.doneMessage</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"clickhouse ready, starting query service now"
-</pre>
+				<div style="max-width: 300px;"><code>"clickhouse ready, starting query service now"</code>
 </div>
 			</td>
 			<td></td>
@@ -830,10 +648,7 @@ true
 			<td id="signoz--initContainers--init--resources"><a href="./values.yaml#L649">signoz.initContainers.init.resources</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td></td>
@@ -842,10 +657,7 @@ true
 			<td id="signoz--initContainers--migration--enabled"><a href="./values.yaml#L657">signoz.initContainers.migration.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td></td>
@@ -854,10 +666,7 @@ false
 			<td id="signoz--initContainers--migration--image--registry"><a href="./values.yaml#L659">signoz.initContainers.migration.image.registry</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"docker.io"
-</pre>
+				<div style="max-width: 300px;"><code>"docker.io"</code>
 </div>
 			</td>
 			<td></td>
@@ -866,10 +675,7 @@ false
 			<td id="signoz--initContainers--migration--image--repository"><a href="./values.yaml#L660">signoz.initContainers.migration.image.repository</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"busybox"
-</pre>
+				<div style="max-width: 300px;"><code>"busybox"</code>
 </div>
 			</td>
 			<td></td>
@@ -878,10 +684,7 @@ false
 			<td id="signoz--initContainers--migration--image--tag"><a href="./values.yaml#L661">signoz.initContainers.migration.image.tag</a></td>
 			<td>float</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1.35
-</pre>
+				<div style="max-width: 300px;"><code>1.35</code>
 </div>
 			</td>
 			<td></td>
@@ -890,10 +693,7 @@ false
 			<td id="signoz--initContainers--migration--image--pullPolicy"><a href="./values.yaml#L662">signoz.initContainers.migration.image.pullPolicy</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"IfNotPresent"
-</pre>
+				<div style="max-width: 300px;"><code>"IfNotPresent"</code>
 </div>
 			</td>
 			<td></td>
@@ -902,10 +702,7 @@ false
 			<td id="signoz--initContainers--migration--args"><a href="./values.yaml#L663">signoz.initContainers.migration.args</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td></td>
@@ -914,10 +711,7 @@ false
 			<td id="signoz--initContainers--migration--command"><a href="./values.yaml#L664">signoz.initContainers.migration.command</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td></td>
@@ -926,10 +720,7 @@ false
 			<td id="signoz--initContainers--migration--resources"><a href="./values.yaml#L671">signoz.initContainers.migration.resources</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td></td>
@@ -938,10 +729,7 @@ false
 			<td id="signoz--initContainers--migration--additionalVolumeMounts"><a href="./values.yaml#L679">signoz.initContainers.migration.additionalVolumeMounts</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Additional volume mounts for signoz</td>
@@ -950,10 +738,7 @@ false
 			<td id="signoz--initContainers--migration--additionalVolumes"><a href="./values.yaml#L681">signoz.initContainers.migration.additionalVolumes</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Additional volumes for signoz</td>
@@ -962,10 +747,7 @@ false
 			<td id="signoz--podSecurityContext"><a href="./values.yaml#L684">signoz.podSecurityContext</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Pod security context for signoz</td>
@@ -974,10 +756,7 @@ false
 			<td id="signoz--podAnnotations"><a href="./values.yaml#L687">signoz.podAnnotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Pod annotations for signoz</td>
@@ -986,10 +765,7 @@ false
 			<td id="signoz--securityContext"><a href="./values.yaml#L689">signoz.securityContext</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Security context for signoz</td>
@@ -998,10 +774,7 @@ false
 			<td id="signoz--additionalVolumeMounts"><a href="./values.yaml#L698">signoz.additionalVolumeMounts</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Additional volume mounts for signoz</td>
@@ -1010,10 +783,7 @@ false
 			<td id="signoz--additionalVolumes"><a href="./values.yaml#L700">signoz.additionalVolumes</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Additional volumes for signoz</td>
@@ -1022,9 +792,7 @@ false
 			<td id="signoz--livenessProbe"><a href="./values.yaml#L703">signoz.livenessProbe</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{
+				<div style="max-width: 300px;"><code>{
   "enabled": true,
   "failureThreshold": 6,
   "initialDelaySeconds": 5,
@@ -1033,8 +801,7 @@ false
   "port": "http",
   "successThreshold": 1,
   "timeoutSeconds": 5
-}
-</pre>
+}</code>
 </div>
 			</td>
 			<td>Configure liveness and readiness probes. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes</td>
@@ -1043,10 +810,7 @@ false
 			<td id="signoz--readinessProbe--enabled"><a href="./values.yaml#L713">signoz.readinessProbe.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td></td>
@@ -1055,10 +819,7 @@ true
 			<td id="signoz--readinessProbe--port"><a href="./values.yaml#L714">signoz.readinessProbe.port</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"http"
-</pre>
+				<div style="max-width: 300px;"><code>"http"</code>
 </div>
 			</td>
 			<td></td>
@@ -1067,10 +828,7 @@ true
 			<td id="signoz--readinessProbe--path"><a href="./values.yaml#L715">signoz.readinessProbe.path</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"/api/v1/health?live=1"
-</pre>
+				<div style="max-width: 300px;"><code>"/api/v1/health?live=1"</code>
 </div>
 			</td>
 			<td></td>
@@ -1079,10 +837,7 @@ true
 			<td id="signoz--readinessProbe--initialDelaySeconds"><a href="./values.yaml#L716">signoz.readinessProbe.initialDelaySeconds</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-5
-</pre>
+				<div style="max-width: 300px;"><code>5</code>
 </div>
 			</td>
 			<td></td>
@@ -1091,10 +846,7 @@ true
 			<td id="signoz--readinessProbe--periodSeconds"><a href="./values.yaml#L717">signoz.readinessProbe.periodSeconds</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-10
-</pre>
+				<div style="max-width: 300px;"><code>10</code>
 </div>
 			</td>
 			<td></td>
@@ -1103,10 +855,7 @@ true
 			<td id="signoz--readinessProbe--timeoutSeconds"><a href="./values.yaml#L718">signoz.readinessProbe.timeoutSeconds</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-5
-</pre>
+				<div style="max-width: 300px;"><code>5</code>
 </div>
 			</td>
 			<td></td>
@@ -1115,10 +864,7 @@ true
 			<td id="signoz--readinessProbe--failureThreshold"><a href="./values.yaml#L719">signoz.readinessProbe.failureThreshold</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-6
-</pre>
+				<div style="max-width: 300px;"><code>6</code>
 </div>
 			</td>
 			<td></td>
@@ -1127,10 +873,7 @@ true
 			<td id="signoz--readinessProbe--successThreshold"><a href="./values.yaml#L720">signoz.readinessProbe.successThreshold</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1
-</pre>
+				<div style="max-width: 300px;"><code>1</code>
 </div>
 			</td>
 			<td></td>
@@ -1139,10 +882,7 @@ true
 			<td id="signoz--customLivenessProbe"><a href="./values.yaml#L722">signoz.customLivenessProbe</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Custom liveness probe</td>
@@ -1151,10 +891,7 @@ true
 			<td id="signoz--customReadinessProbe"><a href="./values.yaml#L724">signoz.customReadinessProbe</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Custom readiness probe</td>
@@ -1163,10 +900,7 @@ true
 			<td id="signoz--ingress--enabled"><a href="./values.yaml#L727">signoz.ingress.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Enable ingress for signoz</td>
@@ -1175,10 +909,7 @@ false
 			<td id="signoz--ingress--className"><a href="./values.yaml#L729">signoz.ingress.className</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Ingress Class Name to be used to identify ingress controllers</td>
@@ -1187,10 +918,7 @@ false
 			<td id="signoz--ingress--annotations"><a href="./values.yaml#L731">signoz.ingress.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Annotations to signoz Ingress</td>
@@ -1199,9 +927,7 @@ false
 			<td id="signoz--ingress--hosts"><a href="./values.yaml#L736">signoz.ingress.hosts</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[
+				<div style="max-width: 300px;"><code>[
   {
     "host": "signoz.domain.com",
     "paths": [
@@ -1212,8 +938,7 @@ false
       }
     ]
   }
-]
-</pre>
+]</code>
 </div>
 			</td>
 			<td>signoz Ingress Host names with their path details</td>
@@ -1222,10 +947,7 @@ false
 			<td id="signoz--ingress--tls"><a href="./values.yaml#L743">signoz.ingress.tls</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>signoz Ingress TLS</td>
@@ -1234,10 +956,7 @@ false
 			<td id="signoz--resources"><a href="./values.yaml#L752">signoz.resources</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="">
-See `values.yaml` for defaults
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Configure resource requests and limits. Update according to your own use case as these values might not be suitable for your workload. Ref: http://kubernetes.io/docs/user-guide/compute-resources/ </td>
@@ -1246,10 +965,7 @@ See `values.yaml` for defaults
 			<td id="signoz--priorityClassName"><a href="./values.yaml#L760">signoz.priorityClassName</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Priority class name for signoz</td>
@@ -1258,10 +974,7 @@ See `values.yaml` for defaults
 			<td id="signoz--nodeSelector"><a href="./values.yaml#L762">signoz.nodeSelector</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Node selector for settings for signoz pod</td>
@@ -1270,10 +983,7 @@ See `values.yaml` for defaults
 			<td id="signoz--tolerations"><a href="./values.yaml#L764">signoz.tolerations</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Toleration labels for signoz pod assignment</td>
@@ -1282,10 +992,7 @@ See `values.yaml` for defaults
 			<td id="signoz--affinity"><a href="./values.yaml#L766">signoz.affinity</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Affinity settings for signoz pod</td>
@@ -1294,10 +1001,7 @@ See `values.yaml` for defaults
 			<td id="signoz--topologySpreadConstraints"><a href="./values.yaml#L768">signoz.topologySpreadConstraints</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>TopologySpreadConstraints describes how g pods ought to spread</td>
@@ -1306,10 +1010,7 @@ See `values.yaml` for defaults
 			<td id="signoz--persistence--enabled"><a href="./values.yaml#L771">signoz.persistence.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Enable data persistence using PVC for SQLiteDB data.</td>
@@ -1318,10 +1019,7 @@ true
 			<td id="signoz--persistence--existingClaim"><a href="./values.yaml#L773">signoz.persistence.existingClaim</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Name of an existing PVC to use (only when deploying a single replica)</td>
@@ -1330,10 +1028,7 @@ true
 			<td id="signoz--persistence--storageClass"><a href="./values.yaml#L780">signoz.persistence.storageClass</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Persistent Volume Storage Class to use. If defined, `storageClassName: <storageClass>`. If set to "-", `storageClassName: ""`, which disables dynamic provisioning If undefined (the default) or set to `null`, no storageClassName spec is set, choosing the default provisioner. </td>
@@ -1342,12 +1037,9 @@ null
 			<td id="signoz--persistence--accessModes"><a href="./values.yaml#L782">signoz.persistence.accessModes</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[
+				<div style="max-width: 300px;"><code>[
   "ReadWriteOnce"
-]
-</pre>
+]</code>
 </div>
 			</td>
 			<td>Access Modes for persistent volume</td>
@@ -1356,10 +1048,7 @@ null
 			<td id="signoz--persistence--size"><a href="./values.yaml#L785">signoz.persistence.size</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"1Gi"
-</pre>
+				<div style="max-width: 300px;"><code>"1Gi"</code>
 </div>
 			</td>
 			<td>Persistent Volume size</td>
@@ -1368,10 +1057,7 @@ null
 			<td id="schemaMigrator--enabled"><a href="./values.yaml#L788">schemaMigrator.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td></td>
@@ -1380,10 +1066,7 @@ true
 			<td id="schemaMigrator--name"><a href="./values.yaml#L789">schemaMigrator.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"schema-migrator"
-</pre>
+				<div style="max-width: 300px;"><code>"schema-migrator"</code>
 </div>
 			</td>
 			<td></td>
@@ -1392,10 +1075,7 @@ true
 			<td id="schemaMigrator--image--registry"><a href="./values.yaml#L791">schemaMigrator.image.registry</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"docker.io"
-</pre>
+				<div style="max-width: 300px;"><code>"docker.io"</code>
 </div>
 			</td>
 			<td></td>
@@ -1404,10 +1084,7 @@ true
 			<td id="schemaMigrator--image--repository"><a href="./values.yaml#L792">schemaMigrator.image.repository</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"signoz/signoz-schema-migrator"
-</pre>
+				<div style="max-width: 300px;"><code>"signoz/signoz-schema-migrator"</code>
 </div>
 			</td>
 			<td></td>
@@ -1416,10 +1093,7 @@ true
 			<td id="schemaMigrator--image--tag"><a href="./values.yaml#L793">schemaMigrator.image.tag</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"v0.128.0"
-</pre>
+				<div style="max-width: 300px;"><code>"v0.128.0"</code>
 </div>
 			</td>
 			<td></td>
@@ -1428,10 +1102,7 @@ true
 			<td id="schemaMigrator--image--pullPolicy"><a href="./values.yaml#L794">schemaMigrator.image.pullPolicy</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"IfNotPresent"
-</pre>
+				<div style="max-width: 300px;"><code>"IfNotPresent"</code>
 </div>
 			</td>
 			<td></td>
@@ -1440,10 +1111,7 @@ true
 			<td id="schemaMigrator--args[0]"><a href="./values.yaml#L796">schemaMigrator.args[0]</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"--up="
-</pre>
+				<div style="max-width: 300px;"><code>"--up="</code>
 </div>
 			</td>
 			<td></td>
@@ -1452,10 +1120,7 @@ true
 			<td id="schemaMigrator--annotations"><a href="./values.yaml#L800">schemaMigrator.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td></td>
@@ -1464,10 +1129,7 @@ true
 			<td id="schemaMigrator--upgradeHelmHooks"><a href="./values.yaml#L803">schemaMigrator.upgradeHelmHooks</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td></td>
@@ -1476,10 +1138,7 @@ true
 			<td id="schemaMigrator--enableReplication"><a href="./values.yaml#L805">schemaMigrator.enableReplication</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Whether to enable replication for schemaMigrator</td>
@@ -1488,10 +1147,7 @@ false
 			<td id="schemaMigrator--nodeSelector"><a href="./values.yaml#L807">schemaMigrator.nodeSelector</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Node selector for settings for schemaMigrator</td>
@@ -1500,10 +1156,7 @@ false
 			<td id="schemaMigrator--tolerations"><a href="./values.yaml#L809">schemaMigrator.tolerations</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Toleration labels for schemaMigrator assignment</td>
@@ -1512,10 +1165,7 @@ false
 			<td id="schemaMigrator--affinity"><a href="./values.yaml#L811">schemaMigrator.affinity</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Affinity settings for schemaMigrator</td>
@@ -1524,10 +1174,7 @@ false
 			<td id="schemaMigrator--topologySpreadConstraints"><a href="./values.yaml#L813">schemaMigrator.topologySpreadConstraints</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>TopologySpreadConstraints describes how schemaMigrator pods ought to spread</td>
@@ -1536,10 +1183,7 @@ false
 			<td id="schemaMigrator--initContainers--init--enabled"><a href="./values.yaml#L816">schemaMigrator.initContainers.init.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td></td>
@@ -1548,10 +1192,7 @@ true
 			<td id="schemaMigrator--initContainers--init--image--registry"><a href="./values.yaml#L818">schemaMigrator.initContainers.init.image.registry</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"docker.io"
-</pre>
+				<div style="max-width: 300px;"><code>"docker.io"</code>
 </div>
 			</td>
 			<td></td>
@@ -1560,10 +1201,7 @@ true
 			<td id="schemaMigrator--initContainers--init--image--repository"><a href="./values.yaml#L819">schemaMigrator.initContainers.init.image.repository</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"busybox"
-</pre>
+				<div style="max-width: 300px;"><code>"busybox"</code>
 </div>
 			</td>
 			<td></td>
@@ -1572,10 +1210,7 @@ true
 			<td id="schemaMigrator--initContainers--init--image--tag"><a href="./values.yaml#L820">schemaMigrator.initContainers.init.image.tag</a></td>
 			<td>float</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1.35
-</pre>
+				<div style="max-width: 300px;"><code>1.35</code>
 </div>
 			</td>
 			<td></td>
@@ -1584,10 +1219,7 @@ true
 			<td id="schemaMigrator--initContainers--init--image--pullPolicy"><a href="./values.yaml#L821">schemaMigrator.initContainers.init.image.pullPolicy</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"IfNotPresent"
-</pre>
+				<div style="max-width: 300px;"><code>"IfNotPresent"</code>
 </div>
 			</td>
 			<td></td>
@@ -1596,10 +1228,7 @@ true
 			<td id="schemaMigrator--initContainers--init--command--delay"><a href="./values.yaml#L823">schemaMigrator.initContainers.init.command.delay</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-5
-</pre>
+				<div style="max-width: 300px;"><code>5</code>
 </div>
 			</td>
 			<td></td>
@@ -1608,10 +1237,7 @@ true
 			<td id="schemaMigrator--initContainers--init--command--endpoint"><a href="./values.yaml#L824">schemaMigrator.initContainers.init.command.endpoint</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"/ping"
-</pre>
+				<div style="max-width: 300px;"><code>"/ping"</code>
 </div>
 			</td>
 			<td></td>
@@ -1620,10 +1246,7 @@ true
 			<td id="schemaMigrator--initContainers--init--command--waitMessage"><a href="./values.yaml#L825">schemaMigrator.initContainers.init.command.waitMessage</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"waiting for clickhouseDB"
-</pre>
+				<div style="max-width: 300px;"><code>"waiting for clickhouseDB"</code>
 </div>
 			</td>
 			<td></td>
@@ -1632,10 +1255,7 @@ true
 			<td id="schemaMigrator--initContainers--init--command--doneMessage"><a href="./values.yaml#L826">schemaMigrator.initContainers.init.command.doneMessage</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"clickhouse ready, starting schema migrator now"
-</pre>
+				<div style="max-width: 300px;"><code>"clickhouse ready, starting schema migrator now"</code>
 </div>
 			</td>
 			<td></td>
@@ -1644,10 +1264,7 @@ true
 			<td id="schemaMigrator--initContainers--init--resources"><a href="./values.yaml#L827">schemaMigrator.initContainers.init.resources</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td></td>
@@ -1656,10 +1273,7 @@ true
 			<td id="schemaMigrator--initContainers--wait--enabled"><a href="./values.yaml#L899">schemaMigrator.initContainers.wait.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td></td>
@@ -1668,10 +1282,7 @@ true
 			<td id="schemaMigrator--initContainers--wait--image--registry"><a href="./values.yaml#L901">schemaMigrator.initContainers.wait.image.registry</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"docker.io"
-</pre>
+				<div style="max-width: 300px;"><code>"docker.io"</code>
 </div>
 			</td>
 			<td></td>
@@ -1680,10 +1291,7 @@ true
 			<td id="schemaMigrator--initContainers--wait--image--repository"><a href="./values.yaml#L902">schemaMigrator.initContainers.wait.image.repository</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"groundnuty/k8s-wait-for"
-</pre>
+				<div style="max-width: 300px;"><code>"groundnuty/k8s-wait-for"</code>
 </div>
 			</td>
 			<td></td>
@@ -1692,10 +1300,7 @@ true
 			<td id="schemaMigrator--initContainers--wait--image--tag"><a href="./values.yaml#L903">schemaMigrator.initContainers.wait.image.tag</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"v2.0"
-</pre>
+				<div style="max-width: 300px;"><code>"v2.0"</code>
 </div>
 			</td>
 			<td></td>
@@ -1704,10 +1309,7 @@ true
 			<td id="schemaMigrator--initContainers--wait--image--pullPolicy"><a href="./values.yaml#L904">schemaMigrator.initContainers.wait.image.pullPolicy</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"IfNotPresent"
-</pre>
+				<div style="max-width: 300px;"><code>"IfNotPresent"</code>
 </div>
 			</td>
 			<td></td>
@@ -1716,10 +1318,7 @@ true
 			<td id="schemaMigrator--initContainers--wait--env"><a href="./values.yaml#L905">schemaMigrator.initContainers.wait.env</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td></td>
@@ -1728,10 +1327,7 @@ true
 			<td id="schemaMigrator--serviceAccount--create"><a href="./values.yaml#L909">schemaMigrator.serviceAccount.create</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td></td>
@@ -1740,10 +1336,7 @@ true
 			<td id="schemaMigrator--serviceAccount--annotations"><a href="./values.yaml#L911">schemaMigrator.serviceAccount.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td></td>
@@ -1752,10 +1345,7 @@ true
 			<td id="schemaMigrator--serviceAccount--name"><a href="./values.yaml#L914">schemaMigrator.serviceAccount.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td></td>
@@ -1764,10 +1354,7 @@ null
 			<td id="schemaMigrator--role--create"><a href="./values.yaml#L918">schemaMigrator.role.create</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Specifies whether a clusterRole should be created</td>
@@ -1776,10 +1363,7 @@ true
 			<td id="schemaMigrator--role--annotations"><a href="./values.yaml#L920">schemaMigrator.role.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Annotations to add to the clusterRole</td>
@@ -1788,10 +1372,7 @@ true
 			<td id="schemaMigrator--role--name"><a href="./values.yaml#L923">schemaMigrator.role.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>The name of the clusterRole to use. If not set and create is true, a name is generated using the fullname template</td>
@@ -1800,10 +1381,7 @@ true
 			<td id="schemaMigrator--role--rules"><a href="./values.yaml#L927">schemaMigrator.role.rules</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="">
-See `values.yaml` for defaults
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>A set of rules as documented here. ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/</td>
@@ -1812,10 +1390,7 @@ See `values.yaml` for defaults
 			<td id="schemaMigrator--role--roleBinding--annotations"><a href="./values.yaml#L934">schemaMigrator.role.roleBinding.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td></td>
@@ -1824,10 +1399,7 @@ See `values.yaml` for defaults
 			<td id="schemaMigrator--role--roleBinding--name"><a href="./values.yaml#L937">schemaMigrator.role.roleBinding.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td></td>
@@ -1836,10 +1408,7 @@ See `values.yaml` for defaults
 			<td id="otelCollector--name"><a href="./values.yaml#L940">otelCollector.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"otel-collector"
-</pre>
+				<div style="max-width: 300px;"><code>"otel-collector"</code>
 </div>
 			</td>
 			<td></td>
@@ -1848,10 +1417,7 @@ See `values.yaml` for defaults
 			<td id="otelCollector--image--registry"><a href="./values.yaml#L942">otelCollector.image.registry</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"docker.io"
-</pre>
+				<div style="max-width: 300px;"><code>"docker.io"</code>
 </div>
 			</td>
 			<td></td>
@@ -1860,10 +1426,7 @@ See `values.yaml` for defaults
 			<td id="otelCollector--image--repository"><a href="./values.yaml#L943">otelCollector.image.repository</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"signoz/signoz-otel-collector"
-</pre>
+				<div style="max-width: 300px;"><code>"signoz/signoz-otel-collector"</code>
 </div>
 			</td>
 			<td></td>
@@ -1872,10 +1435,7 @@ See `values.yaml` for defaults
 			<td id="otelCollector--image--tag"><a href="./values.yaml#L944">otelCollector.image.tag</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"v0.128.0"
-</pre>
+				<div style="max-width: 300px;"><code>"v0.128.0"</code>
 </div>
 			</td>
 			<td></td>
@@ -1884,10 +1444,7 @@ See `values.yaml` for defaults
 			<td id="otelCollector--image--pullPolicy"><a href="./values.yaml#L945">otelCollector.image.pullPolicy</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"IfNotPresent"
-</pre>
+				<div style="max-width: 300px;"><code>"IfNotPresent"</code>
 </div>
 			</td>
 			<td></td>
@@ -1896,10 +1453,7 @@ See `values.yaml` for defaults
 			<td id="otelCollector--imagePullSecrets"><a href="./values.yaml#L948">otelCollector.imagePullSecrets</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Image Registry Secret Names for OtelCollector If set, this has higher precedence than the root level or global value of imagePullSecrets.</td>
@@ -1908,10 +1462,7 @@ See `values.yaml` for defaults
 			<td id="otelCollector--initContainers--init--enabled"><a href="./values.yaml#L951">otelCollector.initContainers.init.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td></td>
@@ -1920,10 +1471,7 @@ false
 			<td id="otelCollector--initContainers--init--image--registry"><a href="./values.yaml#L953">otelCollector.initContainers.init.image.registry</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"docker.io"
-</pre>
+				<div style="max-width: 300px;"><code>"docker.io"</code>
 </div>
 			</td>
 			<td></td>
@@ -1932,10 +1480,7 @@ false
 			<td id="otelCollector--initContainers--init--image--repository"><a href="./values.yaml#L954">otelCollector.initContainers.init.image.repository</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"busybox"
-</pre>
+				<div style="max-width: 300px;"><code>"busybox"</code>
 </div>
 			</td>
 			<td></td>
@@ -1944,10 +1489,7 @@ false
 			<td id="otelCollector--initContainers--init--image--tag"><a href="./values.yaml#L955">otelCollector.initContainers.init.image.tag</a></td>
 			<td>float</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1.35
-</pre>
+				<div style="max-width: 300px;"><code>1.35</code>
 </div>
 			</td>
 			<td></td>
@@ -1956,10 +1498,7 @@ false
 			<td id="otelCollector--initContainers--init--image--pullPolicy"><a href="./values.yaml#L956">otelCollector.initContainers.init.image.pullPolicy</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"IfNotPresent"
-</pre>
+				<div style="max-width: 300px;"><code>"IfNotPresent"</code>
 </div>
 			</td>
 			<td></td>
@@ -1968,10 +1507,7 @@ false
 			<td id="otelCollector--initContainers--init--command--delay"><a href="./values.yaml#L958">otelCollector.initContainers.init.command.delay</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-5
-</pre>
+				<div style="max-width: 300px;"><code>5</code>
 </div>
 			</td>
 			<td></td>
@@ -1980,10 +1516,7 @@ false
 			<td id="otelCollector--initContainers--init--command--endpoint"><a href="./values.yaml#L959">otelCollector.initContainers.init.command.endpoint</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"/ping"
-</pre>
+				<div style="max-width: 300px;"><code>"/ping"</code>
 </div>
 			</td>
 			<td></td>
@@ -1992,10 +1525,7 @@ false
 			<td id="otelCollector--initContainers--init--command--waitMessage"><a href="./values.yaml#L960">otelCollector.initContainers.init.command.waitMessage</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"waiting for clickhouseDB"
-</pre>
+				<div style="max-width: 300px;"><code>"waiting for clickhouseDB"</code>
 </div>
 			</td>
 			<td></td>
@@ -2004,10 +1534,7 @@ false
 			<td id="otelCollector--initContainers--init--command--doneMessage"><a href="./values.yaml#L961">otelCollector.initContainers.init.command.doneMessage</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"clickhouse ready, starting otel collector now"
-</pre>
+				<div style="max-width: 300px;"><code>"clickhouse ready, starting otel collector now"</code>
 </div>
 			</td>
 			<td></td>
@@ -2016,10 +1543,7 @@ false
 			<td id="otelCollector--initContainers--init--resources"><a href="./values.yaml#L962">otelCollector.initContainers.init.resources</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td></td>
@@ -2028,10 +1552,7 @@ false
 			<td id="otelCollector--command--name"><a href="./values.yaml#L972">otelCollector.command.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"/signoz-otel-collector"
-</pre>
+				<div style="max-width: 300px;"><code>"/signoz-otel-collector"</code>
 </div>
 			</td>
 			<td>OtelCollector command name</td>
@@ -2040,12 +1561,9 @@ false
 			<td id="otelCollector--command--extraArgs"><a href="./values.yaml#L974">otelCollector.command.extraArgs</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[
+				<div style="max-width: 300px;"><code>[
   "--feature-gates=-pkg.translator.prometheus.NormalizeName"
-]
-</pre>
+]</code>
 </div>
 			</td>
 			<td>OtelCollector command extra arguments</td>
@@ -2054,10 +1572,7 @@ false
 			<td id="otelCollector--configMap--create"><a href="./values.yaml#L978">otelCollector.configMap.create</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Specifies whether a configMap should be created (true by default)</td>
@@ -2066,10 +1581,7 @@ true
 			<td id="otelCollector--serviceAccount--create"><a href="./values.yaml#L982">otelCollector.serviceAccount.create</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td></td>
@@ -2078,10 +1590,7 @@ true
 			<td id="otelCollector--serviceAccount--annotations"><a href="./values.yaml#L984">otelCollector.serviceAccount.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td></td>
@@ -2090,10 +1599,7 @@ true
 			<td id="otelCollector--serviceAccount--name"><a href="./values.yaml#L987">otelCollector.serviceAccount.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td></td>
@@ -2102,10 +1608,7 @@ null
 			<td id="otelCollector--service--annotations"><a href="./values.yaml#L991">otelCollector.service.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Annotations to use by service associated to OtelCollector</td>
@@ -2114,10 +1617,7 @@ null
 			<td id="otelCollector--service--labels"><a href="./values.yaml#L993">otelCollector.service.labels</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Labels to use by service associated to OtelCollector</td>
@@ -2126,10 +1626,7 @@ null
 			<td id="otelCollector--service--type"><a href="./values.yaml#L995">otelCollector.service.type</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"ClusterIP"
-</pre>
+				<div style="max-width: 300px;"><code>"ClusterIP"</code>
 </div>
 			</td>
 			<td>Service Type: LoadBalancer (allows external access) or NodePort (more secure, no extra cost)</td>
@@ -2138,10 +1635,7 @@ null
 			<td id="otelCollector--service--loadBalancerSourceRanges"><a href="./values.yaml#L997">otelCollector.service.loadBalancerSourceRanges</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>LoadBalancer Source Ranges when service type is LoadBalancer</td>
@@ -2150,10 +1644,7 @@ null
 			<td id="otelCollector--annotations"><a href="./values.yaml#L999">otelCollector.annotations</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>OtelCollector Deployment annotation.</td>
@@ -2162,13 +1653,10 @@ null
 			<td id="otelCollector--podAnnotations"><a href="./values.yaml#L1001">otelCollector.podAnnotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{
+				<div style="max-width: 300px;"><code>{
   "signoz.io/port": "8888",
   "signoz.io/scrape": "true"
-}
-</pre>
+}</code>
 </div>
 			</td>
 			<td>OtelCollector pod(s) annotation.</td>
@@ -2177,10 +1665,7 @@ null
 			<td id="otelCollector--podLabels"><a href="./values.yaml#L1005">otelCollector.podLabels</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>OtelCollector pod(s) labels.</td>
@@ -2189,10 +1674,7 @@ null
 			<td id="otelCollector--additionalEnvs"><a href="./values.yaml#L1007">otelCollector.additionalEnvs</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Additional environments to set for OtelCollector</td>
@@ -2201,10 +1683,7 @@ null
 			<td id="otelCollector--lowCardinalityExceptionGrouping"><a href="./values.yaml#L1013">otelCollector.lowCardinalityExceptionGrouping</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Whether to enable grouping of exceptions with same name and different stack trace. This is useful when you have a lot of exceptions with same name but different stack trace. This is a tradeoff between cardinality and accuracy of exception grouping.</td>
@@ -2213,10 +1692,7 @@ false
 			<td id="otelCollector--minReadySeconds"><a href="./values.yaml#L1014">otelCollector.minReadySeconds</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-5
-</pre>
+				<div style="max-width: 300px;"><code>5</code>
 </div>
 			</td>
 			<td></td>
@@ -2225,10 +1701,7 @@ false
 			<td id="otelCollector--progressDeadlineSeconds"><a href="./values.yaml#L1015">otelCollector.progressDeadlineSeconds</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-600
-</pre>
+				<div style="max-width: 300px;"><code>600</code>
 </div>
 			</td>
 			<td></td>
@@ -2237,10 +1710,7 @@ false
 			<td id="otelCollector--replicaCount"><a href="./values.yaml#L1016">otelCollector.replicaCount</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1
-</pre>
+				<div style="max-width: 300px;"><code>1</code>
 </div>
 			</td>
 			<td></td>
@@ -2249,10 +1719,7 @@ false
 			<td id="otelCollector--clusterRole--create"><a href="./values.yaml#L1020">otelCollector.clusterRole.create</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Specifies whether a clusterRole should be created</td>
@@ -2261,10 +1728,7 @@ true
 			<td id="otelCollector--clusterRole--annotations"><a href="./values.yaml#L1022">otelCollector.clusterRole.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Annotations to add to the clusterRole</td>
@@ -2273,10 +1737,7 @@ true
 			<td id="otelCollector--clusterRole--name"><a href="./values.yaml#L1025">otelCollector.clusterRole.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>The name of the clusterRole to use. If not set and create is true, a name is generated using the fullname template</td>
@@ -2285,10 +1746,7 @@ true
 			<td id="otelCollector--clusterRole--rules"><a href="./values.yaml#L1029">otelCollector.clusterRole.rules</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="">
-See `values.yaml` for defaults
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>A set of rules as documented here. ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/</td>
@@ -2297,10 +1755,7 @@ See `values.yaml` for defaults
 			<td id="otelCollector--clusterRole--clusterRoleBinding--annotations"><a href="./values.yaml#L1046">otelCollector.clusterRole.clusterRoleBinding.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td></td>
@@ -2309,10 +1764,7 @@ See `values.yaml` for defaults
 			<td id="otelCollector--clusterRole--clusterRoleBinding--name"><a href="./values.yaml#L1049">otelCollector.clusterRole.clusterRoleBinding.name</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td></td>
@@ -2321,10 +1773,7 @@ See `values.yaml` for defaults
 			<td id="otelCollector--ports--otlp--enabled"><a href="./values.yaml#L1054">otelCollector.ports.otlp.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Whether to enable service port for OTLP gRPC</td>
@@ -2333,10 +1782,7 @@ true
 			<td id="otelCollector--ports--otlp--containerPort"><a href="./values.yaml#L1056">otelCollector.ports.otlp.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-4317
-</pre>
+				<div style="max-width: 300px;"><code>4317</code>
 </div>
 			</td>
 			<td>Container port for OTLP gRPC</td>
@@ -2345,10 +1791,7 @@ true
 			<td id="otelCollector--ports--otlp--servicePort"><a href="./values.yaml#L1058">otelCollector.ports.otlp.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-4317
-</pre>
+				<div style="max-width: 300px;"><code>4317</code>
 </div>
 			</td>
 			<td>Service port for OTLP gRPC</td>
@@ -2357,10 +1800,7 @@ true
 			<td id="otelCollector--ports--otlp--nodePort"><a href="./values.yaml#L1060">otelCollector.ports.otlp.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for OTLP gRPC</td>
@@ -2369,10 +1809,7 @@ true
 			<td id="otelCollector--ports--otlp--protocol"><a href="./values.yaml#L1062">otelCollector.ports.otlp.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for OTLP gRPC</td>
@@ -2381,10 +1818,7 @@ true
 			<td id="otelCollector--ports--otlp-http--enabled"><a href="./values.yaml#L1065">otelCollector.ports.otlp-http.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Whether to enable service port for OTLP HTTP</td>
@@ -2393,10 +1827,7 @@ true
 			<td id="otelCollector--ports--otlp-http--containerPort"><a href="./values.yaml#L1067">otelCollector.ports.otlp-http.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-4318
-</pre>
+				<div style="max-width: 300px;"><code>4318</code>
 </div>
 			</td>
 			<td>Container port for OTLP HTTP</td>
@@ -2405,10 +1836,7 @@ true
 			<td id="otelCollector--ports--otlp-http--servicePort"><a href="./values.yaml#L1069">otelCollector.ports.otlp-http.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-4318
-</pre>
+				<div style="max-width: 300px;"><code>4318</code>
 </div>
 			</td>
 			<td>Service port for OTLP HTTP</td>
@@ -2417,10 +1845,7 @@ true
 			<td id="otelCollector--ports--otlp-http--nodePort"><a href="./values.yaml#L1071">otelCollector.ports.otlp-http.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for OTLP HTTP</td>
@@ -2429,10 +1854,7 @@ true
 			<td id="otelCollector--ports--otlp-http--protocol"><a href="./values.yaml#L1073">otelCollector.ports.otlp-http.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for OTLP HTTP</td>
@@ -2441,10 +1863,7 @@ true
 			<td id="otelCollector--ports--jaeger-compact--enabled"><a href="./values.yaml#L1076">otelCollector.ports.jaeger-compact.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Whether to enable service port for Jaeger Compact</td>
@@ -2453,10 +1872,7 @@ false
 			<td id="otelCollector--ports--jaeger-compact--containerPort"><a href="./values.yaml#L1078">otelCollector.ports.jaeger-compact.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-6831
-</pre>
+				<div style="max-width: 300px;"><code>6831</code>
 </div>
 			</td>
 			<td>Container port for Jaeger Compact</td>
@@ -2465,10 +1881,7 @@ false
 			<td id="otelCollector--ports--jaeger-compact--servicePort"><a href="./values.yaml#L1080">otelCollector.ports.jaeger-compact.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-6831
-</pre>
+				<div style="max-width: 300px;"><code>6831</code>
 </div>
 			</td>
 			<td>Service port for Jaeger Compact</td>
@@ -2477,10 +1890,7 @@ false
 			<td id="otelCollector--ports--jaeger-compact--nodePort"><a href="./values.yaml#L1082">otelCollector.ports.jaeger-compact.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for Jaeger Compact</td>
@@ -2489,10 +1899,7 @@ false
 			<td id="otelCollector--ports--jaeger-compact--protocol"><a href="./values.yaml#L1084">otelCollector.ports.jaeger-compact.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"UDP"
-</pre>
+				<div style="max-width: 300px;"><code>"UDP"</code>
 </div>
 			</td>
 			<td>Protocol to use for Jaeger Compact</td>
@@ -2501,10 +1908,7 @@ false
 			<td id="otelCollector--ports--jaeger-thrift--enabled"><a href="./values.yaml#L1087">otelCollector.ports.jaeger-thrift.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Whether to enable service port for Jaeger Thrift HTTP</td>
@@ -2513,10 +1917,7 @@ true
 			<td id="otelCollector--ports--jaeger-thrift--containerPort"><a href="./values.yaml#L1089">otelCollector.ports.jaeger-thrift.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-14268
-</pre>
+				<div style="max-width: 300px;"><code>14268</code>
 </div>
 			</td>
 			<td>Container port for Jaeger Thrift</td>
@@ -2525,10 +1926,7 @@ true
 			<td id="otelCollector--ports--jaeger-thrift--servicePort"><a href="./values.yaml#L1091">otelCollector.ports.jaeger-thrift.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-14268
-</pre>
+				<div style="max-width: 300px;"><code>14268</code>
 </div>
 			</td>
 			<td>Service port for Jaeger Thrift</td>
@@ -2537,10 +1935,7 @@ true
 			<td id="otelCollector--ports--jaeger-thrift--nodePort"><a href="./values.yaml#L1093">otelCollector.ports.jaeger-thrift.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for Jaeger Thrift</td>
@@ -2549,10 +1944,7 @@ true
 			<td id="otelCollector--ports--jaeger-thrift--protocol"><a href="./values.yaml#L1095">otelCollector.ports.jaeger-thrift.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for Jaeger Thrift</td>
@@ -2561,10 +1953,7 @@ true
 			<td id="otelCollector--ports--jaeger-grpc--enabled"><a href="./values.yaml#L1098">otelCollector.ports.jaeger-grpc.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Whether to enable service port for Jaeger gRPC</td>
@@ -2573,10 +1962,7 @@ true
 			<td id="otelCollector--ports--jaeger-grpc--containerPort"><a href="./values.yaml#L1100">otelCollector.ports.jaeger-grpc.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-14250
-</pre>
+				<div style="max-width: 300px;"><code>14250</code>
 </div>
 			</td>
 			<td>Container port for Jaeger gRPC</td>
@@ -2585,10 +1971,7 @@ true
 			<td id="otelCollector--ports--jaeger-grpc--servicePort"><a href="./values.yaml#L1102">otelCollector.ports.jaeger-grpc.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-14250
-</pre>
+				<div style="max-width: 300px;"><code>14250</code>
 </div>
 			</td>
 			<td>Service port for Jaeger gRPC</td>
@@ -2597,10 +1980,7 @@ true
 			<td id="otelCollector--ports--jaeger-grpc--nodePort"><a href="./values.yaml#L1104">otelCollector.ports.jaeger-grpc.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for Jaeger gRPC</td>
@@ -2609,10 +1989,7 @@ true
 			<td id="otelCollector--ports--jaeger-grpc--protocol"><a href="./values.yaml#L1106">otelCollector.ports.jaeger-grpc.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for Jaeger gRPC</td>
@@ -2621,10 +1998,7 @@ true
 			<td id="otelCollector--ports--zipkin--enabled"><a href="./values.yaml#L1109">otelCollector.ports.zipkin.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Whether to enable service port for Zipkin</td>
@@ -2633,10 +2007,7 @@ false
 			<td id="otelCollector--ports--zipkin--containerPort"><a href="./values.yaml#L1111">otelCollector.ports.zipkin.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-9411
-</pre>
+				<div style="max-width: 300px;"><code>9411</code>
 </div>
 			</td>
 			<td>Container port for Zipkin</td>
@@ -2645,10 +2016,7 @@ false
 			<td id="otelCollector--ports--zipkin--servicePort"><a href="./values.yaml#L1113">otelCollector.ports.zipkin.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-9411
-</pre>
+				<div style="max-width: 300px;"><code>9411</code>
 </div>
 			</td>
 			<td>Service port for Zipkin</td>
@@ -2657,10 +2025,7 @@ false
 			<td id="otelCollector--ports--zipkin--nodePort"><a href="./values.yaml#L1115">otelCollector.ports.zipkin.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for Zipkin</td>
@@ -2669,10 +2034,7 @@ false
 			<td id="otelCollector--ports--zipkin--protocol"><a href="./values.yaml#L1117">otelCollector.ports.zipkin.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for Zipkin</td>
@@ -2681,10 +2043,7 @@ false
 			<td id="otelCollector--ports--metrics--enabled"><a href="./values.yaml#L1120">otelCollector.ports.metrics.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Whether to enable service port for internal metrics</td>
@@ -2693,10 +2052,7 @@ true
 			<td id="otelCollector--ports--metrics--containerPort"><a href="./values.yaml#L1122">otelCollector.ports.metrics.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-8888
-</pre>
+				<div style="max-width: 300px;"><code>8888</code>
 </div>
 			</td>
 			<td>Container port for internal metrics</td>
@@ -2705,10 +2061,7 @@ true
 			<td id="otelCollector--ports--metrics--servicePort"><a href="./values.yaml#L1124">otelCollector.ports.metrics.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-8888
-</pre>
+				<div style="max-width: 300px;"><code>8888</code>
 </div>
 			</td>
 			<td>Service port for internal metrics</td>
@@ -2717,10 +2070,7 @@ true
 			<td id="otelCollector--ports--metrics--nodePort"><a href="./values.yaml#L1126">otelCollector.ports.metrics.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for internal metrics</td>
@@ -2729,10 +2079,7 @@ true
 			<td id="otelCollector--ports--metrics--protocol"><a href="./values.yaml#L1128">otelCollector.ports.metrics.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for internal metrics</td>
@@ -2741,10 +2088,7 @@ true
 			<td id="otelCollector--ports--zpages--enabled"><a href="./values.yaml#L1131">otelCollector.ports.zpages.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Whether to enable service port for ZPages</td>
@@ -2753,10 +2097,7 @@ false
 			<td id="otelCollector--ports--zpages--containerPort"><a href="./values.yaml#L1133">otelCollector.ports.zpages.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-55679
-</pre>
+				<div style="max-width: 300px;"><code>55679</code>
 </div>
 			</td>
 			<td>Container port for Zpages</td>
@@ -2765,10 +2106,7 @@ false
 			<td id="otelCollector--ports--zpages--servicePort"><a href="./values.yaml#L1135">otelCollector.ports.zpages.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-55679
-</pre>
+				<div style="max-width: 300px;"><code>55679</code>
 </div>
 			</td>
 			<td>Service port for Zpages</td>
@@ -2777,10 +2115,7 @@ false
 			<td id="otelCollector--ports--zpages--nodePort"><a href="./values.yaml#L1137">otelCollector.ports.zpages.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for Zpages</td>
@@ -2789,10 +2124,7 @@ false
 			<td id="otelCollector--ports--zpages--protocol"><a href="./values.yaml#L1139">otelCollector.ports.zpages.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for Zpages</td>
@@ -2801,10 +2133,7 @@ false
 			<td id="otelCollector--ports--pprof--enabled"><a href="./values.yaml#L1142">otelCollector.ports.pprof.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Whether to enable service port for pprof</td>
@@ -2813,10 +2142,7 @@ false
 			<td id="otelCollector--ports--pprof--containerPort"><a href="./values.yaml#L1144">otelCollector.ports.pprof.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1777
-</pre>
+				<div style="max-width: 300px;"><code>1777</code>
 </div>
 			</td>
 			<td>Container port for pprof</td>
@@ -2825,10 +2151,7 @@ false
 			<td id="otelCollector--ports--pprof--servicePort"><a href="./values.yaml#L1146">otelCollector.ports.pprof.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1777
-</pre>
+				<div style="max-width: 300px;"><code>1777</code>
 </div>
 			</td>
 			<td>Service port for pprof</td>
@@ -2837,10 +2160,7 @@ false
 			<td id="otelCollector--ports--pprof--nodePort"><a href="./values.yaml#L1148">otelCollector.ports.pprof.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for pprof</td>
@@ -2849,10 +2169,7 @@ false
 			<td id="otelCollector--ports--pprof--protocol"><a href="./values.yaml#L1150">otelCollector.ports.pprof.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for pprof</td>
@@ -2861,10 +2178,7 @@ false
 			<td id="otelCollector--ports--logsheroku--enabled"><a href="./values.yaml#L1153">otelCollector.ports.logsheroku.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Whether to enable service port for logsheroku</td>
@@ -2873,10 +2187,7 @@ true
 			<td id="otelCollector--ports--logsheroku--containerPort"><a href="./values.yaml#L1155">otelCollector.ports.logsheroku.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-8081
-</pre>
+				<div style="max-width: 300px;"><code>8081</code>
 </div>
 			</td>
 			<td>Container port for logsheroku</td>
@@ -2885,10 +2196,7 @@ true
 			<td id="otelCollector--ports--logsheroku--servicePort"><a href="./values.yaml#L1157">otelCollector.ports.logsheroku.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-8081
-</pre>
+				<div style="max-width: 300px;"><code>8081</code>
 </div>
 			</td>
 			<td>Service port for logsheroku</td>
@@ -2897,10 +2205,7 @@ true
 			<td id="otelCollector--ports--logsheroku--nodePort"><a href="./values.yaml#L1159">otelCollector.ports.logsheroku.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for logsheroku</td>
@@ -2909,10 +2214,7 @@ true
 			<td id="otelCollector--ports--logsheroku--protocol"><a href="./values.yaml#L1161">otelCollector.ports.logsheroku.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for logsheroku</td>
@@ -2921,10 +2223,7 @@ true
 			<td id="otelCollector--ports--logsjson--enabled"><a href="./values.yaml#L1164">otelCollector.ports.logsjson.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td>Whether to enable service port for logsjson</td>
@@ -2933,10 +2232,7 @@ true
 			<td id="otelCollector--ports--logsjson--containerPort"><a href="./values.yaml#L1166">otelCollector.ports.logsjson.containerPort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-8082
-</pre>
+				<div style="max-width: 300px;"><code>8082</code>
 </div>
 			</td>
 			<td>Container port for logsjson</td>
@@ -2945,10 +2241,7 @@ true
 			<td id="otelCollector--ports--logsjson--servicePort"><a href="./values.yaml#L1168">otelCollector.ports.logsjson.servicePort</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-8082
-</pre>
+				<div style="max-width: 300px;"><code>8082</code>
 </div>
 			</td>
 			<td>Service port for logsjson</td>
@@ -2957,10 +2250,7 @@ true
 			<td id="otelCollector--ports--logsjson--nodePort"><a href="./values.yaml#L1170">otelCollector.ports.logsjson.nodePort</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Node port for logsjson</td>
@@ -2969,10 +2259,7 @@ true
 			<td id="otelCollector--ports--logsjson--protocol"><a href="./values.yaml#L1172">otelCollector.ports.logsjson.protocol</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"TCP"
-</pre>
+				<div style="max-width: 300px;"><code>"TCP"</code>
 </div>
 			</td>
 			<td>Protocol to use for logsjson</td>
@@ -2981,9 +2268,7 @@ true
 			<td id="otelCollector--livenessProbe"><a href="./values.yaml#L1175">otelCollector.livenessProbe</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{
+				<div style="max-width: 300px;"><code>{
   "enabled": true,
   "failureThreshold": 6,
   "initialDelaySeconds": 5,
@@ -2992,8 +2277,7 @@ true
   "port": 13133,
   "successThreshold": 1,
   "timeoutSeconds": 5
-}
-</pre>
+}</code>
 </div>
 			</td>
 			<td>Configure liveness and readiness probes. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes</td>
@@ -3002,10 +2286,7 @@ true
 			<td id="otelCollector--readinessProbe--enabled"><a href="./values.yaml#L1185">otelCollector.readinessProbe.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-true
-</pre>
+				<div style="max-width: 300px;"><code>true</code>
 </div>
 			</td>
 			<td></td>
@@ -3014,10 +2295,7 @@ true
 			<td id="otelCollector--readinessProbe--port"><a href="./values.yaml#L1186">otelCollector.readinessProbe.port</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-13133
-</pre>
+				<div style="max-width: 300px;"><code>13133</code>
 </div>
 			</td>
 			<td></td>
@@ -3026,10 +2304,7 @@ true
 			<td id="otelCollector--readinessProbe--path"><a href="./values.yaml#L1187">otelCollector.readinessProbe.path</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"/"
-</pre>
+				<div style="max-width: 300px;"><code>"/"</code>
 </div>
 			</td>
 			<td></td>
@@ -3038,10 +2313,7 @@ true
 			<td id="otelCollector--readinessProbe--initialDelaySeconds"><a href="./values.yaml#L1188">otelCollector.readinessProbe.initialDelaySeconds</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-5
-</pre>
+				<div style="max-width: 300px;"><code>5</code>
 </div>
 			</td>
 			<td></td>
@@ -3050,10 +2322,7 @@ true
 			<td id="otelCollector--readinessProbe--periodSeconds"><a href="./values.yaml#L1189">otelCollector.readinessProbe.periodSeconds</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-10
-</pre>
+				<div style="max-width: 300px;"><code>10</code>
 </div>
 			</td>
 			<td></td>
@@ -3062,10 +2331,7 @@ true
 			<td id="otelCollector--readinessProbe--timeoutSeconds"><a href="./values.yaml#L1190">otelCollector.readinessProbe.timeoutSeconds</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-5
-</pre>
+				<div style="max-width: 300px;"><code>5</code>
 </div>
 			</td>
 			<td></td>
@@ -3074,10 +2340,7 @@ true
 			<td id="otelCollector--readinessProbe--failureThreshold"><a href="./values.yaml#L1191">otelCollector.readinessProbe.failureThreshold</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-6
-</pre>
+				<div style="max-width: 300px;"><code>6</code>
 </div>
 			</td>
 			<td></td>
@@ -3086,10 +2349,7 @@ true
 			<td id="otelCollector--readinessProbe--successThreshold"><a href="./values.yaml#L1192">otelCollector.readinessProbe.successThreshold</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1
-</pre>
+				<div style="max-width: 300px;"><code>1</code>
 </div>
 			</td>
 			<td></td>
@@ -3098,10 +2358,7 @@ true
 			<td id="otelCollector--customLivenessProbe"><a href="./values.yaml#L1194">otelCollector.customLivenessProbe</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Custom liveness probe</td>
@@ -3110,10 +2367,7 @@ true
 			<td id="otelCollector--customReadinessProbe"><a href="./values.yaml#L1196">otelCollector.customReadinessProbe</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Custom readiness probe</td>
@@ -3122,10 +2376,7 @@ true
 			<td id="otelCollector--extraVolumeMounts"><a href="./values.yaml#L1198">otelCollector.extraVolumeMounts</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Extra volumes mount for OtelCollector pod</td>
@@ -3134,10 +2385,7 @@ true
 			<td id="otelCollector--extraVolumes"><a href="./values.yaml#L1200">otelCollector.extraVolumes</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Extra volumes for OtelCollector pod</td>
@@ -3146,10 +2394,7 @@ true
 			<td id="otelCollector--ingress--enabled"><a href="./values.yaml#L1203">otelCollector.ingress.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td>Enable ingress for OtelCollector</td>
@@ -3158,10 +2403,7 @@ false
 			<td id="otelCollector--ingress--className"><a href="./values.yaml#L1205">otelCollector.ingress.className</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>Ingress Class Name to be used to identify ingress controllers</td>
@@ -3170,10 +2412,7 @@ false
 			<td id="otelCollector--ingress--annotations"><a href="./values.yaml#L1207">otelCollector.ingress.annotations</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Annotations to OtelCollector Ingress</td>
@@ -3182,9 +2421,7 @@ false
 			<td id="otelCollector--ingress--hosts"><a href="./values.yaml#L1214">otelCollector.ingress.hosts</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[
+				<div style="max-width: 300px;"><code>[
   {
     "host": "otelcollector.domain.com",
     "paths": [
@@ -3195,8 +2432,7 @@ false
       }
     ]
   }
-]
-</pre>
+]</code>
 </div>
 			</td>
 			<td>OtelCollector Ingress Host names with their path details</td>
@@ -3205,10 +2441,7 @@ false
 			<td id="otelCollector--ingress--tls"><a href="./values.yaml#L1221">otelCollector.ingress.tls</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>OtelCollector Ingress TLS</td>
@@ -3217,10 +2450,7 @@ false
 			<td id="otelCollector--resources"><a href="./values.yaml#L1230">otelCollector.resources</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="">
-See `values.yaml` for defaults
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Configure resource requests and limits. Update according to your own use case as these values might not be suitable for your workload. Ref: http://kubernetes.io/docs/user-guide/compute-resources/ </td>
@@ -3229,10 +2459,7 @@ See `values.yaml` for defaults
 			<td id="otelCollector--priorityClassName"><a href="./values.yaml#L1238">otelCollector.priorityClassName</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-""
-</pre>
+				<div style="max-width: 300px;"><code>""</code>
 </div>
 			</td>
 			<td>OtelCollector priority class name</td>
@@ -3241,10 +2468,7 @@ See `values.yaml` for defaults
 			<td id="otelCollector--nodeSelector"><a href="./values.yaml#L1240">otelCollector.nodeSelector</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Node selector for settings for OtelCollector pod</td>
@@ -3253,10 +2477,7 @@ See `values.yaml` for defaults
 			<td id="otelCollector--tolerations"><a href="./values.yaml#L1242">otelCollector.tolerations</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td>Toleration labels for OtelCollector pod assignment</td>
@@ -3265,10 +2486,7 @@ See `values.yaml` for defaults
 			<td id="otelCollector--affinity"><a href="./values.yaml#L1244">otelCollector.affinity</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td>Affinity settings for OtelCollector pod</td>
@@ -3277,9 +2495,7 @@ See `values.yaml` for defaults
 			<td id="otelCollector--topologySpreadConstraints"><a href="./values.yaml#L1246">otelCollector.topologySpreadConstraints</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[
+				<div style="max-width: 300px;"><code>[
   {
     "labelSelector": {
       "matchLabels": {
@@ -3290,8 +2506,7 @@ See `values.yaml` for defaults
     "topologyKey": "kubernetes.io/hostname",
     "whenUnsatisfiable": "ScheduleAnyway"
   }
-]
-</pre>
+]</code>
 </div>
 			</td>
 			<td>TopologySpreadConstraints describes how OtelCollector pods ought to spread</td>
@@ -3300,10 +2515,7 @@ See `values.yaml` for defaults
 			<td id="otelCollector--podSecurityContext"><a href="./values.yaml#L1253">otelCollector.podSecurityContext</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td></td>
@@ -3312,10 +2524,7 @@ See `values.yaml` for defaults
 			<td id="otelCollector--securityContext"><a href="./values.yaml#L1256">otelCollector.securityContext</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td></td>
@@ -3324,10 +2533,7 @@ See `values.yaml` for defaults
 			<td id="otelCollector--autoscaling--enabled"><a href="./values.yaml#L1265">otelCollector.autoscaling.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td></td>
@@ -3336,10 +2542,7 @@ false
 			<td id="otelCollector--autoscaling--minReplicas"><a href="./values.yaml#L1266">otelCollector.autoscaling.minReplicas</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1
-</pre>
+				<div style="max-width: 300px;"><code>1</code>
 </div>
 			</td>
 			<td></td>
@@ -3348,10 +2551,7 @@ false
 			<td id="otelCollector--autoscaling--maxReplicas"><a href="./values.yaml#L1267">otelCollector.autoscaling.maxReplicas</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-11
-</pre>
+				<div style="max-width: 300px;"><code>11</code>
 </div>
 			</td>
 			<td></td>
@@ -3360,10 +2560,7 @@ false
 			<td id="otelCollector--autoscaling--targetCPUUtilizationPercentage"><a href="./values.yaml#L1268">otelCollector.autoscaling.targetCPUUtilizationPercentage</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-50
-</pre>
+				<div style="max-width: 300px;"><code>50</code>
 </div>
 			</td>
 			<td></td>
@@ -3372,10 +2569,7 @@ false
 			<td id="otelCollector--autoscaling--targetMemoryUtilizationPercentage"><a href="./values.yaml#L1269">otelCollector.autoscaling.targetMemoryUtilizationPercentage</a></td>
 			<td>int</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-50
-</pre>
+				<div style="max-width: 300px;"><code>50</code>
 </div>
 			</td>
 			<td></td>
@@ -3384,10 +2578,7 @@ false
 			<td id="otelCollector--autoscaling--behavior"><a href="./values.yaml#L1270">otelCollector.autoscaling.behavior</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-{}
-</pre>
+				<div style="max-width: 300px;"><code>{}</code>
 </div>
 			</td>
 			<td></td>
@@ -3396,10 +2587,7 @@ false
 			<td id="otelCollector--autoscaling--autoscalingTemplate"><a href="./values.yaml#L1284">otelCollector.autoscaling.autoscalingTemplate</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td></td>
@@ -3408,10 +2596,7 @@ false
 			<td id="otelCollector--autoscaling--keda--annotations"><a href="./values.yaml#L1286">otelCollector.autoscaling.keda.annotations</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-null
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td></td>
@@ -3420,10 +2605,7 @@ null
 			<td id="otelCollector--autoscaling--keda--enabled"><a href="./values.yaml#L1287">otelCollector.autoscaling.keda.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td></td>
@@ -3432,10 +2614,7 @@ false
 			<td id="otelCollector--autoscaling--keda--pollingInterval"><a href="./values.yaml#L1290">otelCollector.autoscaling.keda.pollingInterval</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"30"
-</pre>
+				<div style="max-width: 300px;"><code>"30"</code>
 </div>
 			</td>
 			<td>Polling interval for metrics data Checks 30sec periodically for metrics data</td>
@@ -3444,10 +2623,7 @@ false
 			<td id="otelCollector--autoscaling--keda--cooldownPeriod"><a href="./values.yaml#L1293">otelCollector.autoscaling.keda.cooldownPeriod</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"300"
-</pre>
+				<div style="max-width: 300px;"><code>"300"</code>
 </div>
 			</td>
 			<td>Cooldown period for metrics data Once the load decreased, it will wait for 5 min and downscale</td>
@@ -3456,10 +2632,7 @@ false
 			<td id="otelCollector--autoscaling--keda--minReplicaCount"><a href="./values.yaml#L1296">otelCollector.autoscaling.keda.minReplicaCount</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"1"
-</pre>
+				<div style="max-width: 300px;"><code>"1"</code>
 </div>
 			</td>
 			<td>Minimum replica count Should be >= replicaCount specified in values.yaml</td>
@@ -3468,10 +2641,7 @@ false
 			<td id="otelCollector--autoscaling--keda--maxReplicaCount"><a href="./values.yaml#L1298">otelCollector.autoscaling.keda.maxReplicaCount</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-"5"
-</pre>
+				<div style="max-width: 300px;"><code>"5"</code>
 </div>
 			</td>
 			<td>Maximum replica count</td>
@@ -3480,10 +2650,7 @@ false
 			<td id="otelCollector--autoscaling--keda--triggers"><a href="./values.yaml#L1299">otelCollector.autoscaling.keda.triggers</a></td>
 			<td>list</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-[]
-</pre>
+				<div style="max-width: 300px;"><code>[]</code>
 </div>
 			</td>
 			<td></td>
@@ -3492,10 +2659,7 @@ false
 			<td id="otelCollector--config"><a href="./values.yaml#L1310">otelCollector.config</a></td>
 			<td>object</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="">
-See `values.yaml` for defaults
-</pre>
+				<div style="max-width: 300px;"><code>null</code>
 </div>
 			</td>
 			<td>Configurations for OtelCollector</td>
@@ -3504,10 +2668,7 @@ See `values.yaml` for defaults
 			<td id="signoz-otel-gateway--enabled"><a href="./values.yaml#L1402">signoz-otel-gateway.enabled</a></td>
 			<td>bool</td>
 			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-false
-</pre>
+				<div style="max-width: 300px;"><code>false</code>
 </div>
 			</td>
 			<td></td>

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -1,4 +1,7 @@
+
 # SigNoz
+
+![Version: 0.86.0](https://img.shields.io/badge/Version-0.86.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.89.0](https://img.shields.io/badge/AppVersion-v0.89.0-informational?style=flat-square)
 
 SigNoz is an open-source APM. It helps developers monitor their applications & troubleshoot problems,
 an open-source alternative to DataDog, NewRelic, etc. Open source Application Performance Monitoring (APM)
@@ -60,107 +63,3422 @@ Sometimes everything doesn't get properly removed. If that happens try deleting 
 kubectl delete namespace platform
 ```
 
+## Values
 
-## Configuration
+<table height="400px" >
+	<thead>
+		<th>Key</th>
+		<th>Type</th>
+		<th>Default</th>
+		<th>Description</th>
+	</thead>
+	<tbody>
+		<tr>
+			<td id="global--imageRegistry"><a href="./values.yaml#L4">global.imageRegistry</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td>Overrides the Image registry globally</td>
+		</tr>
+		<tr>
+			<td id="global--imagePullSecrets"><a href="./values.yaml#L6">global.imagePullSecrets</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Global Image Pull Secrets</td>
+		</tr>
+		<tr>
+			<td id="global--storageClass"><a href="./values.yaml#L10">global.storageClass</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td>Overrides the storage class for all PVC with persistence enabled. If not set, the default storage class is used. If set to "-", storageClassName: "", which disables dynamic provisioning</td>
+		</tr>
+		<tr>
+			<td id="global--clusterDomain"><a href="./values.yaml#L13">global.clusterDomain</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"cluster.local"
+</pre>
+</div>
+			</td>
+			<td>Kubernetes cluster domain It is used only when components are installed in different namespace</td>
+		</tr>
+		<tr>
+			<td id="global--clusterName"><a href="./values.yaml#L16">global.clusterName</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Kubernetes cluster name It is used to attached to telemetry data via resource detection processor</td>
+		</tr>
+		<tr>
+			<td id="global--cloud"><a href="./values.yaml#L21">global.cloud</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"other"
+</pre>
+</div>
+			</td>
+			<td>Kubernetes cluster cloud provider along with distribution if any. example: `aws`, `azure`, `gcp`, `gcp/autogke`, `hcloud`, `other` Based on the cloud, storage class for the persistent volume is selected. When set to 'aws' or 'gcp' along with `installCustomStorageClass` enabled, then new expandible storage class is created.</td>
+		</tr>
+		<tr>
+			<td id="nameOverride"><a href="./values.yaml#L23">nameOverride</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>SigNoz chart name override</td>
+		</tr>
+		<tr>
+			<td id="fullnameOverride"><a href="./values.yaml#L25">fullnameOverride</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>SigNoz chart full name override</td>
+		</tr>
+		<tr>
+			<td id="clusterName"><a href="./values.yaml#L27">clusterName</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Name of the K8s cluster. Used by SigNoz OtelCollectors to attach in telemetry data.</td>
+		</tr>
+		<tr>
+			<td id="imagePullSecrets"><a href="./values.yaml#L31">imagePullSecrets</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Image Registry Secret Names for all SigNoz components. If global.imagePullSecrets is set as well, it will merged. However, this has lower precedence than the imagePullSecrets at inner component level.</td>
+		</tr>
+		<tr>
+			<td id="externalClickhouse--host"><a href="./values.yaml#L532">externalClickhouse.host</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td>Host of the external cluster.</td>
+		</tr>
+		<tr>
+			<td id="externalClickhouse--cluster"><a href="./values.yaml#L534">externalClickhouse.cluster</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"cluster"
+</pre>
+</div>
+			</td>
+			<td>Name of the external cluster to run DDL queries on.</td>
+		</tr>
+		<tr>
+			<td id="externalClickhouse--database"><a href="./values.yaml#L536">externalClickhouse.database</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"signoz_metrics"
+</pre>
+</div>
+			</td>
+			<td>Database name for the external cluster</td>
+		</tr>
+		<tr>
+			<td id="externalClickhouse--traceDatabase"><a href="./values.yaml#L538">externalClickhouse.traceDatabase</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"signoz_traces"
+</pre>
+</div>
+			</td>
+			<td>Clickhouse trace database (SigNoz Traces)</td>
+		</tr>
+		<tr>
+			<td id="externalClickhouse--logDatabase"><a href="./values.yaml#L540">externalClickhouse.logDatabase</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"signoz_logs"
+</pre>
+</div>
+			</td>
+			<td>Clickhouse log database (SigNoz Logs)</td>
+		</tr>
+		<tr>
+			<td id="externalClickhouse--user"><a href="./values.yaml#L542">externalClickhouse.user</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>User name for the external cluster to connect to the external cluster as</td>
+		</tr>
+		<tr>
+			<td id="externalClickhouse--password"><a href="./values.yaml#L544">externalClickhouse.password</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Password for the cluster. Ignored if externalClickhouse.existingSecret is set</td>
+		</tr>
+		<tr>
+			<td id="externalClickhouse--existingSecret"><a href="./values.yaml#L546">externalClickhouse.existingSecret</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td>Name of an existing Kubernetes secret object containing the password</td>
+		</tr>
+		<tr>
+			<td id="externalClickhouse--existingSecretPasswordKey"><a href="./values.yaml#L548">externalClickhouse.existingSecretPasswordKey</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td>Name of the key pointing to the password in your Kubernetes secret</td>
+		</tr>
+		<tr>
+			<td id="externalClickhouse--secure"><a href="./values.yaml#L550">externalClickhouse.secure</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Whether to use TLS connection connecting to ClickHouse</td>
+		</tr>
+		<tr>
+			<td id="externalClickhouse--verify"><a href="./values.yaml#L552">externalClickhouse.verify</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Whether to verify TLS connection connecting to ClickHouse</td>
+		</tr>
+		<tr>
+			<td id="externalClickhouse--httpPort"><a href="./values.yaml#L554">externalClickhouse.httpPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+8123
+</pre>
+</div>
+			</td>
+			<td>HTTP port of Clickhouse</td>
+		</tr>
+		<tr>
+			<td id="externalClickhouse--tcpPort"><a href="./values.yaml#L556">externalClickhouse.tcpPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+9000
+</pre>
+</div>
+			</td>
+			<td>TCP port of Clickhouse</td>
+		</tr>
+		<tr>
+			<td id="signoz--name"><a href="./values.yaml#L559">signoz.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"signoz"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--replicaCount"><a href="./values.yaml#L560">signoz.replicaCount</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--image--registry"><a href="./values.yaml#L562">signoz.image.registry</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"docker.io"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--image--repository"><a href="./values.yaml#L563">signoz.image.repository</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"signoz/signoz"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--image--tag"><a href="./values.yaml#L564">signoz.image.tag</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"v0.89.0"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--image--pullPolicy"><a href="./values.yaml#L565">signoz.image.pullPolicy</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"IfNotPresent"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--imagePullSecrets"><a href="./values.yaml#L568">signoz.imagePullSecrets</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Image Registry Secret Names for signoz If set, this has higher precedence than the root level or global value of imagePullSecrets.</td>
+		</tr>
+		<tr>
+			<td id="signoz--serviceAccount--create"><a href="./values.yaml#L572">signoz.serviceAccount.create</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--serviceAccount--annotations"><a href="./values.yaml#L574">signoz.serviceAccount.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--serviceAccount--name"><a href="./values.yaml#L577">signoz.serviceAccount.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--service--annotations"><a href="./values.yaml#L581">signoz.service.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Annotations to use by service associated to signoz</td>
+		</tr>
+		<tr>
+			<td id="signoz--service--labels"><a href="./values.yaml#L583">signoz.service.labels</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Labels to use by service associated to signoz</td>
+		</tr>
+		<tr>
+			<td id="signoz--service--type"><a href="./values.yaml#L585">signoz.service.type</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"ClusterIP"
+</pre>
+</div>
+			</td>
+			<td>Service Type: LoadBalancer (allows external access) or NodePort (more secure, no extra cost)</td>
+		</tr>
+		<tr>
+			<td id="signoz--service--port"><a href="./values.yaml#L587">signoz.service.port</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+8080
+</pre>
+</div>
+			</td>
+			<td>signoz HTTP port</td>
+		</tr>
+		<tr>
+			<td id="signoz--service--internalPort"><a href="./values.yaml#L589">signoz.service.internalPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+8085
+</pre>
+</div>
+			</td>
+			<td>signoz Internal port</td>
+		</tr>
+		<tr>
+			<td id="signoz--service--opampPort"><a href="./values.yaml#L591">signoz.service.opampPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+4320
+</pre>
+</div>
+			</td>
+			<td>signoz OpAMP Internal port</td>
+		</tr>
+		<tr>
+			<td id="signoz--service--nodePort"><a href="./values.yaml#L594">signoz.service.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td>Set this if you want to force a specific nodePort for http. Must be use with service.type=NodePort</td>
+		</tr>
+		<tr>
+			<td id="signoz--service--internalNodePort"><a href="./values.yaml#L597">signoz.service.internalNodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td>Set this if you want to force a specific nodePort for internal. Must be use with service.type=NodePort</td>
+		</tr>
+		<tr>
+			<td id="signoz--service--opampInternalNodePort"><a href="./values.yaml#L600">signoz.service.opampInternalNodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td>Set this if you want to force a specific nodePort for OpAMP. Must be use with service.type=NodePort</td>
+		</tr>
+		<tr>
+			<td id="signoz--annotations"><a href="./values.yaml#L602">signoz.annotations</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td>signoz annotations</td>
+		</tr>
+		<tr>
+			<td id="signoz--additionalArgs"><a href="./values.yaml#L604">signoz.additionalArgs</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>signoz additional arguments for command line</td>
+		</tr>
+		<tr>
+			<td id="signoz--env--storage"><a href="./values.yaml#L622">signoz.env.storage</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"clickhouse"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--env--godebug"><a href="./values.yaml#L623">signoz.env.godebug</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"netdns=go"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--env--telemetry_enabled"><a href="./values.yaml#L624">signoz.env.telemetry_enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--env--deployment_type"><a href="./values.yaml#L625">signoz.env.deployment_type</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"kubernetes-helm"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--env--dot_metrics_enabled"><a href="./values.yaml#L626">signoz.env.dot_metrics_enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--env--signoz_alertmanager_provider"><a href="./values.yaml#L627">signoz.env.signoz_alertmanager_provider</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"signoz"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--env--smtp_enabled"><a href="./values.yaml#L634">signoz.env.smtp_enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Enable SMTP for user invitations. Sets `SMTP_ENABLED` to true when enabled.</td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--init--enabled"><a href="./values.yaml#L638">signoz.initContainers.init.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--init--image--registry"><a href="./values.yaml#L640">signoz.initContainers.init.image.registry</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"docker.io"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--init--image--repository"><a href="./values.yaml#L641">signoz.initContainers.init.image.repository</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"busybox"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--init--image--tag"><a href="./values.yaml#L642">signoz.initContainers.init.image.tag</a></td>
+			<td>float</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1.35
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--init--image--pullPolicy"><a href="./values.yaml#L643">signoz.initContainers.init.image.pullPolicy</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"IfNotPresent"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--init--command--delay"><a href="./values.yaml#L645">signoz.initContainers.init.command.delay</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+5
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--init--command--endpoint"><a href="./values.yaml#L646">signoz.initContainers.init.command.endpoint</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"/ping"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--init--command--waitMessage"><a href="./values.yaml#L647">signoz.initContainers.init.command.waitMessage</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"waiting for clickhouseDB"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--init--command--doneMessage"><a href="./values.yaml#L648">signoz.initContainers.init.command.doneMessage</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"clickhouse ready, starting query service now"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--init--resources"><a href="./values.yaml#L649">signoz.initContainers.init.resources</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--migration--enabled"><a href="./values.yaml#L657">signoz.initContainers.migration.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--migration--image--registry"><a href="./values.yaml#L659">signoz.initContainers.migration.image.registry</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"docker.io"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--migration--image--repository"><a href="./values.yaml#L660">signoz.initContainers.migration.image.repository</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"busybox"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--migration--image--tag"><a href="./values.yaml#L661">signoz.initContainers.migration.image.tag</a></td>
+			<td>float</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1.35
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--migration--image--pullPolicy"><a href="./values.yaml#L662">signoz.initContainers.migration.image.pullPolicy</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"IfNotPresent"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--migration--args"><a href="./values.yaml#L663">signoz.initContainers.migration.args</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--migration--command"><a href="./values.yaml#L664">signoz.initContainers.migration.command</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--migration--resources"><a href="./values.yaml#L671">signoz.initContainers.migration.resources</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--migration--additionalVolumeMounts"><a href="./values.yaml#L679">signoz.initContainers.migration.additionalVolumeMounts</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Additional volume mounts for signoz</td>
+		</tr>
+		<tr>
+			<td id="signoz--initContainers--migration--additionalVolumes"><a href="./values.yaml#L681">signoz.initContainers.migration.additionalVolumes</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Additional volumes for signoz</td>
+		</tr>
+		<tr>
+			<td id="signoz--podSecurityContext"><a href="./values.yaml#L684">signoz.podSecurityContext</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Pod security context for signoz</td>
+		</tr>
+		<tr>
+			<td id="signoz--podAnnotations"><a href="./values.yaml#L687">signoz.podAnnotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Pod annotations for signoz</td>
+		</tr>
+		<tr>
+			<td id="signoz--securityContext"><a href="./values.yaml#L689">signoz.securityContext</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Security context for signoz</td>
+		</tr>
+		<tr>
+			<td id="signoz--additionalVolumeMounts"><a href="./values.yaml#L698">signoz.additionalVolumeMounts</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Additional volume mounts for signoz</td>
+		</tr>
+		<tr>
+			<td id="signoz--additionalVolumes"><a href="./values.yaml#L700">signoz.additionalVolumes</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Additional volumes for signoz</td>
+		</tr>
+		<tr>
+			<td id="signoz--livenessProbe"><a href="./values.yaml#L703">signoz.livenessProbe</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{
+  "enabled": true,
+  "failureThreshold": 6,
+  "initialDelaySeconds": 5,
+  "path": "/api/v1/health",
+  "periodSeconds": 10,
+  "port": "http",
+  "successThreshold": 1,
+  "timeoutSeconds": 5
+}
+</pre>
+</div>
+			</td>
+			<td>Configure liveness and readiness probes. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes</td>
+		</tr>
+		<tr>
+			<td id="signoz--readinessProbe--enabled"><a href="./values.yaml#L713">signoz.readinessProbe.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--readinessProbe--port"><a href="./values.yaml#L714">signoz.readinessProbe.port</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"http"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--readinessProbe--path"><a href="./values.yaml#L715">signoz.readinessProbe.path</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"/api/v1/health?live=1"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--readinessProbe--initialDelaySeconds"><a href="./values.yaml#L716">signoz.readinessProbe.initialDelaySeconds</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+5
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--readinessProbe--periodSeconds"><a href="./values.yaml#L717">signoz.readinessProbe.periodSeconds</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+10
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--readinessProbe--timeoutSeconds"><a href="./values.yaml#L718">signoz.readinessProbe.timeoutSeconds</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+5
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--readinessProbe--failureThreshold"><a href="./values.yaml#L719">signoz.readinessProbe.failureThreshold</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+6
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--readinessProbe--successThreshold"><a href="./values.yaml#L720">signoz.readinessProbe.successThreshold</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="signoz--customLivenessProbe"><a href="./values.yaml#L722">signoz.customLivenessProbe</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Custom liveness probe</td>
+		</tr>
+		<tr>
+			<td id="signoz--customReadinessProbe"><a href="./values.yaml#L724">signoz.customReadinessProbe</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Custom readiness probe</td>
+		</tr>
+		<tr>
+			<td id="signoz--ingress--enabled"><a href="./values.yaml#L727">signoz.ingress.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Enable ingress for signoz</td>
+		</tr>
+		<tr>
+			<td id="signoz--ingress--className"><a href="./values.yaml#L729">signoz.ingress.className</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Ingress Class Name to be used to identify ingress controllers</td>
+		</tr>
+		<tr>
+			<td id="signoz--ingress--annotations"><a href="./values.yaml#L731">signoz.ingress.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Annotations to signoz Ingress</td>
+		</tr>
+		<tr>
+			<td id="signoz--ingress--hosts"><a href="./values.yaml#L736">signoz.ingress.hosts</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[
+  {
+    "host": "signoz.domain.com",
+    "paths": [
+      {
+        "path": "/",
+        "pathType": "ImplementationSpecific",
+        "port": 8080
+      }
+    ]
+  }
+]
+</pre>
+</div>
+			</td>
+			<td>signoz Ingress Host names with their path details</td>
+		</tr>
+		<tr>
+			<td id="signoz--ingress--tls"><a href="./values.yaml#L743">signoz.ingress.tls</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>signoz Ingress TLS</td>
+		</tr>
+		<tr>
+			<td id="signoz--resources"><a href="./values.yaml#L752">signoz.resources</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="">
+See `values.yaml` for defaults
+</pre>
+</div>
+			</td>
+			<td>Configure resource requests and limits. Update according to your own use case as these values might not be suitable for your workload. Ref: http://kubernetes.io/docs/user-guide/compute-resources/ </td>
+		</tr>
+		<tr>
+			<td id="signoz--priorityClassName"><a href="./values.yaml#L760">signoz.priorityClassName</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Priority class name for signoz</td>
+		</tr>
+		<tr>
+			<td id="signoz--nodeSelector"><a href="./values.yaml#L762">signoz.nodeSelector</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Node selector for settings for signoz pod</td>
+		</tr>
+		<tr>
+			<td id="signoz--tolerations"><a href="./values.yaml#L764">signoz.tolerations</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Toleration labels for signoz pod assignment</td>
+		</tr>
+		<tr>
+			<td id="signoz--affinity"><a href="./values.yaml#L766">signoz.affinity</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Affinity settings for signoz pod</td>
+		</tr>
+		<tr>
+			<td id="signoz--topologySpreadConstraints"><a href="./values.yaml#L768">signoz.topologySpreadConstraints</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>TopologySpreadConstraints describes how g pods ought to spread</td>
+		</tr>
+		<tr>
+			<td id="signoz--persistence--enabled"><a href="./values.yaml#L771">signoz.persistence.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Enable data persistence using PVC for SQLiteDB data.</td>
+		</tr>
+		<tr>
+			<td id="signoz--persistence--existingClaim"><a href="./values.yaml#L773">signoz.persistence.existingClaim</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Name of an existing PVC to use (only when deploying a single replica)</td>
+		</tr>
+		<tr>
+			<td id="signoz--persistence--storageClass"><a href="./values.yaml#L780">signoz.persistence.storageClass</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td>Persistent Volume Storage Class to use. If defined, `storageClassName: <storageClass>`. If set to "-", `storageClassName: ""`, which disables dynamic provisioning If undefined (the default) or set to `null`, no storageClassName spec is set, choosing the default provisioner. </td>
+		</tr>
+		<tr>
+			<td id="signoz--persistence--accessModes"><a href="./values.yaml#L782">signoz.persistence.accessModes</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[
+  "ReadWriteOnce"
+]
+</pre>
+</div>
+			</td>
+			<td>Access Modes for persistent volume</td>
+		</tr>
+		<tr>
+			<td id="signoz--persistence--size"><a href="./values.yaml#L785">signoz.persistence.size</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"1Gi"
+</pre>
+</div>
+			</td>
+			<td>Persistent Volume size</td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--enabled"><a href="./values.yaml#L788">schemaMigrator.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--name"><a href="./values.yaml#L789">schemaMigrator.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"schema-migrator"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--image--registry"><a href="./values.yaml#L791">schemaMigrator.image.registry</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"docker.io"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--image--repository"><a href="./values.yaml#L792">schemaMigrator.image.repository</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"signoz/signoz-schema-migrator"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--image--tag"><a href="./values.yaml#L793">schemaMigrator.image.tag</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"v0.128.0"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--image--pullPolicy"><a href="./values.yaml#L794">schemaMigrator.image.pullPolicy</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"IfNotPresent"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--args[0]"><a href="./values.yaml#L796">schemaMigrator.args[0]</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"--up="
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--annotations"><a href="./values.yaml#L800">schemaMigrator.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--upgradeHelmHooks"><a href="./values.yaml#L803">schemaMigrator.upgradeHelmHooks</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--enableReplication"><a href="./values.yaml#L805">schemaMigrator.enableReplication</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Whether to enable replication for schemaMigrator</td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--nodeSelector"><a href="./values.yaml#L807">schemaMigrator.nodeSelector</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Node selector for settings for schemaMigrator</td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--tolerations"><a href="./values.yaml#L809">schemaMigrator.tolerations</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Toleration labels for schemaMigrator assignment</td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--affinity"><a href="./values.yaml#L811">schemaMigrator.affinity</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Affinity settings for schemaMigrator</td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--topologySpreadConstraints"><a href="./values.yaml#L813">schemaMigrator.topologySpreadConstraints</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>TopologySpreadConstraints describes how schemaMigrator pods ought to spread</td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--initContainers--init--enabled"><a href="./values.yaml#L816">schemaMigrator.initContainers.init.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--initContainers--init--image--registry"><a href="./values.yaml#L818">schemaMigrator.initContainers.init.image.registry</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"docker.io"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--initContainers--init--image--repository"><a href="./values.yaml#L819">schemaMigrator.initContainers.init.image.repository</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"busybox"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--initContainers--init--image--tag"><a href="./values.yaml#L820">schemaMigrator.initContainers.init.image.tag</a></td>
+			<td>float</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1.35
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--initContainers--init--image--pullPolicy"><a href="./values.yaml#L821">schemaMigrator.initContainers.init.image.pullPolicy</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"IfNotPresent"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--initContainers--init--command--delay"><a href="./values.yaml#L823">schemaMigrator.initContainers.init.command.delay</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+5
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--initContainers--init--command--endpoint"><a href="./values.yaml#L824">schemaMigrator.initContainers.init.command.endpoint</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"/ping"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--initContainers--init--command--waitMessage"><a href="./values.yaml#L825">schemaMigrator.initContainers.init.command.waitMessage</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"waiting for clickhouseDB"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--initContainers--init--command--doneMessage"><a href="./values.yaml#L826">schemaMigrator.initContainers.init.command.doneMessage</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"clickhouse ready, starting schema migrator now"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--initContainers--init--resources"><a href="./values.yaml#L827">schemaMigrator.initContainers.init.resources</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--initContainers--wait--enabled"><a href="./values.yaml#L899">schemaMigrator.initContainers.wait.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--initContainers--wait--image--registry"><a href="./values.yaml#L901">schemaMigrator.initContainers.wait.image.registry</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"docker.io"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--initContainers--wait--image--repository"><a href="./values.yaml#L902">schemaMigrator.initContainers.wait.image.repository</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"groundnuty/k8s-wait-for"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--initContainers--wait--image--tag"><a href="./values.yaml#L903">schemaMigrator.initContainers.wait.image.tag</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"v2.0"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--initContainers--wait--image--pullPolicy"><a href="./values.yaml#L904">schemaMigrator.initContainers.wait.image.pullPolicy</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"IfNotPresent"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--initContainers--wait--env"><a href="./values.yaml#L905">schemaMigrator.initContainers.wait.env</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--serviceAccount--create"><a href="./values.yaml#L909">schemaMigrator.serviceAccount.create</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--serviceAccount--annotations"><a href="./values.yaml#L911">schemaMigrator.serviceAccount.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--serviceAccount--name"><a href="./values.yaml#L914">schemaMigrator.serviceAccount.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--role--create"><a href="./values.yaml#L918">schemaMigrator.role.create</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Specifies whether a clusterRole should be created</td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--role--annotations"><a href="./values.yaml#L920">schemaMigrator.role.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Annotations to add to the clusterRole</td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--role--name"><a href="./values.yaml#L923">schemaMigrator.role.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>The name of the clusterRole to use. If not set and create is true, a name is generated using the fullname template</td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--role--rules"><a href="./values.yaml#L927">schemaMigrator.role.rules</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="">
+See `values.yaml` for defaults
+</pre>
+</div>
+			</td>
+			<td>A set of rules as documented here. ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/</td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--role--roleBinding--annotations"><a href="./values.yaml#L934">schemaMigrator.role.roleBinding.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="schemaMigrator--role--roleBinding--name"><a href="./values.yaml#L937">schemaMigrator.role.roleBinding.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--name"><a href="./values.yaml#L940">otelCollector.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"otel-collector"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--image--registry"><a href="./values.yaml#L942">otelCollector.image.registry</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"docker.io"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--image--repository"><a href="./values.yaml#L943">otelCollector.image.repository</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"signoz/signoz-otel-collector"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--image--tag"><a href="./values.yaml#L944">otelCollector.image.tag</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"v0.128.0"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--image--pullPolicy"><a href="./values.yaml#L945">otelCollector.image.pullPolicy</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"IfNotPresent"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--imagePullSecrets"><a href="./values.yaml#L948">otelCollector.imagePullSecrets</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Image Registry Secret Names for OtelCollector If set, this has higher precedence than the root level or global value of imagePullSecrets.</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--initContainers--init--enabled"><a href="./values.yaml#L951">otelCollector.initContainers.init.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--initContainers--init--image--registry"><a href="./values.yaml#L953">otelCollector.initContainers.init.image.registry</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"docker.io"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--initContainers--init--image--repository"><a href="./values.yaml#L954">otelCollector.initContainers.init.image.repository</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"busybox"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--initContainers--init--image--tag"><a href="./values.yaml#L955">otelCollector.initContainers.init.image.tag</a></td>
+			<td>float</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1.35
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--initContainers--init--image--pullPolicy"><a href="./values.yaml#L956">otelCollector.initContainers.init.image.pullPolicy</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"IfNotPresent"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--initContainers--init--command--delay"><a href="./values.yaml#L958">otelCollector.initContainers.init.command.delay</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+5
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--initContainers--init--command--endpoint"><a href="./values.yaml#L959">otelCollector.initContainers.init.command.endpoint</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"/ping"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--initContainers--init--command--waitMessage"><a href="./values.yaml#L960">otelCollector.initContainers.init.command.waitMessage</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"waiting for clickhouseDB"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--initContainers--init--command--doneMessage"><a href="./values.yaml#L961">otelCollector.initContainers.init.command.doneMessage</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"clickhouse ready, starting otel collector now"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--initContainers--init--resources"><a href="./values.yaml#L962">otelCollector.initContainers.init.resources</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--command--name"><a href="./values.yaml#L972">otelCollector.command.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"/signoz-otel-collector"
+</pre>
+</div>
+			</td>
+			<td>OtelCollector command name</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--command--extraArgs"><a href="./values.yaml#L974">otelCollector.command.extraArgs</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[
+  "--feature-gates=-pkg.translator.prometheus.NormalizeName"
+]
+</pre>
+</div>
+			</td>
+			<td>OtelCollector command extra arguments</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--configMap--create"><a href="./values.yaml#L978">otelCollector.configMap.create</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Specifies whether a configMap should be created (true by default)</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--serviceAccount--create"><a href="./values.yaml#L982">otelCollector.serviceAccount.create</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--serviceAccount--annotations"><a href="./values.yaml#L984">otelCollector.serviceAccount.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--serviceAccount--name"><a href="./values.yaml#L987">otelCollector.serviceAccount.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--service--annotations"><a href="./values.yaml#L991">otelCollector.service.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Annotations to use by service associated to OtelCollector</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--service--labels"><a href="./values.yaml#L993">otelCollector.service.labels</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Labels to use by service associated to OtelCollector</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--service--type"><a href="./values.yaml#L995">otelCollector.service.type</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"ClusterIP"
+</pre>
+</div>
+			</td>
+			<td>Service Type: LoadBalancer (allows external access) or NodePort (more secure, no extra cost)</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--service--loadBalancerSourceRanges"><a href="./values.yaml#L997">otelCollector.service.loadBalancerSourceRanges</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>LoadBalancer Source Ranges when service type is LoadBalancer</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--annotations"><a href="./values.yaml#L999">otelCollector.annotations</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td>OtelCollector Deployment annotation.</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--podAnnotations"><a href="./values.yaml#L1001">otelCollector.podAnnotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{
+  "signoz.io/port": "8888",
+  "signoz.io/scrape": "true"
+}
+</pre>
+</div>
+			</td>
+			<td>OtelCollector pod(s) annotation.</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--podLabels"><a href="./values.yaml#L1005">otelCollector.podLabels</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>OtelCollector pod(s) labels.</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--additionalEnvs"><a href="./values.yaml#L1007">otelCollector.additionalEnvs</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Additional environments to set for OtelCollector</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--lowCardinalityExceptionGrouping"><a href="./values.yaml#L1013">otelCollector.lowCardinalityExceptionGrouping</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Whether to enable grouping of exceptions with same name and different stack trace. This is useful when you have a lot of exceptions with same name but different stack trace. This is a tradeoff between cardinality and accuracy of exception grouping.</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--minReadySeconds"><a href="./values.yaml#L1014">otelCollector.minReadySeconds</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+5
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--progressDeadlineSeconds"><a href="./values.yaml#L1015">otelCollector.progressDeadlineSeconds</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+600
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--replicaCount"><a href="./values.yaml#L1016">otelCollector.replicaCount</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--clusterRole--create"><a href="./values.yaml#L1020">otelCollector.clusterRole.create</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Specifies whether a clusterRole should be created</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--clusterRole--annotations"><a href="./values.yaml#L1022">otelCollector.clusterRole.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Annotations to add to the clusterRole</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--clusterRole--name"><a href="./values.yaml#L1025">otelCollector.clusterRole.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>The name of the clusterRole to use. If not set and create is true, a name is generated using the fullname template</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--clusterRole--rules"><a href="./values.yaml#L1029">otelCollector.clusterRole.rules</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="">
+See `values.yaml` for defaults
+</pre>
+</div>
+			</td>
+			<td>A set of rules as documented here. ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--clusterRole--clusterRoleBinding--annotations"><a href="./values.yaml#L1046">otelCollector.clusterRole.clusterRoleBinding.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--clusterRole--clusterRoleBinding--name"><a href="./values.yaml#L1049">otelCollector.clusterRole.clusterRoleBinding.name</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--otlp--enabled"><a href="./values.yaml#L1054">otelCollector.ports.otlp.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for OTLP gRPC</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--otlp--containerPort"><a href="./values.yaml#L1056">otelCollector.ports.otlp.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+4317
+</pre>
+</div>
+			</td>
+			<td>Container port for OTLP gRPC</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--otlp--servicePort"><a href="./values.yaml#L1058">otelCollector.ports.otlp.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+4317
+</pre>
+</div>
+			</td>
+			<td>Service port for OTLP gRPC</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--otlp--nodePort"><a href="./values.yaml#L1060">otelCollector.ports.otlp.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for OTLP gRPC</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--otlp--protocol"><a href="./values.yaml#L1062">otelCollector.ports.otlp.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for OTLP gRPC</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--otlp-http--enabled"><a href="./values.yaml#L1065">otelCollector.ports.otlp-http.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for OTLP HTTP</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--otlp-http--containerPort"><a href="./values.yaml#L1067">otelCollector.ports.otlp-http.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+4318
+</pre>
+</div>
+			</td>
+			<td>Container port for OTLP HTTP</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--otlp-http--servicePort"><a href="./values.yaml#L1069">otelCollector.ports.otlp-http.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+4318
+</pre>
+</div>
+			</td>
+			<td>Service port for OTLP HTTP</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--otlp-http--nodePort"><a href="./values.yaml#L1071">otelCollector.ports.otlp-http.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for OTLP HTTP</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--otlp-http--protocol"><a href="./values.yaml#L1073">otelCollector.ports.otlp-http.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for OTLP HTTP</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--jaeger-compact--enabled"><a href="./values.yaml#L1076">otelCollector.ports.jaeger-compact.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for Jaeger Compact</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--jaeger-compact--containerPort"><a href="./values.yaml#L1078">otelCollector.ports.jaeger-compact.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+6831
+</pre>
+</div>
+			</td>
+			<td>Container port for Jaeger Compact</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--jaeger-compact--servicePort"><a href="./values.yaml#L1080">otelCollector.ports.jaeger-compact.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+6831
+</pre>
+</div>
+			</td>
+			<td>Service port for Jaeger Compact</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--jaeger-compact--nodePort"><a href="./values.yaml#L1082">otelCollector.ports.jaeger-compact.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for Jaeger Compact</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--jaeger-compact--protocol"><a href="./values.yaml#L1084">otelCollector.ports.jaeger-compact.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"UDP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for Jaeger Compact</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--jaeger-thrift--enabled"><a href="./values.yaml#L1087">otelCollector.ports.jaeger-thrift.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for Jaeger Thrift HTTP</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--jaeger-thrift--containerPort"><a href="./values.yaml#L1089">otelCollector.ports.jaeger-thrift.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+14268
+</pre>
+</div>
+			</td>
+			<td>Container port for Jaeger Thrift</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--jaeger-thrift--servicePort"><a href="./values.yaml#L1091">otelCollector.ports.jaeger-thrift.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+14268
+</pre>
+</div>
+			</td>
+			<td>Service port for Jaeger Thrift</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--jaeger-thrift--nodePort"><a href="./values.yaml#L1093">otelCollector.ports.jaeger-thrift.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for Jaeger Thrift</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--jaeger-thrift--protocol"><a href="./values.yaml#L1095">otelCollector.ports.jaeger-thrift.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for Jaeger Thrift</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--jaeger-grpc--enabled"><a href="./values.yaml#L1098">otelCollector.ports.jaeger-grpc.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for Jaeger gRPC</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--jaeger-grpc--containerPort"><a href="./values.yaml#L1100">otelCollector.ports.jaeger-grpc.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+14250
+</pre>
+</div>
+			</td>
+			<td>Container port for Jaeger gRPC</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--jaeger-grpc--servicePort"><a href="./values.yaml#L1102">otelCollector.ports.jaeger-grpc.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+14250
+</pre>
+</div>
+			</td>
+			<td>Service port for Jaeger gRPC</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--jaeger-grpc--nodePort"><a href="./values.yaml#L1104">otelCollector.ports.jaeger-grpc.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for Jaeger gRPC</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--jaeger-grpc--protocol"><a href="./values.yaml#L1106">otelCollector.ports.jaeger-grpc.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for Jaeger gRPC</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--zipkin--enabled"><a href="./values.yaml#L1109">otelCollector.ports.zipkin.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for Zipkin</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--zipkin--containerPort"><a href="./values.yaml#L1111">otelCollector.ports.zipkin.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+9411
+</pre>
+</div>
+			</td>
+			<td>Container port for Zipkin</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--zipkin--servicePort"><a href="./values.yaml#L1113">otelCollector.ports.zipkin.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+9411
+</pre>
+</div>
+			</td>
+			<td>Service port for Zipkin</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--zipkin--nodePort"><a href="./values.yaml#L1115">otelCollector.ports.zipkin.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for Zipkin</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--zipkin--protocol"><a href="./values.yaml#L1117">otelCollector.ports.zipkin.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for Zipkin</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--metrics--enabled"><a href="./values.yaml#L1120">otelCollector.ports.metrics.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for internal metrics</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--metrics--containerPort"><a href="./values.yaml#L1122">otelCollector.ports.metrics.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+8888
+</pre>
+</div>
+			</td>
+			<td>Container port for internal metrics</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--metrics--servicePort"><a href="./values.yaml#L1124">otelCollector.ports.metrics.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+8888
+</pre>
+</div>
+			</td>
+			<td>Service port for internal metrics</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--metrics--nodePort"><a href="./values.yaml#L1126">otelCollector.ports.metrics.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for internal metrics</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--metrics--protocol"><a href="./values.yaml#L1128">otelCollector.ports.metrics.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for internal metrics</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--zpages--enabled"><a href="./values.yaml#L1131">otelCollector.ports.zpages.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for ZPages</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--zpages--containerPort"><a href="./values.yaml#L1133">otelCollector.ports.zpages.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+55679
+</pre>
+</div>
+			</td>
+			<td>Container port for Zpages</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--zpages--servicePort"><a href="./values.yaml#L1135">otelCollector.ports.zpages.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+55679
+</pre>
+</div>
+			</td>
+			<td>Service port for Zpages</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--zpages--nodePort"><a href="./values.yaml#L1137">otelCollector.ports.zpages.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for Zpages</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--zpages--protocol"><a href="./values.yaml#L1139">otelCollector.ports.zpages.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for Zpages</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--pprof--enabled"><a href="./values.yaml#L1142">otelCollector.ports.pprof.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for pprof</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--pprof--containerPort"><a href="./values.yaml#L1144">otelCollector.ports.pprof.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1777
+</pre>
+</div>
+			</td>
+			<td>Container port for pprof</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--pprof--servicePort"><a href="./values.yaml#L1146">otelCollector.ports.pprof.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1777
+</pre>
+</div>
+			</td>
+			<td>Service port for pprof</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--pprof--nodePort"><a href="./values.yaml#L1148">otelCollector.ports.pprof.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for pprof</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--pprof--protocol"><a href="./values.yaml#L1150">otelCollector.ports.pprof.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for pprof</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--logsheroku--enabled"><a href="./values.yaml#L1153">otelCollector.ports.logsheroku.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for logsheroku</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--logsheroku--containerPort"><a href="./values.yaml#L1155">otelCollector.ports.logsheroku.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+8081
+</pre>
+</div>
+			</td>
+			<td>Container port for logsheroku</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--logsheroku--servicePort"><a href="./values.yaml#L1157">otelCollector.ports.logsheroku.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+8081
+</pre>
+</div>
+			</td>
+			<td>Service port for logsheroku</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--logsheroku--nodePort"><a href="./values.yaml#L1159">otelCollector.ports.logsheroku.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for logsheroku</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--logsheroku--protocol"><a href="./values.yaml#L1161">otelCollector.ports.logsheroku.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for logsheroku</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--logsjson--enabled"><a href="./values.yaml#L1164">otelCollector.ports.logsjson.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>Whether to enable service port for logsjson</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--logsjson--containerPort"><a href="./values.yaml#L1166">otelCollector.ports.logsjson.containerPort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+8082
+</pre>
+</div>
+			</td>
+			<td>Container port for logsjson</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--logsjson--servicePort"><a href="./values.yaml#L1168">otelCollector.ports.logsjson.servicePort</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+8082
+</pre>
+</div>
+			</td>
+			<td>Service port for logsjson</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--logsjson--nodePort"><a href="./values.yaml#L1170">otelCollector.ports.logsjson.nodePort</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Node port for logsjson</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ports--logsjson--protocol"><a href="./values.yaml#L1172">otelCollector.ports.logsjson.protocol</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"TCP"
+</pre>
+</div>
+			</td>
+			<td>Protocol to use for logsjson</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--livenessProbe"><a href="./values.yaml#L1175">otelCollector.livenessProbe</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{
+  "enabled": true,
+  "failureThreshold": 6,
+  "initialDelaySeconds": 5,
+  "path": "/",
+  "periodSeconds": 10,
+  "port": 13133,
+  "successThreshold": 1,
+  "timeoutSeconds": 5
+}
+</pre>
+</div>
+			</td>
+			<td>Configure liveness and readiness probes. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--readinessProbe--enabled"><a href="./values.yaml#L1185">otelCollector.readinessProbe.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--readinessProbe--port"><a href="./values.yaml#L1186">otelCollector.readinessProbe.port</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+13133
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--readinessProbe--path"><a href="./values.yaml#L1187">otelCollector.readinessProbe.path</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"/"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--readinessProbe--initialDelaySeconds"><a href="./values.yaml#L1188">otelCollector.readinessProbe.initialDelaySeconds</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+5
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--readinessProbe--periodSeconds"><a href="./values.yaml#L1189">otelCollector.readinessProbe.periodSeconds</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+10
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--readinessProbe--timeoutSeconds"><a href="./values.yaml#L1190">otelCollector.readinessProbe.timeoutSeconds</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+5
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--readinessProbe--failureThreshold"><a href="./values.yaml#L1191">otelCollector.readinessProbe.failureThreshold</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+6
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--readinessProbe--successThreshold"><a href="./values.yaml#L1192">otelCollector.readinessProbe.successThreshold</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--customLivenessProbe"><a href="./values.yaml#L1194">otelCollector.customLivenessProbe</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Custom liveness probe</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--customReadinessProbe"><a href="./values.yaml#L1196">otelCollector.customReadinessProbe</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Custom readiness probe</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--extraVolumeMounts"><a href="./values.yaml#L1198">otelCollector.extraVolumeMounts</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Extra volumes mount for OtelCollector pod</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--extraVolumes"><a href="./values.yaml#L1200">otelCollector.extraVolumes</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Extra volumes for OtelCollector pod</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ingress--enabled"><a href="./values.yaml#L1203">otelCollector.ingress.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>Enable ingress for OtelCollector</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ingress--className"><a href="./values.yaml#L1205">otelCollector.ingress.className</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>Ingress Class Name to be used to identify ingress controllers</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ingress--annotations"><a href="./values.yaml#L1207">otelCollector.ingress.annotations</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Annotations to OtelCollector Ingress</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ingress--hosts"><a href="./values.yaml#L1214">otelCollector.ingress.hosts</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[
+  {
+    "host": "otelcollector.domain.com",
+    "paths": [
+      {
+        "path": "/",
+        "pathType": "ImplementationSpecific",
+        "port": 4318
+      }
+    ]
+  }
+]
+</pre>
+</div>
+			</td>
+			<td>OtelCollector Ingress Host names with their path details</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--ingress--tls"><a href="./values.yaml#L1221">otelCollector.ingress.tls</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>OtelCollector Ingress TLS</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--resources"><a href="./values.yaml#L1230">otelCollector.resources</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="">
+See `values.yaml` for defaults
+</pre>
+</div>
+			</td>
+			<td>Configure resource requests and limits. Update according to your own use case as these values might not be suitable for your workload. Ref: http://kubernetes.io/docs/user-guide/compute-resources/ </td>
+		</tr>
+		<tr>
+			<td id="otelCollector--priorityClassName"><a href="./values.yaml#L1238">otelCollector.priorityClassName</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>OtelCollector priority class name</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--nodeSelector"><a href="./values.yaml#L1240">otelCollector.nodeSelector</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Node selector for settings for OtelCollector pod</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--tolerations"><a href="./values.yaml#L1242">otelCollector.tolerations</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>Toleration labels for OtelCollector pod assignment</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--affinity"><a href="./values.yaml#L1244">otelCollector.affinity</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>Affinity settings for OtelCollector pod</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--topologySpreadConstraints"><a href="./values.yaml#L1246">otelCollector.topologySpreadConstraints</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[
+  {
+    "labelSelector": {
+      "matchLabels": {
+        "app.kubernetes.io/component": "otel-collector"
+      }
+    },
+    "maxSkew": 1,
+    "topologyKey": "kubernetes.io/hostname",
+    "whenUnsatisfiable": "ScheduleAnyway"
+  }
+]
+</pre>
+</div>
+			</td>
+			<td>TopologySpreadConstraints describes how OtelCollector pods ought to spread</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--podSecurityContext"><a href="./values.yaml#L1253">otelCollector.podSecurityContext</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--securityContext"><a href="./values.yaml#L1256">otelCollector.securityContext</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--autoscaling--enabled"><a href="./values.yaml#L1265">otelCollector.autoscaling.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--autoscaling--minReplicas"><a href="./values.yaml#L1266">otelCollector.autoscaling.minReplicas</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--autoscaling--maxReplicas"><a href="./values.yaml#L1267">otelCollector.autoscaling.maxReplicas</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+11
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--autoscaling--targetCPUUtilizationPercentage"><a href="./values.yaml#L1268">otelCollector.autoscaling.targetCPUUtilizationPercentage</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+50
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--autoscaling--targetMemoryUtilizationPercentage"><a href="./values.yaml#L1269">otelCollector.autoscaling.targetMemoryUtilizationPercentage</a></td>
+			<td>int</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+50
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--autoscaling--behavior"><a href="./values.yaml#L1270">otelCollector.autoscaling.behavior</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--autoscaling--autoscalingTemplate"><a href="./values.yaml#L1284">otelCollector.autoscaling.autoscalingTemplate</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--autoscaling--keda--annotations"><a href="./values.yaml#L1286">otelCollector.autoscaling.keda.annotations</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+null
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--autoscaling--keda--enabled"><a href="./values.yaml#L1287">otelCollector.autoscaling.keda.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--autoscaling--keda--pollingInterval"><a href="./values.yaml#L1290">otelCollector.autoscaling.keda.pollingInterval</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"30"
+</pre>
+</div>
+			</td>
+			<td>Polling interval for metrics data Checks 30sec periodically for metrics data</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--autoscaling--keda--cooldownPeriod"><a href="./values.yaml#L1293">otelCollector.autoscaling.keda.cooldownPeriod</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"300"
+</pre>
+</div>
+			</td>
+			<td>Cooldown period for metrics data Once the load decreased, it will wait for 5 min and downscale</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--autoscaling--keda--minReplicaCount"><a href="./values.yaml#L1296">otelCollector.autoscaling.keda.minReplicaCount</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"1"
+</pre>
+</div>
+			</td>
+			<td>Minimum replica count Should be >= replicaCount specified in values.yaml</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--autoscaling--keda--maxReplicaCount"><a href="./values.yaml#L1298">otelCollector.autoscaling.keda.maxReplicaCount</a></td>
+			<td>string</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"5"
+</pre>
+</div>
+			</td>
+			<td>Maximum replica count</td>
+		</tr>
+		<tr>
+			<td id="otelCollector--autoscaling--keda--triggers"><a href="./values.yaml#L1299">otelCollector.autoscaling.keda.triggers</a></td>
+			<td>list</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="otelCollector--config"><a href="./values.yaml#L1310">otelCollector.config</a></td>
+			<td>object</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="">
+See `values.yaml` for defaults
+</pre>
+</div>
+			</td>
+			<td>Configurations for OtelCollector</td>
+		</tr>
+		<tr>
+			<td id="signoz-otel-gateway--enabled"><a href="./values.yaml#L1402">signoz-otel-gateway.enabled</a></td>
+			<td>bool</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+	</tbody>
+</table>
 
-The following table lists the configurable parameters of the `signoz` chart and their default values.
-
-| Parameter                                                   | Description                                                                                                | Default                        |
-|-------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|--------------------------------|
-| `fullnameOverride`                                          | SigNoz chart full name override (the release name is ignored)                                              | `""`                           |
-| `signoz.name`                                         | Query Service component name                                                                               | `signoz`                |
-| `signoz.image.registry`                               | Query Service image registry name                                                                          | `docker.io`                    |
-| `signoz.image.repository`                             | Container image name                                                                                       | `signoz/signoz`         |
-| `signoz.image.tag`                                    | Container image tag                                                                                        | `0.64.0`                       |
-| `signoz.image.pullPolicy`                             | Container pull policy                                                                                      | `IfNotPresent`                 |
-| `signoz.replicaCount`                                 | Number of signoz nodes                                                                              | `1`                            |
-| `signoz.initContainers.init.enabled`                  | Query Service initContainer enabled                                                                        | `true`                         |
-| `signoz.initContainers.init.image.registry`           | Query Service initContainer registry name                                                                  | `docker.io`                    |
-| `signoz.initContainers.init.image.repository`         | Query Service initContainer image name                                                                     | `busybox`                      |
-| `signoz.initContainers.init.image.tag`                | Query Service initContainer image tag                                                                      | `1.35`                         |
-| `signoz.initContainers.init.image.pullPolicy`         | Query Service initContainer pull policy                                                                    | `IfNotPresent`                 |
-| `signoz.initContainers.init.command`                  | Query Service initContainer command line to execute                                                        | See `values.yaml` for defaults |
-| `signoz.initContainers.init.resources`                | Resources requests and limits                                                                              | See `values.yaml` for defaults |
-| `signoz.additionalEnvs`                               | Additional environment variables for signoz container                                               | `[]`                           |
-| `signoz.configVars`                                   | Query Service configurations                                                                               | See `values.yaml` for defaults |
-| `signoz.smtpVars.enabled`                             | Enable SMTP for user invitation. It will set `SMTP_ENABLED` when enabled.                                  | `false`                        |
-| `signoz.smtpVars.existingSecret.fromKey`              | Name of key in secret to get value for `SMTP_FROM`. If empty, will not set the env variable.               | `""`                           | 
-| `signoz.smtpVars.existingSecret.hostKey`              | Name of key in secret to get value for `SMTP_HOST`. If empty will not set the env variable.                | `""`                           | 
-| `signoz.smtpVars.existingSecret.name`                 | Name fo the existing k8s secret to pick the values. Needed when one of the key for existing secret is set. | `""`                           | 
-| `signoz.smtpVars.existingSecret.passwordKey`          | Name of key in secret to get value for `SMTP_PASSWORD`. If empty will not set the env variable.            | `""`                           | 
-| `signoz.smtpVars.existingSecret.portKey`              | Name of key in secret to get value for `SMTP_PORT`. If empty will not set the env variable.                | `""`                           | 
-| `signoz.smtpVars.existingSecret.usernameKey `         | Name of key in secret to get value for `SMTP_USERNAME`. If empty will not set the env variable.            | `""`                           | 
-| `signoz.imagePullSecrets`                             | Reference to secrets to be used when pulling images                                                        | `[]`                           |
-| `signoz.serviceAccount.create`                        | Service account for signoz nodes enabled                                                            | `true`                         |
-| `signoz.serviceAccount.annotations`                   | Service account annotations                                                                                | `{}`                           |
-| `signoz.serviceAccount.name`                          | Name of the service account                                                                                | `nil`                          |
-| `signoz.resources`                                    | Resources requests and limits                                                                              | See `values.yaml` for defaults |
-| `signoz.podSecurityContext`                           | Pods security context                                                                                      | `{}`                           |
-| `signoz.securityContext`                              | Security context for signoz node                                                                    | `{}`                           |
-| `signoz.service.annotations`                          | Service annotations                                                                                        | `{}`                           |
-| `signoz.service.labels`                               | Service labels                                                                                             | `{}`                           |
-| `signoz.service.type`                                 | Query Service service type                                                                                 | `ClusterIP`                    |
-| `signoz.service.port`                                 | Query Service service port                                                                                 | `8080`                         |
-| `signoz.service.internalPort`                         | Query Service service internal port                                                                        | `8085`                         |
-| `signoz.livenessProbe`                                | Query Service liveness probes                                                                              | See `values.yaml` for defaults |
-| `signoz.readinessProbe`                               | Query Service readiness probes                                                                             | See `values.yaml` for defaults |
-| `signoz.customLivenessProbe`                          | Custom liveness probes (if `signoz.livenessProbe` not enabled)                                       | `{}`                           |
-| `signoz.customReadinessProbe`                         | Custom readiness probes (if `signoz.readinessProbe` not enabled)                                     | `{}`                           |
-| `signoz.ingress.enabled`                              | Query Service ingress resource enabled                                                                     | `false`                        |
-| `signoz.ingress.className`                            | Query Service ingress class name                                                                           | `""`                           |
-| `signoz.ingress.hosts`                                | Query Service ingress virtual hosts                                                                        | See `values.yaml` for defaults |
-| `signoz.ingress.annotations`                          | Query Service ingress annotations                                                                          | `{}`                           |
-| `signoz.ingress.tls`                                  | Query Service ingress TLS settings                                                                         | `[]`                           |
-| `signoz.nodeSelector`                                 | Node labels for signoz pod assignment                                                               | `{}`                           |
-| `signoz.tolerations`                                  | Query Service tolerations                                                                                  | `[]`                           |
-| `signoz.nodeAffinity`                                 | Query Service affinity policy                                                                              | `{}`                           |
-| `schemaMigrator.nodeSelector`                               | Node labels for schemaMigrator pod assignment                                                              | `{}`                           |
-| `schemaMigrator.tolerations`                                | schemaMigrator tolerations                                                                                 | `[]`                           |
-| `schemaMigrator.nodeAffinity`                               | schemaMigrator affinity policy                                                                             | `{}`                           |
-| `schemaMigrator.initContainers.init.enabled`                | Schema migrator initContainer enabled                                                                      | `true`                         |
-| `schemaMigrator.initContainers.init.image.registry`         | Schema migrator initContainer registry name                                                                | `docker.io`                    |
-| `schemaMigrator.initContainers.init.image.repository`       | Schema migrator initContainer image name                                                                   | `busybox`                      |
-| `schemaMigrator.initContainers.init.image.tag`              | Schema migrator initContainer image tag                                                                    | `1.35`                         |
-| `schemaMigrator.initContainers.init.image.pullPolicy`       | Schema migrator initContainer pull policy                                                                  | `IfNotPresent`                 |
-| `schemaMigrator.initContainers.init.command`                | Schema migrator initContainer command line to execute                                                      | See `values.yaml` for defaults |
-| `schemaMigrator.initContainers.init.resources`              | Resources requests and limits                                                                              | See `values.yaml` for defaults |
-| `otelCollector.name`                                        | Otel Collector component name                                                                              | `otel-collector`               |
-| `otelCollector.image.registry`                              | Otel Collector image registry name                                                                         | `docker.io`                    |
-| `otelCollector.image.repository`                            | Container image name                                                                                       | `signoz/signoz-otel-collector` |
-| `otelCollector.image.tag`                                   | Container image tag                                                                                        | `0.111.16`                     |
-| `otelCollector.image.pullPolicy`                            | Container pull policy                                                                                      | `IfNotPresent`                 |
-| `otelCollector.replicaCount`                                | Number of otel-collector nodes                                                                             | `1`                            |
-| `otelCollector.service.type`                                | Otel Collector service type                                                                                | `ClusterIP`                    |
-| `otelCollector.service.annotations`                         | Service annotations                                                                                        | `{}`                           |
-| `otelCollector.service.labels`                              | Service labels                                                                                             | `{}`                           |
-| `otelCollector.ports`                                       | Lists of ports exposed by otel-collector service                                                           | See `values.yaml` for defaults |
-| `otelCollector.additionalEnvs`                              | Additional environment variables for otel-collector container                                              | `[]`                           |
-| `otelCollector.initContainers.init.enabled`                 | Otel Collector initContainer enabled                                                                       | `false`                        |
-| `otelCollector.initContainers.init.image.registry`          | Otel Collector initContainer registry name                                                                 | `docker.io`                    |
-| `otelCollector.initContainers.init.image.repository`        | Otel Collector initContainer image name                                                                    | `busybox`                      |
-| `otelCollector.initContainers.init.image.tag`               | Otel Collector initContainer image tag                                                                     | `1.35`                         |
-| `otelCollector.initContainers.init.image.pullPolicy`        | Otel Collector initContainer pull policy                                                                   | `IfNotPresent`                 |
-| `otelCollector.initContainers.init.command`                 | Otel Collector initContainer command line to execute                                                       | See `values.yaml` for defaults |
-| `otelCollector.initContainers.init.resources`               | Resources requests and limits                                                                              | See `values.yaml` for defaults |
-| `otelCollector.config`                                      | Otel Collector configurations                                                                              | See `values.yaml` for defaults |
-| `otelCollector.imagePullSecrets`                            | Reference to secrets to be used when pulling images                                                        | `[]`                           |
-| `otelCollector.serviceAccount.create`                       | Service account for otel-collector nodes enabled                                                           | `true`                         |
-| `otelCollector.serviceAccount.annotations`                  | Service account annotations                                                                                | `{}`                           |
-| `otelCollector.serviceAccount.name`                         | Name of the service account                                                                                | `nil`                          |
-| `otelCollector.resources`                                   | Resources requests and limits                                                                              | See `values.yaml` for defaults |
-| `otelCollector.nodeSelector`                                | Node labels for Otel Collector pod assignment                                                              | `{}`                           |
-| `otelCollector.tolerations`                                 | Otel Collector tolerations                                                                                 | `[]`                           |
-| `otelCollector.nodeAffinity`                                | Otel Collector affinity policy                                                                             | `{}`                           |
-| `otelCollector.livenessProbe`                               | Otel Collector liveness probes                                                                             | See `values.yaml` for defaults |
-| `otelCollector.readinessProbe`                              | Otel Collector readiness probes                                                                            | See `values.yaml` for defaults |
-| `otelCollector.customLivenessProbe`                         | Custom liveness probes (if `otelCollector.livenessProbe` not enabled)                                      | `{}`                           |
-| `otelCollector.customReadinessProbe`                        | Custom readiness probes (if `otelCollector.readinessProbe` not enabled)                                    | `{}`                           |
-| `otelCollector.extraVolumes`                                | Extra volumes to be added to the otel-collector pods                                                       | `[]`                           |
-| `otelCollector.extraVolumeMounts`                           | Extra volume mounts to be added to the otel-collector pods                                                 | `[]`                           |
-| `otelCollector.ingress.enabled`                             | Open Telemetry Collector ingress resource enabled                                                          | `false`                        |
-| `otelCollector.ingress.className`                           | Open Telemetry Collector ingress class name                                                                | `""`                           |
-| `otelCollector.ingress.hosts`                               | Open Telemetry Collector ingress virtual hosts                                                             | See `values.yaml` for defaults |
-| `otelCollector.ingress.annotations`                         | Open Telemetry Collector ingress annotations                                                               | `{}`                           |
-| `otelCollector.ingress.tls`                                 | Open Telemetry Collector ingress TLS settings                                                              | `[]`                           |
-| `otelCollector.podSecurityContext`                          | Pods security context                                                                                      | `{}`                           |
-| `otelCollector.minReadySeconds`                             | Minimum seconds for otel-collector pod to be ready without crashing                                        | `300`                          |

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -94,7 +94,7 @@ signoz:
       key: my-smtp-host-key
 ```
 
-<h2> Configuration </h2>
+## Configuration
 
 <table>
 	<thead>

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -63,6 +63,39 @@ Sometimes everything doesn't get properly removed. If that happens try deleting 
 kubectl delete namespace platform
 ```
 
+### Breaking Changes
+
+#### Version 0.87.0
+
+**Configuration Migration Required:**
+- `signoz.configVars` has been deprecated
+- `signoz.smtpVars` has been deprecated
+
+Both configuration options must now be specified under `signoz.env` instead.
+
+**Before:**
+```yaml
+signoz:
+  configVars:
+	storage: clickhouse
+  smtpVars:
+    existingSecret:
+		name: my-secret-name
+		hostKey: my-smtp-host-key
+```
+
+**After:**
+```yaml
+signoz:
+  env:
+    storage: clickhouse
+    smtp_port:
+		valueFrom:
+		 secretKeyRef:
+		 	name: my-secret-name
+			key: my-smtp-host-key
+```
+
 ## Values
 
 <table height="400px" >

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -1,7 +1,7 @@
 
 # SigNoz
 
-![Version: 0.86.0](https://img.shields.io/badge/Version-0.86.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.89.0](https://img.shields.io/badge/AppVersion-v0.89.0-informational?style=flat-square)
+![Version: 0.87.1](https://img.shields.io/badge/Version-0.87.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.90.1](https://img.shields.io/badge/AppVersion-v0.90.1-informational?style=flat-square)
 
 SigNoz is an open-source observability platform native to OpenTelemetry with logs, traces and metrics in a single application. An open-source alternative to DataDog, NewRelic, etc. 🔥 🖥. 👉 Open source Application Performance Monitoring (APM) & Observability tool
 
@@ -351,7 +351,7 @@ signoz:
 			<td id="signoz--image--tag"><a href="./values.yaml#L564">signoz.image.tag</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;"><code>"v0.89.0"</code>
+				<div style="max-width: 300px;"><code>"v0.90.1"</code>
 </div>
 			</td>
 			<td></td>
@@ -1093,7 +1093,7 @@ signoz:
 			<td id="schemaMigrator--image--tag"><a href="./values.yaml#L793">schemaMigrator.image.tag</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;"><code>"v0.128.0"</code>
+				<div style="max-width: 300px;"><code>"v0.128.2"</code>
 </div>
 			</td>
 			<td></td>
@@ -1435,7 +1435,7 @@ signoz:
 			<td id="otelCollector--image--tag"><a href="./values.yaml#L944">otelCollector.image.tag</a></td>
 			<td>string</td>
 			<td>
-				<div style="max-width: 300px;"><code>"v0.128.0"</code>
+				<div style="max-width: 300px;"><code>"v0.128.2"</code>
 </div>
 			</td>
 			<td></td>

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -77,11 +77,11 @@ Both configuration options must now be specified under `signoz.env` instead.
 ```yaml
 signoz:
   configVars:
-	storage: clickhouse
+   storage: clickhouse
   smtpVars:
     existingSecret:
-		name: my-secret-name
-		hostKey: my-smtp-host-key
+     name: my-secret-name
+     hostKey: my-smtp-host-key
 ```
 
 **After:**
@@ -90,13 +90,13 @@ signoz:
   env:
     storage: clickhouse
     smtp_port:
-		valueFrom:
-		 secretKeyRef:
-		 	name: my-secret-name
-			key: my-smtp-host-key
+     valueFrom:
+      secretKeyRef:
+      name: my-secret-name
+      key: my-smtp-host-key
 ```
 
-## Values
+<h2> Configuration </h2>
 
 <table height="400px" >
 	<thead>

--- a/charts/signoz/README.md.gotmpl
+++ b/charts/signoz/README.md.gotmpl
@@ -119,7 +119,7 @@ signoz:
 <h2> Configuration </h2>
 {{end}}
 {{ define "chart.valuesTableHtml" }}
-<table height="400px" >
+<table>
 	<thead>
 		<th>Key</th>
 		<th>Type</th>

--- a/charts/signoz/README.md.gotmpl
+++ b/charts/signoz/README.md.gotmpl
@@ -75,11 +75,11 @@ Both configuration options must now be specified under `signoz.env` instead.
 ```yaml
 signoz:
   configVars:
-   storage: clickhouse
+    storage: clickhouse
   smtpVars:
     existingSecret:
-     name: my-secret-name
-     hostKey: my-smtp-host-key
+      name: my-secret-name
+      hostKey: my-smtp-host-key
 ```
 
 **After:**
@@ -87,11 +87,11 @@ signoz:
 signoz:
   env:
     storage: clickhouse
-    smtp_port: 
-     valueFrom:
-      secretKeyRef:
-      name: my-secret-name
-      key: my-smtp-host-key
+    smtp_port:
+      valueFrom:
+        secretKeyRef:
+          name: my-secret-name
+          key: my-smtp-host-key
 ```
 
 {{ define "chart.valueDefaultColumnRender" }}
@@ -103,7 +103,7 @@ signoz:
 {{ end }}
 
 {{define "chart.valuesHeader"}}
-<h2> Configuration </h2>
+## Configuration
 {{end}}
 {{ define "chart.valuesTableHtml" }}
 <table>

--- a/charts/signoz/README.md.gotmpl
+++ b/charts/signoz/README.md.gotmpl
@@ -63,6 +63,39 @@ Sometimes everything doesn't get properly removed. If that happens try deleting 
 kubectl delete namespace platform
 ```
 
+### Breaking Changes
+
+#### Version 0.87.0
+
+**Configuration Migration Required:**
+- `signoz.configVars` has been deprecated
+- `signoz.smtpVars` has been deprecated
+
+Both configuration options must now be specified under `signoz.env` instead.
+
+**Before:**
+```yaml
+signoz:
+  configVars:
+	storage: clickhouse
+  smtpVars:
+    existingSecret:
+		name: my-secret-name
+		hostKey: my-smtp-host-key
+```
+
+**After:**
+```yaml
+signoz:
+  env:
+    storage: clickhouse
+    smtp_port: 
+		valueFrom:
+		 secretKeyRef:
+		 	name: my-secret-name
+			key: my-smtp-host-key
+```
+
 {{ define "chart.valueDefaultColumnRender" }}
 {{- $defaultValue := (default .Default .AutoDefault)  -}}
 {{- $notationType := .NotationType }}

--- a/charts/signoz/README.md.gotmpl
+++ b/charts/signoz/README.md.gotmpl
@@ -1,0 +1,110 @@
+
+# SigNoz
+
+{{ template "chart.badgesSection" . }}
+
+SigNoz is an open-source APM. It helps developers monitor their applications & troubleshoot problems,
+an open-source alternative to DataDog, NewRelic, etc. Open source Application Performance Monitoring (APM)
+& Observability tool.
+
+### TL;DR;
+
+```sh
+helm repo add signoz https://charts.signoz.io
+helm install -n platform --create-namespace "my-release" signoz/signoz
+```
+
+### Introduction
+
+This chart bootstraps [SigNoz](https://signoz.io) cluster deployment on a
+Kubernetes cluster using [Helm](https://helm.sh) package manager.
+
+### Prerequisites
+
+- Kubernetes 1.16+
+- Helm 3.0+
+
+### Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+helm repo add signoz https://charts.signoz.io
+helm -n platform --create-namespace install "my-release" signoz/signoz
+```
+
+These commands deploy SigNoz on the Kubernetes cluster in the default configuration.
+The [Configuration](#configuration) section lists the parameters that can be configured during installation:
+
+> **Tip**: List all releases using `helm list`
+
+### Uninstalling the chart
+
+To uninstall/delete the `my-release` resources:
+
+```bash
+helm -n platform uninstall "my-release"
+```
+
+See the [Helm docs](https://helm.sh/docs/helm/helm_uninstall/) for documentation on the helm uninstall command.
+
+The command above removes all the Kubernetes components associated
+with the chart and deletes the release.
+
+Deletion of the StatefulSet doesn't cascade to deleting associated PVCs. To delete them:
+
+```bash
+kubectl -n platform delete pvc --selector app.kubernetes.io/instance=my-release
+```
+
+Sometimes everything doesn't get properly removed. If that happens try deleting the namespace:
+
+```bash
+kubectl delete namespace platform
+```
+
+{{ define "chart.valueDefaultColumnRender" }}
+{{- $defaultValue := (default .Default .AutoDefault)  -}}
+{{- $notationType := .NotationType }}
+{{- if (and (hasPrefix "`" $defaultValue) (hasSuffix "`" $defaultValue) ) -}}
+{{- $defaultValue = (toPrettyJson (fromJson (trimAll "`" (default .Default .AutoDefault) ) ) ) -}}
+{{- $notationType = "json" }}
+{{- end -}}
+{{- if (eq $notationType "tpl" ) }}
+<pre lang="{{ $notationType }}">
+{{ .Key }}: |
+{{- $defaultValue | nindent 2 }}
+</pre>
+{{- else }}
+<pre lang="{{ $notationType }}">
+{{ $defaultValue }}
+</pre>
+{{- end }}
+{{ end }}
+
+
+{{ define "chart.valuesTableHtml" }}
+<table height="400px" >
+	<thead>
+		<th>Key</th>
+		<th>Type</th>
+		<th>Default</th>
+		<th>Description</th>
+	</thead>
+	<tbody>
+	{{- range .Values }}
+		<tr>
+			<td id="{{ .Key | replace "." "--" }}"><a href="./values.yaml#L{{ .LineNumber }}">{{ .Key }}</a></td>
+			<td>{{.Type}}</td>
+			<td>
+				<div style="max-width: 300px;">{{ template "chart.valueDefaultColumnRender" . }}</div>
+			</td>
+			<td>{{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }}</td>
+		</tr>
+	{{- end }}
+	</tbody>
+</table>
+{{ end }}
+
+{{ template "chart.valuesSectionHtml" . }}
+

--- a/charts/signoz/README.md.gotmpl
+++ b/charts/signoz/README.md.gotmpl
@@ -77,11 +77,11 @@ Both configuration options must now be specified under `signoz.env` instead.
 ```yaml
 signoz:
   configVars:
-	storage: clickhouse
+   storage: clickhouse
   smtpVars:
     existingSecret:
-		name: my-secret-name
-		hostKey: my-smtp-host-key
+     name: my-secret-name
+     hostKey: my-smtp-host-key
 ```
 
 **After:**
@@ -90,10 +90,10 @@ signoz:
   env:
     storage: clickhouse
     smtp_port: 
-		valueFrom:
-		 secretKeyRef:
-		 	name: my-secret-name
-			key: my-smtp-host-key
+     valueFrom:
+      secretKeyRef:
+      name: my-secret-name
+      key: my-smtp-host-key
 ```
 
 {{ define "chart.valueDefaultColumnRender" }}
@@ -115,7 +115,9 @@ signoz:
 {{- end }}
 {{ end }}
 
-
+{{define "chart.valuesHeader"}}
+<h2> Configuration </h2>
+{{end}}
 {{ define "chart.valuesTableHtml" }}
 <table height="400px" >
 	<thead>

--- a/charts/signoz/README.md.gotmpl
+++ b/charts/signoz/README.md.gotmpl
@@ -3,9 +3,7 @@
 
 {{ template "chart.badgesSection" . }}
 
-SigNoz is an open-source APM. It helps developers monitor their applications & troubleshoot problems,
-an open-source alternative to DataDog, NewRelic, etc. Open source Application Performance Monitoring (APM)
-& Observability tool.
+SigNoz is an open-source observability platform native to OpenTelemetry with logs, traces and metrics in a single application. An open-source alternative to DataDog, NewRelic, etc. 🔥 🖥. 👉 Open source Application Performance Monitoring (APM) & Observability tool
 
 ### TL;DR;
 
@@ -97,22 +95,11 @@ signoz:
 ```
 
 {{ define "chart.valueDefaultColumnRender" }}
-{{- $defaultValue := (default .Default .AutoDefault)  -}}
-{{- $notationType := .NotationType }}
-{{- if (and (hasPrefix "`" $defaultValue) (hasSuffix "`" $defaultValue) ) -}}
-{{- $defaultValue = (toPrettyJson (fromJson (trimAll "`" (default .Default .AutoDefault) ) ) ) -}}
-{{- $notationType = "json" }}
+{{- $defaultValue := (default .Default .AutoDefault) -}}
+{{- if (and (hasPrefix "" $defaultValue) (hasSuffix "" $defaultValue) ) -}}
+{{- $defaultValue = (toPrettyJson (fromJson (trimAll "`" $defaultValue) ) ) -}}
 {{- end -}}
-{{- if (eq $notationType "tpl" ) }}
-<pre lang="{{ $notationType }}">
-{{ .Key }}: |
-{{- $defaultValue | nindent 2 }}
-</pre>
-{{- else }}
-<pre lang="{{ $notationType }}">
-{{ $defaultValue }}
-</pre>
-{{- end }}
+<code>{{ $defaultValue }}</code>
 {{ end }}
 
 {{define "chart.valuesHeader"}}

--- a/charts/signoz/templates/_helpers.tpl
+++ b/charts/signoz/templates/_helpers.tpl
@@ -513,7 +513,7 @@ Function to render environment variables
   value: {{ $val | quote }}
 {{- else }}
 - name: {{ $key }}
-  value: {{ $val | quote }}
+  value: {{ $val | quote}}
 {{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/signoz/templates/_helpers.tpl
+++ b/charts/signoz/templates/_helpers.tpl
@@ -494,9 +494,9 @@ imagePullSecrets:
 {{- end }}
 
 {{/*
-Function to render additional environment variables 
+Function to render environment variables 
 */}}
-{{- define "signoz.renderAdditionalEnv" -}}
+{{- define "signoz.renderEnv" -}}
 {{- $dict := . -}}
 {{- $processedKeys := dict -}}
 {{- range keys . | sortAlpha }}
@@ -510,7 +510,10 @@ Function to render additional environment variables
 {{ toYaml $val | indent 2 -}}
 {{- else if eq $valueType "string" }}
 - name: {{ $key }}
-  value: {{ $val | quote }}
+  value: "rtrye"
+{{- else if eq $valueType "bool" }}
+- name: {{ $key }}
+  value: "rtrye"
 {{- else }}
 - name: {{ $key }}
   value: {{ $val | quote }}

--- a/charts/signoz/templates/_helpers.tpl
+++ b/charts/signoz/templates/_helpers.tpl
@@ -510,10 +510,7 @@ Function to render environment variables
 {{ toYaml $val | indent 2 -}}
 {{- else if eq $valueType "string" }}
 - name: {{ $key }}
-  value: "rtrye"
-{{- else if eq $valueType "bool" }}
-- name: {{ $key }}
-  value: "rtrye"
+  value: {{ $val | quote }}
 {{- else }}
 - name: {{ $key }}
   value: {{ $val | quote }}

--- a/charts/signoz/templates/signoz/statefulset.yaml
+++ b/charts/signoz/templates/signoz/statefulset.yaml
@@ -121,47 +121,18 @@ spec:
               containerPort: {{ default 4320 .Values.signoz.service.opampPort }}
               protocol: TCP
           env:
+            {{- if (hasKey $.Values.signoz "configVars") }}
+                {{- fail (printf "Error: signoz.configVars has been deprecated. Use signoz.env instead.") }}
+            {{- end}}
+              {{- if (hasKey $.Values.signoz "smtpVars") }}
+                {{- fail (printf "Error: signoz.smtpVars has been deprecated. Use signoz.env instead.") }}
+            {{- end}}
             {{- include "snippet.clickhouse-credentials" . | nindent 12 }}
-            - name: STORAGE
-              value: {{ .Values.signoz.configVars.storage }}
             - name: ClickHouseUrl
-            {{- if hasKey .Values.signoz.configVars "clickHouseUrl" }}
-              value: {{ .Values.signoz.configVars.clickHouseUrl }}
-            {{- else }}
+            {{- if (not .Values.signoz.env.clickHouseUrl) }}
               value: tcp://{{ include "clickhouse.clickHouseUrl" . }}
             {{- end }}
-            - name: GODEBUG
-              value: {{ .Values.signoz.configVars.goDebug }}
-            - name: TELEMETRY_ENABLED
-              value: {{ quote .Values.signoz.configVars.telemetryEnabled }}
-            - name: DEPLOYMENT_TYPE
-              value: {{ .Values.signoz.configVars.deploymentType }}
-            - name: SIGNOZ_ALERTMANAGER_PROVIDER
-              value: signoz
-            - name: DOT_METRICS_ENABLED
-              value: {{ quote .Values.signoz.configVars.dotMetricsEnabled}}
-            {{- include "signoz.renderAdditionalEnv" .Values.signoz.additionalEnvs | nindent 12 }}
-            {{- if .Values.signoz.smtpVars.enabled }}
-            - name: SMTP_ENABLED
-              value: "true"
-            {{- range $keyName, $envName := dict "fromKey" "SMTP_FROM"
-                       "hostKey" "SMTP_HOST"
-                       "portKey" "SMTP_PORT"
-                       "usernameKey" "SMTP_USERNAME"
-                       "passwordKey" "SMTP_PASSWORD" }}
-            {{- $keyInSecret := get $.Values.signoz.smtpVars.existingSecret $keyName }}
-            {{- if $keyInSecret }}
-              {{- if and $keyInSecret (hasKey $.Values.signoz.additionalEnvs $envName)}}
-                {{- fail (printf "Error: SMTP variable '%s' is configured both in .Values.signoz.additionalEnvs and .Values.signoz.smtpVars.existingSecret.%s. Please use only one configuration method to avoid conflicts." $envName $keyName)}}
-              {{- end}}
-            - name: {{$envName}}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ required (printf "'%s' is set but secret name is missing: .Values.signoz.smtpVars.existingSecret" $keyName) $.Values.signoz.smtpVars.existingSecret.name }}
-                  key: {{ $keyInSecret }}
-            {{- end }}
-            {{- end }}
-            {{- end }}
+            {{- include "signoz.renderEnv" .Values.signoz.env | nindent 12 }}
           {{- if .Values.signoz.livenessProbe.enabled }}
           livenessProbe:
             httpGet:

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -662,7 +662,6 @@ signoz:
         secretKeyRef:
           name: ""
           key: ""
-    
 
   initContainers:
     init:

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -602,24 +602,74 @@ signoz:
   annotations:
   # -- signoz additional arguments for command line
   additionalArgs: []
-  # -- Additional environments to set for signoz
-  additionalEnvs: {}
-  # Environment variables for the Query Service.
-  # You can specify variables in two ways:
-  # 1. Flexible structure for advanced configurations (recommended):
-  #    Example:
-  #      additionalEnvs:
-  #        MY_KEY:
-  #          value: my-value  # Direct value
-  #        SECRET_KEY:
-  #          valueFrom:       # Reference from a Secret or ConfigMap
-  #            secretKeyRef:
-  #              name: my-secret
-  #              key: my-key
-  # 2. Simple key-value pairs (backward-compatible):
-  #    Example:
-  #      additionalEnvs:
-  #        MY_KEY: my-value
+  env:
+    # Environment variables for the SigNoz.
+    # You can specify variables in two ways:
+    # 1. Flexible structure for advanced configurations (recommended):
+    #    Example:
+    #      env:
+    #        MY_KEY:
+    #          value: my-value  # Direct value
+    #        SECRET_KEY:
+    #          valueFrom:       # Reference from a Secret or ConfigMap
+    #            secretKeyRef:
+    #              name: my-secret
+    #              key: my-key
+    # 2. Simple key-value pairs (backward-compatible):
+    #    Example:
+    #      env:
+    #        MY_KEY: my-value
+    storage:
+      value: clickhouse
+    godebug:
+      value: netdns=go
+    telemetry_enabled:
+      value: true
+    deployment_type:
+      value: kubernetes-helm
+    dot_metrics_enabled:
+      value: true
+    signoz_alertmanager_provider:
+      value: "signoz"
+
+    # ClickHouse URL is set and applied internally.
+    # Don't override unless you know what you are doing.
+    # clickHouseUrl: tcp://clickhouse_operator:clickhouse_operator_password@my-release-clickhouse:9000/signoz_traces
+
+    # -- Enable SMTP for user invitations. Sets `SMTP_ENABLED` to true when enabled.
+    smtp_enabled:
+      value: false
+    # -- Name of key in secret to get value for `SMTP_FROM`. If empty, the env variable will not be set.
+    smtp_from:
+      valueFrom:
+        secretKeyRef:
+          name: ""
+          key: ""
+    # -- Name of key in secret to get value for `SMTP_HOST`. If empty, the env variable will not be set.
+    smtp_host:
+      valueFrom:
+        secretKeyRef:
+          name: ""
+          key: ""
+    # -- Name of key in secret to get value for `SMTP_PORT`. If empty, the env variable will not be set.
+    smtp_port:
+      valueFrom:
+        secretKeyRef:
+          name: ""
+          key: ""
+    # -- Name of key in secret to get value for `SMTP_USERNAME`. If empty, the env variable will not be set.
+    smtp_username:
+      valueFrom:
+        secretKeyRef:
+          name: ""
+          key: ""
+    # -- Name of key in secret to get value for `SMTP_PASSWORD`. If empty, the env variable will not be set.
+    smtp_password:
+      valueFrom:
+        secretKeyRef:
+          name: ""
+          key: ""
+    
 
   initContainers:
     init:
@@ -667,31 +717,7 @@ signoz:
       additionalVolumeMounts: []
       # -- Additional volumes for signoz
       additionalVolumes: []
-  configVars:
-    storage: clickhouse
-    # ClickHouse URL is set and applied internally.
-    # Don't override unless you know what you are doing.
-    # clickHouseUrl: tcp://clickhouse_operator:clickhouse_operator_password@my-release-clickhouse:9000/signoz_traces
-    goDebug: netdns=go
-    telemetryEnabled: true
-    deploymentType: kubernetes-helm
-    dotMetricsEnabled: true
-  smtpVars:
-    # -- Enable SMTP for user invitations. Sets `SMTP_ENABLED` to true when enabled.
-    enabled: false
-    existingSecret:
-      # -- Name of the existing k8s secret containing the SMTP values. Required when any secret key is specified.
-      name: ""
-      # -- Name of key in secret to get value for `SMTP_FROM`. If empty, the env variable will not be set.
-      fromKey: ""
-      # -- Name of key in secret to get value for `SMTP_HOST`. If empty, the env variable will not be set.
-      hostKey: ""
-      # -- Name of key in secret to get value for `SMTP_PORT`. If empty, the env variable will not be set.
-      portKey: ""
-      # -- Name of key in secret to get value for `SMTP_USERNAME`. If empty, the env variable will not be set.
-      usernameKey: ""
-      # -- Name of key in secret to get value for `SMTP_PASSWORD`. If empty, the env variable will not be set.
-      passwordKey: ""
+
   # -- Pod security context for signoz
   podSecurityContext: {}
   # fsGroup: 2000

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -619,26 +619,19 @@ signoz:
     #    Example:
     #      env:
     #        MY_KEY: my-value
-    storage:
-      value: clickhouse
-    godebug:
-      value: netdns=go
-    telemetry_enabled:
-      value: true
-    deployment_type:
-      value: kubernetes-helm
-    dot_metrics_enabled:
-      value: true
-    signoz_alertmanager_provider:
-      value: "signoz"
+    storage: "clickhouse"
+    godebug: "netdns=go"
+    telemetry_enabled: true
+    deployment_type: kubernetes-helm
+    dot_metrics_enabled: true
+    signoz_alertmanager_provider: signoz
 
     # ClickHouse URL is set and applied internally.
     # Don't override unless you know what you are doing.
     # clickHouseUrl: tcp://clickhouse_operator:clickhouse_operator_password@my-release-clickhouse:9000/signoz_traces
 
     # -- Enable SMTP for user invitations. Sets `SMTP_ENABLED` to true when enabled.
-    smtp_enabled:
-      value: false
+    smtp_enabled: false
     # -- Name of key in secret to get value for `SMTP_FROM`. If empty, the env variable will not be set.
     smtp_from:
       valueFrom:

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -619,8 +619,8 @@ signoz:
     #    Example:
     #      env:
     #        MY_KEY: my-value
-    storage: "clickhouse"
-    godebug: "netdns=go"
+    storage: clickhouse
+    godebug: netdns=go
     telemetry_enabled: true
     deployment_type: kubernetes-helm
     dot_metrics_enabled: true
@@ -632,36 +632,6 @@ signoz:
 
     # -- Enable SMTP for user invitations. Sets `SMTP_ENABLED` to true when enabled.
     smtp_enabled: false
-    # -- Name of key in secret to get value for `SMTP_FROM`. If empty, the env variable will not be set.
-    smtp_from:
-      valueFrom:
-        secretKeyRef:
-          name: ""
-          key: ""
-    # -- Name of key in secret to get value for `SMTP_HOST`. If empty, the env variable will not be set.
-    smtp_host:
-      valueFrom:
-        secretKeyRef:
-          name: ""
-          key: ""
-    # -- Name of key in secret to get value for `SMTP_PORT`. If empty, the env variable will not be set.
-    smtp_port:
-      valueFrom:
-        secretKeyRef:
-          name: ""
-          key: ""
-    # -- Name of key in secret to get value for `SMTP_USERNAME`. If empty, the env variable will not be set.
-    smtp_username:
-      valueFrom:
-        secretKeyRef:
-          name: ""
-          key: ""
-    # -- Name of key in secret to get value for `SMTP_PASSWORD`. If empty, the env variable will not be set.
-    smtp_password:
-      valueFrom:
-        secretKeyRef:
-          name: ""
-          key: ""
 
   initContainers:
     init:

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -831,6 +831,7 @@ schemaMigrator:
       #   limits:
       #     cpu: 100m
       #     memory: 100Mi
+    # @ignored
     chReady:
       enabled: true
       image:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized all environment variable configuration under a new, detailed env section, supporting both key-value pairs and Kubernetes secret references.
  * Included SMTP enablement flag within the new env map.
  * Added comprehensive documentation for SigNoz and Kubernetes infrastructure Helm charts.
  * Introduced Helm chart README templates with installation, configuration, and uninstallation instructions.

* **Refactor**
  * Removed deprecated configVars, smtpVars, and additionalEnvs sections in favor of the unified env structure.
  * Simplified environment variable management for deployments, enforcing use of the new env section only.
  * Renamed environment variable rendering helper for clarity.
  * Removed detailed SMTP secret references and related keys.

* **Chores**
  * Updated error handling to guide users toward the new configuration approach when deprecated keys are detected.
  * Added a Makefile target to generate Helm chart documentation automatically.
  * Added a GitHub Actions workflow to automate Helm chart documentation generation and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->