### PR TITLE
fix: adds helm unit test for signoz new and deprecated envs

### DIFF
--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -67,7 +67,12 @@ kubectl delete namespace platform
 > **Configuration Migration Required:**
 > - `signoz.configVars` has been deprecated
 > - `signoz.smtpVars` has been deprecated
+>
 > Both configuration options must now be specified under `signoz.env` instead.
+>
+> Refer to the official [documentation](https://github.com/SigNoz/signoz/blob/main/conf/example.yaml) for a complete list of env variables.
+> <br/> Note on Variable Naming: Environment variables are derived from the YAML configuration.
+> <br/> For example, a key `address` for `smtp` under the `emailing` section becomes `signoz_emailing_smtp_address`.
 >
 > **Before:**
 > ```yaml
@@ -78,6 +83,7 @@ kubectl delete namespace platform
 >    existingSecret:
 >      name: my-secret-name
 >      hostKey: my-smtp-host-key
+>      portKey: my-smtp-port-key
 > ```
 >
 > **After:**
@@ -85,11 +91,11 @@ kubectl delete namespace platform
 > signoz:
 >  env:
 >    storage: clickhouse
->    smtp_port:
+>    signoz_emailing_smtp_address:
 >      valueFrom:
 >        secretKeyRef:
 >          name: my-secret-name
->          key: my-smtp-host-key
+>          key: my-smtp-address-key
 > ```
 
 ## Values

--- a/charts/signoz/README.md.gotmpl
+++ b/charts/signoz/README.md.gotmpl
@@ -67,7 +67,12 @@ kubectl delete namespace platform
 > **Configuration Migration Required:**
 > - `signoz.configVars` has been deprecated
 > - `signoz.smtpVars` has been deprecated
+> 
 > Both configuration options must now be specified under `signoz.env` instead.
+>
+> Refer to the official [documentation](https://github.com/SigNoz/signoz/blob/main/conf/example.yaml) for a complete list of env variables.
+> <br/> Note on Variable Naming: Environment variables are derived from the YAML configuration.
+> <br/> For example, a key `address` for `smtp` under the `emailing` section becomes `signoz_emailing_smtp_address`.
 >
 > **Before:**
 > ```yaml
@@ -78,6 +83,7 @@ kubectl delete namespace platform
 >    existingSecret:
 >      name: my-secret-name
 >      hostKey: my-smtp-host-key
+>      portKey: my-smtp-port-key
 > ```
 >
 > **After:**
@@ -85,11 +91,11 @@ kubectl delete namespace platform
 > signoz:
 >  env:
 >    storage: clickhouse
->    smtp_port:
+>    signoz_emailing_smtp_address:
 >      valueFrom:
 >        secretKeyRef:
 >          name: my-secret-name
->          key: my-smtp-host-key
+>          key: my-smtp-address-key
 > ```
 
 

--- a/charts/signoz/templates/_helpers.tpl
+++ b/charts/signoz/templates/_helpers.tpl
@@ -525,10 +525,7 @@ Create Env
 {{- end }}
 
 {{- $smtpSecretEnv := dict -}}
-{{- if and .Values.signoz.smtpVars (hasKey .Values.signoz.smtpVars "enabled") }}
-  {{- $smtpSecretEnv = merge $smtpSecretEnv (dict "signoz_emailing_enabled" .Values.signoz.smtpVars.enabled) -}}
-{{- end }}
-{{- if and .Values.signoz.smtpVars .Values.signoz.smtpVars.enabled .Values.signoz.smtpVars.existingSecret.name }}
+{{- if and .Values.signoz.smtpVars .Values.signoz.smtpVars.enabled .Values.signoz.smtpVars.existingSecret (not .Values.signoz.env.signoz_emailing_enabled) }}  {{- $smtpSecretEnv = merge $smtpSecretEnv (dict "signoz_emailing_enabled" .Values.signoz.smtpVars.enabled) -}}
   {{- with .Values.signoz.smtpVars.existingSecret }}
     {{- $secretName := .name -}}
     {{- if .fromKey }}

--- a/charts/signoz/templates/_helpers.tpl
+++ b/charts/signoz/templates/_helpers.tpl
@@ -525,24 +525,29 @@ Create Env
 {{- end }}
 
 {{- $smtpSecretEnv := dict -}}
+{{- if and .Values.signoz.smtpVars (hasKey .Values.signoz.smtpVars "enabled") }}
+  {{- $smtpSecretEnv = merge $smtpSecretEnv (dict "signoz_emailing_enabled" .Values.signoz.smtpVars.enabled) -}}
+{{- end }}
 {{- if and .Values.signoz.smtpVars .Values.signoz.smtpVars.enabled .Values.signoz.smtpVars.existingSecret.name }}
-  {{- $smtpSecretEnv = merge $smtpSecretEnv (dict "SIGNOZ_EMAILING_ENABLED" .Values.signoz.smtpVars.enabled) -}}
   {{- with .Values.signoz.smtpVars.existingSecret }}
     {{- $secretName := .name -}}
     {{- if .fromKey }}
-      {{- $smtpSecretEnv = merge $smtpSecretEnv (dict "SIGNOZ_EMAILING_SMTP_FROM" (dict "valueFrom" (dict "secretKeyRef" (dict "name" $secretName "key" .fromKey)))) -}}
+      {{- $smtpSecretEnv = merge $smtpSecretEnv (dict "signoz_emailing_smtp_from" (dict "valueFrom" (dict "secretKeyRef" (dict "name" $secretName "key" .fromKey)))) -}}
     {{- end }}
     {{- if .hostKey }}
-      {{- $smtpSecretEnv = merge $smtpSecretEnv (dict "SIGNOZ_EMAILING_SMTP_HOST" (dict "valueFrom" (dict "secretKeyRef" (dict "name" $secretName "key" .hostKey)))) -}}
+      {{- $smtpSecretEnv = merge $smtpSecretEnv (dict "signoz_emailing_smtp_host" (dict "valueFrom" (dict "secretKeyRef" (dict "name" $secretName "key" .hostKey)))) -}}
     {{- end }}
     {{- if .portKey }}
-      {{- $smtpSecretEnv = merge $smtpSecretEnv (dict "SIGNOZ_EMAILING_SMTP_PORT" (dict "valueFrom" (dict "secretKeyRef" (dict "name" $secretName "key" .portKey)))) -}}
+      {{- $smtpSecretEnv = merge $smtpSecretEnv (dict "signoz_emailing_smtp_port" (dict "valueFrom" (dict "secretKeyRef" (dict "name" $secretName "key" .portKey)))) -}}
+    {{- end }}
+    {{- if and .hostKey .portKey }}
+      {{- $smtpSecretEnv = merge $smtpSecretEnv (dict "signoz_emailing_smtp_address" "$(SIGNOZ_EMAILING_SMTP_HOST):$(SIGNOZ_EMAILING_SMTP_PORT)") -}}
     {{- end }}
     {{- if .usernameKey }}
-      {{- $smtpSecretEnv = merge $smtpSecretEnv (dict "SIGNOZ_EMAILING_SMTP_AUTH_USERNAME" (dict "valueFrom" (dict "secretKeyRef" (dict "name" $secretName "key" .usernameKey)))) -}}
+      {{- $smtpSecretEnv = merge $smtpSecretEnv (dict "signoz_emailing_smtp_auth_username" (dict "valueFrom" (dict "secretKeyRef" (dict "name" $secretName "key" .usernameKey)))) -}}
     {{- end }}
     {{- if .passwordKey }}
-      {{- $smtpSecretEnv = merge $smtpSecretEnv (dict "SIGNOZ_EMAILING_SMTP_AUTH_PASSWORD" (dict "valueFrom" (dict "secretKeyRef" (dict "name" $secretName "key" .passwordKey)))) -}}
+      {{- $smtpSecretEnv = merge $smtpSecretEnv (dict "signoz_emailing_smtp_auth_password" (dict "valueFrom" (dict "secretKeyRef" (dict "name" $secretName "key" .passwordKey)))) -}}
     {{- end }}
   {{- end }}
 {{- end }}
@@ -562,7 +567,7 @@ Function to render environment variables
 {{- define "signoz.renderEnv" -}}
 {{- $dict := . -}}
 {{- $processedKeys := dict -}}
-{{- range keys . | sortAlpha }}
+{{- range keys . | sortAlpha | reverse }}
 {{- $val := pluck . $dict | first -}}
 {{- $key := upper . -}}
 {{- if not (hasKey $processedKeys $key) }}

--- a/charts/signoz/tests/signoz-instance_env_format_test.yaml
+++ b/charts/signoz/tests/signoz-instance_env_format_test.yaml
@@ -1,5 +1,3 @@
-# tests/signoz_env_format_test.yaml
-
 suite: Test SigNoz Environment Variable Formats
 
 templates:

--- a/charts/signoz/tests/signoz-instance_env_format_test.yaml
+++ b/charts/signoz/tests/signoz-instance_env_format_test.yaml
@@ -1,0 +1,90 @@
+# tests/signoz_env_format_test.yaml
+
+suite: Test SigNoz Environment Variable Formats
+
+templates:
+  - templates/signoz/statefulset.yaml
+
+tests:
+  # --- Test Case 1: Simple Key-Value Format ---
+  - it: should correctly render simple key-value environment variables
+    set:
+      signoz:
+        env:
+          # Simple key-value pairs
+          VAR_A: "value_a"
+          VAR_B: "value_b"
+    asserts:
+      # Assert that 'VAR_A: "value_a"' is transformed into the standard k8s env format.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VAR_A
+            value: "value_a"
+      # Assert that 'VAR_B: "value_b"' is also transformed correctly.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VAR_B
+            value: "value_b"
+
+  # --- Test Case 2: Advanced Structured Format ---
+  - it: should correctly render advanced (structured) environment variables
+    set:
+      signoz:
+        env:
+          # Advanced format with a direct value
+          STRUCTURED_VAR_1:
+            value: "structured_value_1"
+          # Advanced format referencing a secret
+          STRUCTURED_VAR_2:
+            valueFrom:
+              secretKeyRef:
+                name: my-dummy-secret
+                key: dummy-key-1
+    asserts:
+      # Assert the structured variable with a direct value is rendered correctly.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STRUCTURED_VAR_1
+            value: "structured_value_1"
+      # Assert the variable referencing a secret is passed through as-is.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STRUCTURED_VAR_2
+            valueFrom:
+              secretKeyRef:
+                name: my-dummy-secret
+                key: dummy-key-1
+
+  # --- Test Case 3: Mixed Formats ---
+  - it: should correctly render a mix of simple and advanced environment variables
+    set:
+      signoz:
+        env:
+          # A simple key-value pair
+          MY_SIMPLE_VAR: "some_value"
+          # An advanced, structured variable
+          MY_ADVANCED_VAR:
+            valueFrom:
+              secretKeyRef:
+                name: another-dummy-secret
+                key: dummy-key-2
+    asserts:
+      # Assert the simple format variable is correct.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_SIMPLE_VAR
+            value: "some_value"
+      # Assert the advanced format variable is correct.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_ADVANCED_VAR
+            valueFrom:
+              secretKeyRef:
+                name: another-dummy-secret
+                key: dummy-key-2

--- a/charts/signoz/tests/signoz-instance_env_test.yaml
+++ b/charts/signoz/tests/signoz-instance_env_test.yaml
@@ -1,0 +1,139 @@
+# tests/signoz_env_test.yaml
+
+suite: Test SigNoz Environment Variables
+
+# We are testing the output of the StatefulSet template,
+# where the environment variables are defined.
+templates:
+  - templates/signoz/statefulset.yaml
+
+tests:
+  # --- Test Case 1: SMTP is explicitly disabled ---
+  - it: should not render SMTP-specific variables when emailing is disabled
+    set:
+      # Set values to disable the SMTP feature
+      signoz:
+        env:
+          signoz_emailing_enabled: false
+    asserts:
+      # Assert that SMTP host variable is not present in the environment list.
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SIGNOZ_EMAILING_SMTP_HOST
+
+  # --- Test Case 2: SMTP enabled with the new 'env' convention ---
+  - it: should render SMTP variables correctly using the new 'env' convention
+    set:
+      signoz:
+        env:
+          signoz_emailing_enabled: true
+          signoz_emailing_smtp_address: 
+            valueFrom: 
+              secretKeyRef:
+                name: my-smtp-secret
+                key: smtp-address
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SIGNOZ_EMAILING_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SIGNOZ_EMAILING_SMTP_ADDRESS
+            valueFrom:
+              secretKeyRef:
+                key: smtp-address
+                name: my-smtp-secret
+
+  # --- Test Case 3: SMTP enabled with the deprecated 'smtpVars' convention (Backward Compatibility) ---
+  - it: should render SMTP variables correctly using the deprecated 'smtpVars' convention
+    set:
+      signoz:
+        smtpVars:
+          enabled: true
+          existingSecret:
+            name: my-smtp-secret
+            hostKey: "smtp-host"
+            portKey: "smtp-port"
+            usernameKey: "smtp-user"
+    asserts:
+      # It should enable the master switch
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SIGNOZ_EMAILING_ENABLED
+            value: "true"
+      # It should pull variables from the specified secret
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SIGNOZ_EMAILING_SMTP_HOST
+            valueFrom:
+              secretKeyRef:
+                key: smtp-host
+                name: my-smtp-secret
+      # It should construct the address from the host and port
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SIGNOZ_EMAILING_SMTP_ADDRESS
+            value: "$(SIGNOZ_EMAILING_SMTP_HOST):$(SIGNOZ_EMAILING_SMTP_PORT)"
+
+  # --- Test Case 4: Test precedence for the 'enabled' flag ---
+  - it: should prioritize 'smtpVars.enabled' over 'env.signoz_emailing_enabled'
+    set:
+      signoz:
+        # This value from the new convention should be IGNORED.
+        env:
+          signoz_emailing_enabled: "true"
+        # This value from the old convention should WIN.
+        smtpVars:
+          enabled: false
+    asserts:
+      # Assert that the final rendered value is "false", proving that 'smtpVars.enabled'
+      # took precedence over the value from the 'env' block.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SIGNOZ_EMAILING_ENABLED
+            value: "false"
+
+  # --- Test Case 5: Test precedence for the SMTP address value ---
+  - it: should prioritize the address from 'smtpVars' over 'env.signoz_emailing_smtp_address'
+    set:
+      signoz:
+        # Define the SMTP address using the old 'smtpVars' convention
+        smtpVars:
+          enabled: true
+          existingSecret:
+            name: my-smtp-secret
+            hostKey: "smtp-host"
+            portKey: "smtp-port"
+        # ALSO define the address using the new 'env' convention
+        env:
+          signoz_emailing_enabled: true
+          signoz_emailing_smtp_address: 
+            valueFrom: 
+              secretKeyRef:
+                name: my-smtp-secret
+                key: a-different-address # This value should be IGNORED
+    asserts:
+      # Assert that the address is constructed from 'smtpVars' (host:port),
+      # proving that the old convention for the address takes priority.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SIGNOZ_EMAILING_SMTP_ADDRESS
+            value: "$(SIGNOZ_EMAILING_SMTP_HOST):$(SIGNOZ_EMAILING_SMTP_PORT)"
+      # As a sanity check, ensure the new convention's address is NOT rendered.
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SIGNOZ_EMAILING_SMTP_ADDRESS
+            valueFrom:
+              secretKeyRef:
+                key: a-different-address
+                name: my-smtp-secret

--- a/charts/signoz/tests/signoz-instance_env_test.yaml
+++ b/charts/signoz/tests/signoz-instance_env_test.yaml
@@ -81,26 +81,28 @@ tests:
             value: "$(SIGNOZ_EMAILING_SMTP_HOST):$(SIGNOZ_EMAILING_SMTP_PORT)"
 
   # --- Test Case 4: Test precedence for the 'enabled' flag ---
-  - it: should prioritize 'smtpVars.enabled' over 'env.signoz_emailing_enabled'
+  - it: should prioritize 'env.smtp_emailing_enabled' over 'smtpVars.enabled'
     set:
       signoz:
-        # This value from the new convention should be IGNORED.
+        # This value from the new convention should WIN.
         env:
-          signoz_emailing_enabled: "true"
-        # This value from the old convention should WIN.
+          signoz_emailing_enabled: true
+        # This value from the old convention should be IGNORED.
         smtpVars:
           enabled: false
+          existingSecret:
+            name: my-smtp-secret
     asserts:
-      # Assert that the final rendered value is "false", proving that 'smtpVars.enabled'
-      # took precedence over the value from the 'env' block.
+      # Assert that the final rendered value is "true", proving that 'env.smtp_emailing_enabled'
+      # took precedence over the value from the 'smtpVars' block.
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: SIGNOZ_EMAILING_ENABLED
-            value: "false"
+            value: "true"
 
   # --- Test Case 5: Test precedence for the SMTP address value ---
-  - it: should prioritize the address from 'smtpVars' over 'env.signoz_emailing_smtp_address'
+  - it: should prioritize the address from 'env.signoz_emailing_smtp_address' over 'smtpVars'
     set:
       signoz:
         # Define the SMTP address using the old 'smtpVars' convention
@@ -117,17 +119,17 @@ tests:
             valueFrom: 
               secretKeyRef:
                 name: my-smtp-secret
-                key: a-different-address # This value should be IGNORED
+                key: a-different-address # This value should WIN
     asserts:
-      # Assert that the address is constructed from 'smtpVars' (host:port),
-      # proving that the old convention for the address takes priority.
-      - contains:
+      # Assert that the address is constructed from 'env' (signoz_emailing_smtp_address),
+      # make ensure the old convention for the address NOT takes priority.
+      - notContains:
           path: spec.template.spec.containers[0].env
           content:
             name: SIGNOZ_EMAILING_SMTP_ADDRESS
             value: "$(SIGNOZ_EMAILING_SMTP_HOST):$(SIGNOZ_EMAILING_SMTP_PORT)"
-      # As a sanity check, ensure the new convention's address is NOT rendered.
-      - notContains:
+      # proving the new convention's address is rendered.
+      - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: SIGNOZ_EMAILING_SMTP_ADDRESS

--- a/charts/signoz/tests/signoz-instance_env_test.yaml
+++ b/charts/signoz/tests/signoz-instance_env_test.yaml
@@ -1,5 +1,3 @@
-# tests/signoz_env_test.yaml
-
 suite: Test SigNoz Environment Variables
 
 # We are testing the output of the StatefulSet template,

--- a/charts/signoz/tests/signoz-instance_env_test.yaml
+++ b/charts/signoz/tests/signoz-instance_env_test.yaml
@@ -26,8 +26,8 @@ tests:
       signoz:
         env:
           signoz_emailing_enabled: true
-          signoz_emailing_smtp_address: 
-            valueFrom: 
+          signoz_emailing_smtp_address:
+            valueFrom:
               secretKeyRef:
                 name: my-smtp-secret
                 key: smtp-address
@@ -115,8 +115,8 @@ tests:
         # ALSO define the address using the new 'env' convention
         env:
           signoz_emailing_enabled: true
-          signoz_emailing_smtp_address: 
-            valueFrom: 
+          signoz_emailing_smtp_address:
+            valueFrom:
               secretKeyRef:
                 name: my-smtp-secret
                 key: a-different-address # This value should WIN


### PR DESCRIPTION
Related: https://github.com/SigNoz/platform-pod/issues/807
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect a breaking change in configuration for version 0.88.0, consolidating previous options under a unified section.
  * Added explanatory notes and a reference link to official documentation for environment variables.
  * Revised example configurations to use the new format and naming conventions.
* **Tests**
  * Added new test suites to validate environment variable rendering and SMTP configuration scenarios in Kubernetes manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->