### PR TITLE
chore: update breaking changes readme for charts/signoz

### DIFF
--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -67,8 +67,8 @@ kubectl delete namespace platform
 > **Configuration Migration Required:**
 > - `signoz.configVars` has been deprecated
 > - `signoz.smtpVars` has been deprecated
->
-> Both configuration options must now be specified under `signoz.env` instead.
+> - `signoz.additionalEnvs` has been deprecated
+> These configuration options must now be specified under `signoz.env` instead.
 >
 > Refer to the official [documentation](https://github.com/SigNoz/signoz/blob/main/conf/example.yaml) for a complete list of env variables.
 > <br/> Note on Variable Naming: Environment variables are derived from the YAML configuration.

--- a/charts/signoz/README.md.gotmpl
+++ b/charts/signoz/README.md.gotmpl
@@ -67,8 +67,8 @@ kubectl delete namespace platform
 > **Configuration Migration Required:**
 > - `signoz.configVars` has been deprecated
 > - `signoz.smtpVars` has been deprecated
-> 
-> Both configuration options must now be specified under `signoz.env` instead.
+> - `signoz.additionalEnvs` has been deprecated
+> These configuration options must now be specified under `signoz.env` instead.
 >
 > Refer to the official [documentation](https://github.com/SigNoz/signoz/blob/main/conf/example.yaml) for a complete list of env variables.
 > <br/> Note on Variable Naming: Environment variables are derived from the YAML configuration.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the breaking changes section to include the deprecation of the `signoz.additionalEnvs` configuration option, alongside `signoz.configVars` and `signoz.smtpVars`. All deprecated options should now be specified under `signoz.env`. Clarified documentation wording for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->