### PR TITLE
fix: Render external-clickhouse creds in signoz statefulset

### DIFF
--- a/charts/signoz/templates/_clickhouse.tpl
+++ b/charts/signoz/templates/_clickhouse.tpl
@@ -225,7 +225,7 @@ Return the ClickHouse Traces URL
 {{- if .Values.clickhouse.enabled -}}
   {{- include "clickhouse.servicename" . }}:{{ include "clickhouse.tcpPort" . }}/?username={{ .Values.clickhouse.user }}&password={{ .Values.clickhouse.password -}}
 {{- else -}}
-  {{- required "externalClickhouse.host is required if using external clickhouse" .Values.externalClickhouse.host }}:{{ include "clickhouse.tcpPort" . }}/?username={{ .Values.externalClickhouse.user }}&password=$(CLICKHOUSE_PASSWORD)
+  {{- required "externalClickhouse.host is required if using external clickhouse" .Values.externalClickhouse.host }}:{{ include "clickhouse.tcpPort" . }}/?username=$(CLICKHOUSE_USER)&password=$(CLICKHOUSE_PASSWORD)
 {{- end -}}
 {{- end -}}
 

--- a/charts/signoz/templates/signoz/statefulset.yaml
+++ b/charts/signoz/templates/signoz/statefulset.yaml
@@ -119,6 +119,7 @@ spec:
               containerPort: {{ default 4320 .Values.signoz.service.opampPort }}
               protocol: TCP
           env:
+            {{- include "snippet.clickhouse-credentials" . | nindent 12 }}
             {{- include "signoz.env" . | nindent 12 }}
           {{- if .Values.signoz.livenessProbe.enabled }}
           livenessProbe:


### PR DESCRIPTION
Fixes: https://github.com/SigNoz/charts/issues/711