### PR TITLE
chore(k8s-infra): adds hostNetwork, support otlphttp receiver, replace logging exporter with debug 

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.13.1
+version: 0.14.0
 appVersion: "0.109.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.13.0
+version: 0.13.1
 appVersion: "0.109.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/README.md
+++ b/charts/k8s-infra/README.md
@@ -1351,7 +1351,16 @@ name: ""</pre>
             <td>Enable service port for pprof.</td>
         </tr>
         <tr>
-            <td id="otelAgent--livenessProbe"><a href="./values.yaml#L797">otelAgent.livenessProbe</a></td>
+            <td id="otelAgent--hostNetwork"><a href="./values.yaml#L795">otelAgent.hostNetwork</a></td>
+            <td>bool</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+</div>
+            </td>
+            <td>Host networking requested for this pod. Use the host's network namespace.</td>
+        </tr>
+        <tr>
+            <td id="otelAgent--livenessProbe"><a href="./values.yaml#L799">otelAgent.livenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
@@ -1367,7 +1376,7 @@ timeoutSeconds: 5</pre>
             <td>Configure liveness probe. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command</td>
         </tr>
         <tr>
-            <td id="otelAgent--readinessProbe"><a href="./values.yaml#L818">otelAgent.readinessProbe</a></td>
+            <td id="otelAgent--readinessProbe"><a href="./values.yaml#L820">otelAgent.readinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
@@ -1383,7 +1392,7 @@ timeoutSeconds: 5</pre>
             <td>Configure readiness probe. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes</td>
         </tr>
         <tr>
-            <td id="otelAgent--customLivenessProbe"><a href="./values.yaml#L838">otelAgent.customLivenessProbe</a></td>
+            <td id="otelAgent--customLivenessProbe"><a href="./values.yaml#L840">otelAgent.customLivenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1392,7 +1401,7 @@ timeoutSeconds: 5</pre>
             <td>Custom liveness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--customReadinessProbe"><a href="./values.yaml#L841">otelAgent.customReadinessProbe</a></td>
+            <td id="otelAgent--customReadinessProbe"><a href="./values.yaml#L843">otelAgent.customReadinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1401,7 +1410,7 @@ timeoutSeconds: 5</pre>
             <td>Custom readiness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress"><a href="./values.yaml#L845">otelAgent.ingress</a></td>
+            <td id="otelAgent--ingress"><a href="./values.yaml#L847">otelAgent.ingress</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1419,7 +1428,7 @@ tls: []</pre>
             <td>Ingress configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--enabled"><a href="./values.yaml#L848">otelAgent.ingress.enabled</a></td>
+            <td id="otelAgent--ingress--enabled"><a href="./values.yaml#L850">otelAgent.ingress.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1428,7 +1437,7 @@ tls: []</pre>
             <td>Enable Ingress for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--className"><a href="./values.yaml#L851">otelAgent.ingress.className</a></td>
+            <td id="otelAgent--ingress--className"><a href="./values.yaml#L853">otelAgent.ingress.className</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -1437,7 +1446,7 @@ tls: []</pre>
             <td>Ingress Class Name to be used.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--annotations"><a href="./values.yaml#L854">otelAgent.ingress.annotations</a></td>
+            <td id="otelAgent--ingress--annotations"><a href="./values.yaml#L856">otelAgent.ingress.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1446,7 +1455,7 @@ tls: []</pre>
             <td>Annotations for the OtelAgent Ingress.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--hosts"><a href="./values.yaml#L862">otelAgent.ingress.hosts</a></td>
+            <td id="otelAgent--ingress--hosts"><a href="./values.yaml#L864">otelAgent.ingress.hosts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- host: otel-agent.domain.com
@@ -1459,7 +1468,7 @@ tls: []</pre>
             <td>OtelAgent Ingress hostnames with their path details.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--tls"><a href="./values.yaml#L870">otelAgent.ingress.tls</a></td>
+            <td id="otelAgent--ingress--tls"><a href="./values.yaml#L872">otelAgent.ingress.tls</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1468,7 +1477,7 @@ tls: []</pre>
             <td>OtelAgent Ingress TLS configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--resources"><a href="./values.yaml#L878">otelAgent.resources</a></td>
+            <td id="otelAgent--resources"><a href="./values.yaml#L880">otelAgent.resources</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">requests:
@@ -1479,7 +1488,7 @@ tls: []</pre>
             <td>Configure resource requests and limits for the OtelAgent. ref: http://kubernetes.io/docs/user-guide/compute-resources/</td>
         </tr>
         <tr>
-            <td id="otelAgent--priorityClassName"><a href="./values.yaml#L889">otelAgent.priorityClassName</a></td>
+            <td id="otelAgent--priorityClassName"><a href="./values.yaml#L891">otelAgent.priorityClassName</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -1488,7 +1497,7 @@ tls: []</pre>
             <td>OtelAgent Priority Class name.</td>
         </tr>
         <tr>
-            <td id="otelAgent--nodeSelector"><a href="./values.yaml#L893">otelAgent.nodeSelector</a></td>
+            <td id="otelAgent--nodeSelector"><a href="./values.yaml#L895">otelAgent.nodeSelector</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1497,7 +1506,7 @@ tls: []</pre>
             <td>Node selector for OtelAgent pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelAgent--tolerations"><a href="./values.yaml#L897">otelAgent.tolerations</a></td>
+            <td id="otelAgent--tolerations"><a href="./values.yaml#L899">otelAgent.tolerations</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- operator: Exists</pre>
@@ -1506,7 +1515,7 @@ tls: []</pre>
             <td>Toleration labels for OtelAgent pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelAgent--affinity"><a href="./values.yaml#L902">otelAgent.affinity</a></td>
+            <td id="otelAgent--affinity"><a href="./values.yaml#L904">otelAgent.affinity</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1515,7 +1524,7 @@ tls: []</pre>
             <td>Affinity settings for the OtelAgent pod.</td>
         </tr>
         <tr>
-            <td id="otelAgent--podSecurityContext"><a href="./values.yaml#L906">otelAgent.podSecurityContext</a></td>
+            <td id="otelAgent--podSecurityContext"><a href="./values.yaml#L908">otelAgent.podSecurityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1524,7 +1533,7 @@ tls: []</pre>
             <td>Pod-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--securityContext"><a href="./values.yaml#L911">otelAgent.securityContext</a></td>
+            <td id="otelAgent--securityContext"><a href="./values.yaml#L913">otelAgent.securityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1533,7 +1542,7 @@ tls: []</pre>
             <td>Container-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--config"><a href="./values.yaml#L922">otelAgent.config</a></td>
+            <td id="otelAgent--config"><a href="./values.yaml#L924">otelAgent.config</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please Checkout the values.yml for default values</pre>
@@ -1542,7 +1551,7 @@ tls: []</pre>
             <td>Base configuration for the OtelAgent Collector.</td>
         </tr>
         <tr>
-            <td id="otelAgent--config--processors--batch"><a href="./values.yaml#L937">otelAgent.config.processors.batch</a></td>
+            <td id="otelAgent--config--processors--batch"><a href="./values.yaml#L939">otelAgent.config.processors.batch</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">send_batch_size: 10000
@@ -1552,7 +1561,7 @@ timeout: 200ms</pre>
             <td>Batch processor config. ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md</td>
         </tr>
         <tr>
-            <td id="otelAgent--extraVolumes"><a href="./values.yaml#L979">otelAgent.extraVolumes</a></td>
+            <td id="otelAgent--extraVolumes"><a href="./values.yaml#L981">otelAgent.extraVolumes</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1561,7 +1570,7 @@ timeout: 200ms</pre>
             <td>Additional volumes for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--extraVolumeMounts"><a href="./values.yaml#L989">otelAgent.extraVolumeMounts</a></td>
+            <td id="otelAgent--extraVolumeMounts"><a href="./values.yaml#L991">otelAgent.extraVolumeMounts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1581,7 +1590,7 @@ timeout: 200ms</pre>
     </thead>
     <tbody>
         <tr>
-            <td id="otelDeployment--enabled"><a href="./values.yaml#L1001">otelDeployment.enabled</a></td>
+            <td id="otelDeployment--enabled"><a href="./values.yaml#L1003">otelDeployment.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1590,7 +1599,7 @@ timeout: 200ms</pre>
             <td>Enable the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--name"><a href="./values.yaml#L1004">otelDeployment.name</a></td>
+            <td id="otelDeployment--name"><a href="./values.yaml#L1006">otelDeployment.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">otel-deployment</pre>
@@ -1599,7 +1608,7 @@ timeout: 200ms</pre>
             <td>Name of the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image"><a href="./values.yaml#L1007">otelDeployment.image</a></td>
+            <td id="otelDeployment--image"><a href="./values.yaml#L1009">otelDeployment.image</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">pullPolicy: IfNotPresent
@@ -1611,7 +1620,7 @@ tag: 0.109.0</pre>
             <td>Image configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--registry"><a href="./values.yaml#L1010">otelDeployment.image.registry</a></td>
+            <td id="otelDeployment--image--registry"><a href="./values.yaml#L1012">otelDeployment.image.registry</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">docker.io</pre>
@@ -1620,7 +1629,7 @@ tag: 0.109.0</pre>
             <td>Docker registry for the OtelDeployment image.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--repository"><a href="./values.yaml#L1013">otelDeployment.image.repository</a></td>
+            <td id="otelDeployment--image--repository"><a href="./values.yaml#L1015">otelDeployment.image.repository</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">otel/opentelemetry-collector-contrib</pre>
@@ -1629,7 +1638,7 @@ tag: 0.109.0</pre>
             <td>Repository for the OtelDeployment image.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--tag"><a href="./values.yaml#L1016">otelDeployment.image.tag</a></td>
+            <td id="otelDeployment--image--tag"><a href="./values.yaml#L1018">otelDeployment.image.tag</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">0.109.0</pre>
@@ -1638,7 +1647,7 @@ tag: 0.109.0</pre>
             <td>Tag for the OtelDeployment image.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--pullPolicy"><a href="./values.yaml#L1019">otelDeployment.image.pullPolicy</a></td>
+            <td id="otelDeployment--image--pullPolicy"><a href="./values.yaml#L1021">otelDeployment.image.pullPolicy</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">IfNotPresent</pre>
@@ -1647,7 +1656,7 @@ tag: 0.109.0</pre>
             <td>Image pull policy for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--imagePullSecrets"><a href="./values.yaml#L1023">otelDeployment.imagePullSecrets</a></td>
+            <td id="otelDeployment--imagePullSecrets"><a href="./values.yaml#L1025">otelDeployment.imagePullSecrets</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1656,7 +1665,7 @@ tag: 0.109.0</pre>
             <td>Image Pull Secrets for the OtelDeployment. Merged with `global.imagePullSecrets`.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--command"><a href="./values.yaml#L1028">otelDeployment.command</a></td>
+            <td id="otelDeployment--command"><a href="./values.yaml#L1030">otelDeployment.command</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">extraArgs: []
@@ -1666,7 +1675,7 @@ name: /otelcol-contrib</pre>
             <td>Command and arguments for the OtelDeployment container.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--command--name"><a href="./values.yaml#L1031">otelDeployment.command.name</a></td>
+            <td id="otelDeployment--command--name"><a href="./values.yaml#L1033">otelDeployment.command.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">/otelcol-contrib</pre>
@@ -1675,7 +1684,7 @@ name: /otelcol-contrib</pre>
             <td>OtelDeployment command name.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--command--extraArgs"><a href="./values.yaml#L1034">otelDeployment.command.extraArgs</a></td>
+            <td id="otelDeployment--command--extraArgs"><a href="./values.yaml#L1036">otelDeployment.command.extraArgs</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1684,7 +1693,7 @@ name: /otelcol-contrib</pre>
             <td>Extra arguments for the OtelDeployment command.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--configMap"><a href="./values.yaml#L1038">otelDeployment.configMap</a></td>
+            <td id="otelDeployment--configMap"><a href="./values.yaml#L1040">otelDeployment.configMap</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">create: true</pre>
@@ -1693,7 +1702,7 @@ name: /otelcol-contrib</pre>
             <td>ConfigMap configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--configMap--create"><a href="./values.yaml#L1041">otelDeployment.configMap.create</a></td>
+            <td id="otelDeployment--configMap--create"><a href="./values.yaml#L1043">otelDeployment.configMap.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1702,7 +1711,7 @@ name: /otelcol-contrib</pre>
             <td>Specifies whether a ConfigMap should be created.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--service"><a href="./values.yaml#L1045">otelDeployment.service</a></td>
+            <td id="otelDeployment--service"><a href="./values.yaml#L1047">otelDeployment.service</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1712,7 +1721,7 @@ type: ClusterIP</pre>
             <td>Service configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--service--annotations"><a href="./values.yaml#L1048">otelDeployment.service.annotations</a></td>
+            <td id="otelDeployment--service--annotations"><a href="./values.yaml#L1050">otelDeployment.service.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1721,7 +1730,7 @@ type: ClusterIP</pre>
             <td>Annotations for the OtelDeployment service.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--service--type"><a href="./values.yaml#L1051">otelDeployment.service.type</a></td>
+            <td id="otelDeployment--service--type"><a href="./values.yaml#L1053">otelDeployment.service.type</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">ClusterIP</pre>
@@ -1730,7 +1739,7 @@ type: ClusterIP</pre>
             <td>Service type.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount"><a href="./values.yaml#L1055">otelDeployment.serviceAccount</a></td>
+            <td id="otelDeployment--serviceAccount"><a href="./values.yaml#L1057">otelDeployment.serviceAccount</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1741,7 +1750,7 @@ name: null</pre>
             <td>ServiceAccount configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount--create"><a href="./values.yaml#L1058">otelDeployment.serviceAccount.create</a></td>
+            <td id="otelDeployment--serviceAccount--create"><a href="./values.yaml#L1060">otelDeployment.serviceAccount.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1750,7 +1759,7 @@ name: null</pre>
             <td>Specifies whether a ServiceAccount should be created.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount--annotations"><a href="./values.yaml#L1061">otelDeployment.serviceAccount.annotations</a></td>
+            <td id="otelDeployment--serviceAccount--annotations"><a href="./values.yaml#L1063">otelDeployment.serviceAccount.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1759,7 +1768,7 @@ name: null</pre>
             <td>Annotations for the ServiceAccount.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount--name"><a href="./values.yaml#L1064">otelDeployment.serviceAccount.name</a></td>
+            <td id="otelDeployment--serviceAccount--name"><a href="./values.yaml#L1066">otelDeployment.serviceAccount.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">null</pre>
@@ -1768,7 +1777,7 @@ name: null</pre>
             <td>The name of the ServiceAccount to use. A name is generated if not set.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--annotations"><a href="./values.yaml#L1068">otelDeployment.annotations</a></td>
+            <td id="otelDeployment--annotations"><a href="./values.yaml#L1070">otelDeployment.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1777,7 +1786,7 @@ name: null</pre>
             <td>Annotations for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--podAnnotations"><a href="./values.yaml#L1071">otelDeployment.podAnnotations</a></td>
+            <td id="otelDeployment--podAnnotations"><a href="./values.yaml#L1073">otelDeployment.podAnnotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1786,7 +1795,7 @@ name: null</pre>
             <td>Annotations for the OtelDeployment pods.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--additionalEnvs"><a href="./values.yaml#L1078">otelDeployment.additionalEnvs</a></td>
+            <td id="otelDeployment--additionalEnvs"><a href="./values.yaml#L1080">otelDeployment.additionalEnvs</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1795,7 +1804,7 @@ name: null</pre>
             <td>Additional environment variables for the OtelDeployment container.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--podSecurityContext"><a href="./values.yaml#L1082">otelDeployment.podSecurityContext</a></td>
+            <td id="otelDeployment--podSecurityContext"><a href="./values.yaml#L1084">otelDeployment.podSecurityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1804,7 +1813,7 @@ name: null</pre>
             <td>Pod-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--securityContext"><a href="./values.yaml#L1087">otelDeployment.securityContext</a></td>
+            <td id="otelDeployment--securityContext"><a href="./values.yaml#L1089">otelDeployment.securityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1813,7 +1822,7 @@ name: null</pre>
             <td>Container-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--minReadySeconds"><a href="./values.yaml#L1097">otelDeployment.minReadySeconds</a></td>
+            <td id="otelDeployment--minReadySeconds"><a href="./values.yaml#L1099">otelDeployment.minReadySeconds</a></td>
             <td>int</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">5</pre>
@@ -1822,7 +1831,7 @@ name: null</pre>
             <td>Minimum number of seconds for which a newly created Pod should be ready.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--progressDeadlineSeconds"><a href="./values.yaml#L1101">otelDeployment.progressDeadlineSeconds</a></td>
+            <td id="otelDeployment--progressDeadlineSeconds"><a href="./values.yaml#L1103">otelDeployment.progressDeadlineSeconds</a></td>
             <td>int</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">120</pre>
@@ -1831,7 +1840,7 @@ name: null</pre>
             <td>Seconds to wait for the Deployment to progress before it's considered failed.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports"><a href="./values.yaml#L1105">otelDeployment.ports</a></td>
+            <td id="otelDeployment--ports"><a href="./values.yaml#L1107">otelDeployment.ports</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">health-check:
@@ -1863,7 +1872,7 @@ zpages:
             <td>Port configurations for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--metrics--enabled"><a href="./values.yaml#L1110">otelDeployment.ports.metrics.enabled</a></td>
+            <td id="otelDeployment--ports--metrics--enabled"><a href="./values.yaml#L1112">otelDeployment.ports.metrics.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1872,7 +1881,7 @@ zpages:
             <td>Enable service port for internal metrics.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--zpages--enabled"><a href="./values.yaml#L1123">otelDeployment.ports.zpages.enabled</a></td>
+            <td id="otelDeployment--ports--zpages--enabled"><a href="./values.yaml#L1125">otelDeployment.ports.zpages.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1881,7 +1890,7 @@ zpages:
             <td>Enable service port for ZPages.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--health-check--enabled"><a href="./values.yaml#L1136">otelDeployment.ports.health-check.enabled</a></td>
+            <td id="otelDeployment--ports--health-check--enabled"><a href="./values.yaml#L1138">otelDeployment.ports.health-check.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1890,7 +1899,7 @@ zpages:
             <td>Enable service port for health checks.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--pprof--enabled"><a href="./values.yaml#L1149">otelDeployment.ports.pprof.enabled</a></td>
+            <td id="otelDeployment--ports--pprof--enabled"><a href="./values.yaml#L1151">otelDeployment.ports.pprof.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1899,7 +1908,7 @@ zpages:
             <td>Enable service port for pprof.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--livenessProbe"><a href="./values.yaml#L1161">otelDeployment.livenessProbe</a></td>
+            <td id="otelDeployment--livenessProbe"><a href="./values.yaml#L1163">otelDeployment.livenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
@@ -1915,7 +1924,7 @@ timeoutSeconds: 5</pre>
             <td>Configure liveness probe.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--readinessProbe"><a href="./values.yaml#L1181">otelDeployment.readinessProbe</a></td>
+            <td id="otelDeployment--readinessProbe"><a href="./values.yaml#L1183">otelDeployment.readinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
@@ -1931,7 +1940,7 @@ timeoutSeconds: 5</pre>
             <td>Configure readiness probe.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--customLivenessProbe"><a href="./values.yaml#L1201">otelDeployment.customLivenessProbe</a></td>
+            <td id="otelDeployment--customLivenessProbe"><a href="./values.yaml#L1203">otelDeployment.customLivenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1940,7 +1949,7 @@ timeoutSeconds: 5</pre>
             <td>Custom liveness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--customReadinessProbe"><a href="./values.yaml#L1205">otelDeployment.customReadinessProbe</a></td>
+            <td id="otelDeployment--customReadinessProbe"><a href="./values.yaml#L1207">otelDeployment.customReadinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1949,7 +1958,7 @@ timeoutSeconds: 5</pre>
             <td>Custom readiness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress"><a href="./values.yaml#L1209">otelDeployment.ingress</a></td>
+            <td id="otelDeployment--ingress"><a href="./values.yaml#L1211">otelDeployment.ingress</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1967,7 +1976,7 @@ tls: []</pre>
             <td>Ingress configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--enabled"><a href="./values.yaml#L1212">otelDeployment.ingress.enabled</a></td>
+            <td id="otelDeployment--ingress--enabled"><a href="./values.yaml#L1214">otelDeployment.ingress.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1976,7 +1985,7 @@ tls: []</pre>
             <td>Enable Ingress for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--className"><a href="./values.yaml#L1215">otelDeployment.ingress.className</a></td>
+            <td id="otelDeployment--ingress--className"><a href="./values.yaml#L1217">otelDeployment.ingress.className</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -1985,7 +1994,7 @@ tls: []</pre>
             <td>Ingress Class Name to be used.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--annotations"><a href="./values.yaml#L1218">otelDeployment.ingress.annotations</a></td>
+            <td id="otelDeployment--ingress--annotations"><a href="./values.yaml#L1220">otelDeployment.ingress.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1994,7 +2003,7 @@ tls: []</pre>
             <td>Annotations for the OtelDeployment Ingress.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--hosts"><a href="./values.yaml#L1221">otelDeployment.ingress.hosts</a></td>
+            <td id="otelDeployment--ingress--hosts"><a href="./values.yaml#L1223">otelDeployment.ingress.hosts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- host: otel-deployment.domain.com
@@ -2007,7 +2016,7 @@ tls: []</pre>
             <td>OtelDeployment Ingress hostnames.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--tls"><a href="./values.yaml#L1229">otelDeployment.ingress.tls</a></td>
+            <td id="otelDeployment--ingress--tls"><a href="./values.yaml#L1231">otelDeployment.ingress.tls</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -2016,7 +2025,7 @@ tls: []</pre>
             <td>OtelDeployment Ingress TLS configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--resources"><a href="./values.yaml#L1236">otelDeployment.resources</a></td>
+            <td id="otelDeployment--resources"><a href="./values.yaml#L1238">otelDeployment.resources</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">requests:
@@ -2027,7 +2036,7 @@ tls: []</pre>
             <td>Configure resource requests and limits for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--priorityClassName"><a href="./values.yaml#L1247">otelDeployment.priorityClassName</a></td>
+            <td id="otelDeployment--priorityClassName"><a href="./values.yaml#L1249">otelDeployment.priorityClassName</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -2036,7 +2045,7 @@ tls: []</pre>
             <td>OtelDeployment Priority Class name.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--nodeSelector"><a href="./values.yaml#L1251">otelDeployment.nodeSelector</a></td>
+            <td id="otelDeployment--nodeSelector"><a href="./values.yaml#L1253">otelDeployment.nodeSelector</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -2045,7 +2054,7 @@ tls: []</pre>
             <td>Node selector for OtelDeployment pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--tolerations"><a href="./values.yaml#L1255">otelDeployment.tolerations</a></td>
+            <td id="otelDeployment--tolerations"><a href="./values.yaml#L1257">otelDeployment.tolerations</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -2054,7 +2063,7 @@ tls: []</pre>
             <td>Toleration labels for OtelDeployment pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--affinity"><a href="./values.yaml#L1259">otelDeployment.affinity</a></td>
+            <td id="otelDeployment--affinity"><a href="./values.yaml#L1261">otelDeployment.affinity</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -2063,7 +2072,7 @@ tls: []</pre>
             <td>Affinity settings for the OtelDeployment pod.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--topologySpreadConstraints"><a href="./values.yaml#L1263">otelDeployment.topologySpreadConstraints</a></td>
+            <td id="otelDeployment--topologySpreadConstraints"><a href="./values.yaml#L1265">otelDeployment.topologySpreadConstraints</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -2072,7 +2081,7 @@ tls: []</pre>
             <td>Describes how OtelDeployment pods ought to spread.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole"><a href="./values.yaml#L1268">otelDeployment.clusterRole</a></td>
+            <td id="otelDeployment--clusterRole"><a href="./values.yaml#L1270">otelDeployment.clusterRole</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please Checkout the values.yml for default values</pre>
@@ -2081,7 +2090,7 @@ tls: []</pre>
             <td>ClusterRole configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--create"><a href="./values.yaml#L1271">otelDeployment.clusterRole.create</a></td>
+            <td id="otelDeployment--clusterRole--create"><a href="./values.yaml#L1273">otelDeployment.clusterRole.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -2090,7 +2099,7 @@ tls: []</pre>
             <td>Specifies whether a ClusterRole should be created.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--annotations"><a href="./values.yaml#L1274">otelDeployment.clusterRole.annotations</a></td>
+            <td id="otelDeployment--clusterRole--annotations"><a href="./values.yaml#L1276">otelDeployment.clusterRole.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -2099,7 +2108,7 @@ tls: []</pre>
             <td>Annotations for the ClusterRole.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--name"><a href="./values.yaml#L1277">otelDeployment.clusterRole.name</a></td>
+            <td id="otelDeployment--clusterRole--name"><a href="./values.yaml#L1279">otelDeployment.clusterRole.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -2108,7 +2117,7 @@ tls: []</pre>
             <td>The name of the ClusterRole to use. A name is generated if not set.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--rules"><a href="./values.yaml#L1281">otelDeployment.clusterRole.rules</a></td>
+            <td id="otelDeployment--clusterRole--rules"><a href="./values.yaml#L1283">otelDeployment.clusterRole.rules</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please checkout the values.yml for default values</pre>
@@ -2117,7 +2126,7 @@ tls: []</pre>
             <td>RBAC rules for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--clusterRoleBinding"><a href="./values.yaml#L1311">otelDeployment.clusterRole.clusterRoleBinding</a></td>
+            <td id="otelDeployment--clusterRole--clusterRoleBinding"><a href="./values.yaml#L1313">otelDeployment.clusterRole.clusterRoleBinding</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -2127,7 +2136,7 @@ name: ""</pre>
             <td>ClusterRoleBinding configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--config"><a href="./values.yaml#L1322">otelDeployment.config</a></td>
+            <td id="otelDeployment--config"><a href="./values.yaml#L1324">otelDeployment.config</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please Checkout the values.yml for default values</pre>
@@ -2136,7 +2145,7 @@ name: ""</pre>
             <td>Base configuration for the OtelDeployment Collector.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--config--processors--batch"><a href="./values.yaml#L1329">otelDeployment.config.processors.batch</a></td>
+            <td id="otelDeployment--config--processors--batch"><a href="./values.yaml#L1331">otelDeployment.config.processors.batch</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">send_batch_size: 10000
@@ -2146,7 +2155,7 @@ timeout: 1s</pre>
             <td>Batch processor config.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--extraVolumes"><a href="./values.yaml#L1369">otelDeployment.extraVolumes</a></td>
+            <td id="otelDeployment--extraVolumes"><a href="./values.yaml#L1371">otelDeployment.extraVolumes</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -2155,7 +2164,7 @@ timeout: 1s</pre>
             <td>Additional volumes for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--extraVolumeMounts"><a href="./values.yaml#L1379">otelDeployment.extraVolumeMounts</a></td>
+            <td id="otelDeployment--extraVolumeMounts"><a href="./values.yaml#L1381">otelDeployment.extraVolumeMounts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>

--- a/charts/k8s-infra/README.md
+++ b/charts/k8s-infra/README.md
@@ -341,27 +341,8 @@ storageClass: null</pre>
             <td>TLS certificate authority (CA) certificate to be included in the secret.</td>
         </tr>
     </tbody>
-</table>
-<h3>Configuration Presets</h3>
-<table>
-    <thead>
-        <th>Key</th>
-        <th>Type</th>
-        <th>Default</th>
-        <th>Description</th>
-    </thead>
-    <tbody>
-        <tr>
-            <td id="presets"><a href="./values.yaml#L107">presets</a></td>
-            <td>object</td>
-            <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">Please check out the values.yml for default values</pre>
-</div>
-            </td>
-            <td>Presets to easily set up OtelCollector configurations. For more details, see the documentation: https://signoz.io/docs/metrics-management/k8s-infra-otel-config</td>
-        </tr>
-    </tbody>
-</table>
+</table><h3>Presets Configuration</h3>
+  <p>Presets to easily set up OtelCollector configurations. For more details, see the [documentation](https://signoz.io/docs/collection-agents/k8s/k8s-infra/configure-k8s-infra/).</p>
 <h3>Logging Exporter Presets</h3>
 <table>
     <thead>

--- a/charts/k8s-infra/README.md
+++ b/charts/k8s-infra/README.md
@@ -343,7 +343,7 @@ storageClass: null</pre>
     </tbody>
 </table><h3>Presets Configuration</h3>
   <p>Presets to easily set up OtelCollector configurations. For more details, see the <a href="https://signoz.io/docs/collection-agents/k8s/k8s-infra/configure-k8s-infra/">documentation</a>.</p>
-<h3>Logging Exporter Presets</h3>
+<h4>Logging Exporter Presets</h4>
 <table>
     <thead>
         <th>Key</th>
@@ -366,7 +366,7 @@ verbosity: basic</pre>
         </tr>
     </tbody>
 </table>
-<h3>OTLP Exporter Presets</h3>
+<h4>OTLP Exporter Presets</h4>
 <table>
     <thead>
         <th>Key</th>
@@ -395,7 +395,7 @@ verbosity: basic</pre>
         </tr>
     </tbody>
 </table>
-<h3>Self Telemetry Presets</h3>
+<h4>Self Telemetry Presets</h4>
 <table>
     <thead>
         <th>Key</th>
@@ -471,7 +471,7 @@ traces:
         </tr>
     </tbody>
 </table>
-<h3>Logs Collection Presets</h3>
+<h4>Logs Collection Presets</h4>
 <table>
     <thead>
         <th>Key</th>
@@ -577,7 +577,7 @@ signozLogs: true</pre>
         </tr>
     </tbody>
 </table>
-<h3>Host Metrics Presets</h3>
+<h4>Host Metrics Presets</h4>
 <table>
     <thead>
         <th>Key</th>
@@ -692,7 +692,7 @@ signozLogs: true</pre>
         </tr>
     </tbody>
 </table>
-<h3>Kubelet Metrics Presets</h3>
+<h4>Kubelet Metrics Presets</h4>
 <table>
     <thead>
         <th>Key</th>
@@ -815,7 +815,7 @@ k8s.pod.uptime:
         </tr>
     </tbody>
 </table>
-<h3>Kubernetes Attributes Processor Presets</h3>
+<h4>Kubernetes Attributes Processor Presets</h4>
 <table>
     <thead>
         <th>Key</th>
@@ -924,7 +924,7 @@ k8s.pod.uptime:
         </tr>
     </tbody>
 </table>
-<h3>Cluster Metrics Presets</h3>
+<h4>Cluster Metrics Presets</h4>
 <table>
     <thead>
         <th>Key</th>
@@ -1015,7 +1015,7 @@ k8s.pod.status_reason:
         </tr>
     </tbody>
 </table>
-<h3>Prometheus Metrics Presets</h3>
+<h4>Prometheus Metrics Presets</h4>
 <table>
     <thead>
         <th>Key</th>
@@ -1104,7 +1104,7 @@ scrapeInterval: 60s</pre>
         </tr>
     </tbody>
 </table>
-<h3>Resource Detection Processor Presets</h3>
+<h4>Resource Detection Processor Presets</h4>
 <table>
     <thead>
         <th>Key</th>
@@ -1163,7 +1163,7 @@ timeout: 2s</pre>
         </tr>
     </tbody>
 </table>
-<h3>Kubernetes Events Collection Presets</h3>
+<h4>Kubernetes Events Collection Presets</h4>
 <table>
     <thead>
         <th>Key</th>

--- a/charts/k8s-infra/README.md
+++ b/charts/k8s-infra/README.md
@@ -343,7 +343,7 @@ storageClass: null</pre>
     </tbody>
 </table><h3>Presets Configuration</h3>
   <p>Presets to easily set up OtelCollector configurations. For more details, see the <a href="https://signoz.io/docs/collection-agents/k8s/k8s-infra/configure-k8s-infra/">documentation</a>.</p>
-<h4>Logging Exporter Presets</h4>
+<h4>Debug Exporter Presets</h4>
 <table>
     <thead>
         <th>Key</th>
@@ -353,7 +353,7 @@ storageClass: null</pre>
     </thead>
     <tbody>
         <tr>
-            <td id="presets--loggingExporter"><a href="./values.yaml#L110">presets.loggingExporter</a></td>
+            <td id="presets--debugExporter"><a href="./values.yaml#L110">presets.debugExporter</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">enabled: false
@@ -362,7 +362,43 @@ samplingThereafter: 500
 verbosity: basic</pre>
 </div>
             </td>
-            <td>Configuration for the logging exporter, used for debugging telemetry data.</td>
+            <td>Configuration for the debug exporter, used for debugging telemetry data.</td>
+        </tr>
+        <tr>
+            <td id="presets--debugExporter--enabled"><a href="./values.yaml#L113">presets.debugExporter.enabled</a></td>
+            <td>bool</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
+</div>
+            </td>
+            <td>Enable the debug exporter.</td>
+        </tr>
+        <tr>
+            <td id="presets--debugExporter--verbosity"><a href="./values.yaml#L116">presets.debugExporter.verbosity</a></td>
+            <td>string</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="yaml">basic</pre>
+</div>
+            </td>
+            <td>Verbosity of the debug exporter: `basic`, `normal`, or `detailed`.</td>
+        </tr>
+        <tr>
+            <td id="presets--debugExporter--samplingInitial"><a href="./values.yaml#L119">presets.debugExporter.samplingInitial</a></td>
+            <td>int</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="yaml">2</pre>
+</div>
+            </td>
+            <td>Number of messages initially logged each second.</td>
+        </tr>
+        <tr>
+            <td id="presets--debugExporter--samplingThereafter"><a href="./values.yaml#L122">presets.debugExporter.samplingThereafter</a></td>
+            <td>int</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="yaml">500</pre>
+</div>
+            </td>
+            <td>Sampling rate after the initial messages are logged.</td>
         </tr>
     </tbody>
 </table>

--- a/charts/k8s-infra/README.md
+++ b/charts/k8s-infra/README.md
@@ -78,7 +78,7 @@ kubectl delete namespace platform
             <td id="global"><a href="./values.yaml#L3">global</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">cloud: other
+                <div style="max-width: 300px;"><pre lang="yaml">cloud: other
 clusterDomain: cluster.local
 clusterName: ""
 deploymentEnvironment: ""
@@ -93,7 +93,7 @@ storageClass: null</pre>
             <td id="global--imageRegistry"><a href="./values.yaml#L6">global.imageRegistry</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">null</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">null</pre>
 </div>
             </td>
             <td>Overrides the Docker registry globally for all images.</td>
@@ -102,7 +102,7 @@ storageClass: null</pre>
             <td id="global--imagePullSecrets"><a href="./values.yaml#L9">global.imagePullSecrets</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
 </div>
             </td>
             <td>Global Image Pull Secrets.</td>
@@ -111,7 +111,7 @@ storageClass: null</pre>
             <td id="global--storageClass"><a href="./values.yaml#L12">global.storageClass</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">null</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">null</pre>
 </div>
             </td>
             <td>Overrides the storage class for all PVCs with persistence enabled.</td>
@@ -120,7 +120,7 @@ storageClass: null</pre>
             <td id="global--clusterDomain"><a href="./values.yaml#L15">global.clusterDomain</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">cluster.local</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">cluster.local</pre>
 </div>
             </td>
             <td>Kubernetes cluster domain. Used only when components are installed in different namespaces.</td>
@@ -129,7 +129,7 @@ storageClass: null</pre>
             <td id="global--clusterName"><a href="./values.yaml#L18">global.clusterName</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">""</pre>
 </div>
             </td>
             <td>Kubernetes cluster name. Used to attach to telemetry data via the resource detection processor.</td>
@@ -138,7 +138,7 @@ storageClass: null</pre>
             <td id="global--deploymentEnvironment"><a href="./values.yaml#L21">global.deploymentEnvironment</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">""</pre>
 </div>
             </td>
             <td>Deployment environment to be attached to telemetry data.</td>
@@ -147,7 +147,7 @@ storageClass: null</pre>
             <td id="global--cloud"><a href="./values.yaml#L24">global.cloud</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">other</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">other</pre>
 </div>
             </td>
             <td>Kubernetes cluster cloud provider, along with distribution if any (e.g., `aws`, `azure`, `gcp`, `gcp/autogke`, `other`).</td>
@@ -167,7 +167,7 @@ storageClass: null</pre>
             <td id="nameOverride"><a href="./values.yaml#L28">nameOverride</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">""</pre>
 </div>
             </td>
             <td>K8s infra chart name override.</td>
@@ -176,7 +176,7 @@ storageClass: null</pre>
             <td id="fullnameOverride"><a href="./values.yaml#L32">fullnameOverride</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">""</pre>
 </div>
             </td>
             <td>K8s infra chart full name override.</td>
@@ -185,7 +185,7 @@ storageClass: null</pre>
             <td id="enabled"><a href="./values.yaml#L36">enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Whether to enable the K8s infra chart.</td>
@@ -194,7 +194,7 @@ storageClass: null</pre>
             <td id="clusterName"><a href="./values.yaml#L40">clusterName</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">""</pre>
 </div>
             </td>
             <td>Name of the K8s cluster. Used by OtelCollectors to attach in telemetry data.</td>
@@ -203,7 +203,7 @@ storageClass: null</pre>
             <td id="otelCollectorEndpoint"><a href="./values.yaml#L47">otelCollectorEndpoint</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">null</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">null</pre>
 </div>
             </td>
             <td>Endpoint/IP Address of the SigNoz or any other OpenTelemetry backend. Set it to `ingest.signoz.io:4317` for SigNoz Cloud. If set to null and the chart is installed as a dependency, it will attempt to autogenerate the endpoint of the SigNoz OtelCollector.</td>
@@ -212,7 +212,7 @@ storageClass: null</pre>
             <td id="otelInsecure"><a href="./values.yaml#L52">otelInsecure</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Whether the OTLP endpoint is insecure. Set this to false in case of a secure OTLP endpoint.</td>
@@ -221,7 +221,7 @@ storageClass: null</pre>
             <td id="insecureSkipVerify"><a href="./values.yaml#L56">insecureSkipVerify</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Whether to skip verifying the OTLP endpoint's certificate.</td>
@@ -230,7 +230,7 @@ storageClass: null</pre>
             <td id="namespace"><a href="./values.yaml#L100">namespace</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">null</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">null</pre>
 </div>
             </td>
             <td>The namespace to install k8s-infra components into.</td>
@@ -250,7 +250,7 @@ storageClass: null</pre>
             <td id="signozApiKey"><a href="./values.yaml#L60">signozApiKey</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">""</pre>
 </div>
             </td>
             <td>API key for SigNoz Cloud.</td>
@@ -259,7 +259,7 @@ storageClass: null</pre>
             <td id="apiKeyExistingSecretName"><a href="./values.yaml#L63">apiKeyExistingSecretName</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">""</pre>
 </div>
             </td>
             <td>Existing secret name to be used for the API key.</td>
@@ -268,7 +268,7 @@ storageClass: null</pre>
             <td id="apiKeyExistingSecretKey"><a href="./values.yaml#L66">apiKeyExistingSecretKey</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">""</pre>
 </div>
             </td>
             <td>Existing secret key to be used for the API key.</td>
@@ -288,7 +288,7 @@ storageClass: null</pre>
             <td id="otelTlsSecrets--enabled"><a href="./values.yaml#L72">otelTlsSecrets.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Whether to enable OpenTelemetry OTLP secrets for secure communication.</td>
@@ -297,7 +297,7 @@ storageClass: null</pre>
             <td id="otelTlsSecrets--path"><a href="./values.yaml#L76">otelTlsSecrets.path</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">/secrets</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">/secrets</pre>
 </div>
             </td>
             <td>Path for the secrets volume when mounted in the container.</td>
@@ -306,7 +306,7 @@ storageClass: null</pre>
             <td id="otelTlsSecrets--existingSecretName"><a href="./values.yaml#L81">otelTlsSecrets.existingSecretName</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">null</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">null</pre>
 </div>
             </td>
             <td>Name of an existing secret with TLS certificate, key, and CA to be used. Files in the secret must be named `cert.pem`, `key.pem`, and `ca.pem`.</td>
@@ -315,7 +315,7 @@ storageClass: null</pre>
             <td id="otelTlsSecrets--certificate"><a href="./values.yaml#L85">otelTlsSecrets.certificate</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">|
+                <div style="max-width: 300px;"><pre lang="yaml">|
     <INCLUDE_CERTIFICATE_HERE></pre>
 </div>
             </td>
@@ -325,7 +325,7 @@ storageClass: null</pre>
             <td id="otelTlsSecrets--key"><a href="./values.yaml#L90">otelTlsSecrets.key</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">|
+                <div style="max-width: 300px;"><pre lang="yaml">|
     <INCLUDE_PRIVATE_KEY_HERE></pre>
 </div>
             </td>
@@ -335,7 +335,7 @@ storageClass: null</pre>
             <td id="otelTlsSecrets--ca"><a href="./values.yaml#L95">otelTlsSecrets.ca</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">""</pre>
 </div>
             </td>
             <td>TLS certificate authority (CA) certificate to be included in the secret.</td>
@@ -356,7 +356,7 @@ storageClass: null</pre>
             <td id="presets--loggingExporter"><a href="./values.yaml#L110">presets.loggingExporter</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">enabled: false
+                <div style="max-width: 300px;"><pre lang="yaml">enabled: false
 samplingInitial: 2
 samplingThereafter: 500
 verbosity: basic</pre>
@@ -379,7 +379,7 @@ verbosity: basic</pre>
             <td id="presets--otlpExporter"><a href="./values.yaml#L125">presets.otlpExporter</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">enabled: true</pre>
 </div>
             </td>
             <td>OTLP Exporter for the OTLP exporter.</td>
@@ -388,7 +388,7 @@ verbosity: basic</pre>
             <td id="presets--otlphttpExporter"><a href="./values.yaml#L132">presets.otlphttpExporter</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">enabled: false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">enabled: false</pre>
 </div>
             </td>
             <td>OTLP HTTP Exporter to which data will be sent. Set this to true to enable the OTLP HTTP exporter, which uses the HTTP endpoint instead of the gRPC endpoint.</td>
@@ -408,7 +408,7 @@ verbosity: basic</pre>
             <td id="presets--selfTelemetry"><a href="./values.yaml#L138">presets.selfTelemetry</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">apiKeyExistingSecretKey: ""
+                <div style="max-width: 300px;"><pre lang="yaml">apiKeyExistingSecretKey: ""
 apiKeyExistingSecretName: ""
 endpoint: ""
 insecure: true
@@ -428,7 +428,7 @@ traces:
             <td id="presets--selfTelemetry--endpoint"><a href="./values.yaml#L141">presets.selfTelemetry.endpoint</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">""</pre>
 </div>
             </td>
             <td>OTLP HTTP endpoint to send own telemetry data to.</td>
@@ -437,7 +437,7 @@ traces:
             <td id="presets--selfTelemetry--traces--enabled"><a href="./values.yaml#L162">presets.selfTelemetry.traces.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Enable self-telemetry for traces.</td>
@@ -446,7 +446,7 @@ traces:
             <td id="presets--selfTelemetry--metrics--enabled"><a href="./values.yaml#L168">presets.selfTelemetry.metrics.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Enable self-telemetry for metrics.</td>
@@ -455,7 +455,7 @@ traces:
             <td id="presets--selfTelemetry--logs"><a href="./values.yaml#L171">presets.selfTelemetry.logs</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">enabled: false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">enabled: false</pre>
 </div>
             </td>
             <td>Configuration for self-telemetry logs.</td>
@@ -464,7 +464,7 @@ traces:
             <td id="presets--selfTelemetry--logs--enabled"><a href="./values.yaml#L174">presets.selfTelemetry.logs.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Enable self-telemetry for logs.</td>
@@ -484,7 +484,7 @@ traces:
             <td id="presets--logsCollection"><a href="./values.yaml#L178">presets.logsCollection</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">Please check out the values.yml for default values</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">Please check out the values.yml for default values</pre>
 </div>
             </td>
             <td>Configuration for collecting logs from pods.</td>
@@ -493,7 +493,7 @@ traces:
             <td id="presets--logsCollection--enabled"><a href="./values.yaml#L181">presets.logsCollection.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Enable log collection.</td>
@@ -502,7 +502,7 @@ traces:
             <td id="presets--logsCollection--startAt"><a href="./values.yaml#L184">presets.logsCollection.startAt</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">end</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">end</pre>
 </div>
             </td>
             <td>Where to start reading logs from: `end` or `beginning`.</td>
@@ -511,7 +511,7 @@ traces:
             <td id="presets--logsCollection--includeFilePath"><a href="./values.yaml#L187">presets.logsCollection.includeFilePath</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Include the log file path as an attribute.</td>
@@ -520,7 +520,7 @@ traces:
             <td id="presets--logsCollection--includeFileName"><a href="./values.yaml#L190">presets.logsCollection.includeFileName</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Include the log file name as an attribute.</td>
@@ -529,7 +529,7 @@ traces:
             <td id="presets--logsCollection--include"><a href="./values.yaml#L193">presets.logsCollection.include</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">- /var/log/pods/*/*/*.log</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">- /var/log/pods/*/*/*.log</pre>
 </div>
             </td>
             <td>Include path patterns for log files to be collected. By default, all container logs are collected.</td>
@@ -538,7 +538,7 @@ traces:
             <td id="presets--logsCollection--blacklist"><a href="./values.yaml#L197">presets.logsCollection.blacklist</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">additionalExclude: []
+                <div style="max-width: 300px;"><pre lang="yaml">additionalExclude: []
 containers: []
 enabled: true
 namespaces:
@@ -555,7 +555,7 @@ signozLogs: true</pre>
             <td id="presets--logsCollection--whitelist"><a href="./values.yaml#L221">presets.logsCollection.whitelist</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">additionalInclude: []
+                <div style="max-width: 300px;"><pre lang="yaml">additionalInclude: []
 containers: []
 enabled: false
 namespaces: []
@@ -569,7 +569,7 @@ signozLogs: true</pre>
             <td id="presets--logsCollection--operators"><a href="./values.yaml#L242">presets.logsCollection.operators</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">- id: container-parser
+                <div style="max-width: 300px;"><pre lang="yaml">- id: container-parser
   type: container</pre>
 </div>
             </td>
@@ -590,7 +590,7 @@ signozLogs: true</pre>
             <td id="presets--hostMetrics"><a href="./values.yaml#L248">presets.hostMetrics</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">Please check out the values.yml for default values</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">Please check out the values.yml for default values</pre>
 </div>
             </td>
             <td>Configuration for collecting host-level metrics from nodes.</td>
@@ -599,7 +599,7 @@ signozLogs: true</pre>
             <td id="presets--hostMetrics--enabled"><a href="./values.yaml#L251">presets.hostMetrics.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Enable host metrics collection.</td>
@@ -608,7 +608,7 @@ signozLogs: true</pre>
             <td id="presets--hostMetrics--collectionInterval"><a href="./values.yaml#L254">presets.hostMetrics.collectionInterval</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">30s</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">30s</pre>
 </div>
             </td>
             <td>Frequency at which to scrape host metrics.</td>
@@ -617,7 +617,7 @@ signozLogs: true</pre>
             <td id="presets--hostMetrics--scrapers"><a href="./values.yaml#L258">presets.hostMetrics.scrapers</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">Please check out the values.yml for default values</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">Please check out the values.yml for default values</pre>
 </div>
             </td>
             <td>Fine-grained control over which host metric scrapers are enabled.</td>
@@ -626,7 +626,7 @@ signozLogs: true</pre>
             <td id="presets--hostMetrics--scrapers--cpu"><a href="./values.yaml#L261">presets.hostMetrics.scrapers.cpu</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Enable CPU metrics collection.</td>
@@ -635,7 +635,7 @@ signozLogs: true</pre>
             <td id="presets--hostMetrics--scrapers--load"><a href="./values.yaml#L264">presets.hostMetrics.scrapers.load</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Enable load metrics collection.</td>
@@ -644,7 +644,7 @@ signozLogs: true</pre>
             <td id="presets--hostMetrics--scrapers--memory"><a href="./values.yaml#L267">presets.hostMetrics.scrapers.memory</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Enable memory metrics collection.</td>
@@ -653,7 +653,7 @@ signozLogs: true</pre>
             <td id="presets--hostMetrics--scrapers--disk"><a href="./values.yaml#L270">presets.hostMetrics.scrapers.disk</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">exclude:
+                <div style="max-width: 300px;"><pre lang="yaml">exclude:
     devices:
         - ^ram\d+$
         - ^zram\d+$
@@ -673,7 +673,7 @@ signozLogs: true</pre>
             <td id="presets--hostMetrics--scrapers--network"><a href="./values.yaml#L326">presets.hostMetrics.scrapers.network</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">exclude:
+                <div style="max-width: 300px;"><pre lang="yaml">exclude:
     interfaces:
         - ^veth.*$
         - ^docker.*$
@@ -705,7 +705,7 @@ signozLogs: true</pre>
             <td id="presets--kubeletMetrics"><a href="./values.yaml#L343">presets.kubeletMetrics</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">Please check out the values.yml for default values</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">Please check out the values.yml for default values</pre>
 </div>
             </td>
             <td>Configuration for collecting metrics from Kubelet.</td>
@@ -714,7 +714,7 @@ signozLogs: true</pre>
             <td id="presets--kubeletMetrics--enabled"><a href="./values.yaml#L346">presets.kubeletMetrics.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Enable Kubelet metrics collection.</td>
@@ -723,7 +723,7 @@ signozLogs: true</pre>
             <td id="presets--kubeletMetrics--collectionInterval"><a href="./values.yaml#L349">presets.kubeletMetrics.collectionInterval</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">30s</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">30s</pre>
 </div>
             </td>
             <td>Frequency at which to scrape Kubelet metrics.</td>
@@ -732,7 +732,7 @@ signozLogs: true</pre>
             <td id="presets--kubeletMetrics--authType"><a href="./values.yaml#L352">presets.kubeletMetrics.authType</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">serviceAccount</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">serviceAccount</pre>
 </div>
             </td>
             <td>Authentication type to use with Kubelet: `serviceAccount` or `tls`.</td>
@@ -741,7 +741,7 @@ signozLogs: true</pre>
             <td id="presets--kubeletMetrics--endpoint"><a href="./values.yaml#L355">presets.kubeletMetrics.endpoint</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">${env:K8S_HOST_IP}:10250</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">${env:K8S_HOST_IP}:10250</pre>
 </div>
             </td>
             <td>Kubelet endpoint.</td>
@@ -750,7 +750,7 @@ signozLogs: true</pre>
             <td id="presets--kubeletMetrics--insecureSkipVerify"><a href="./values.yaml#L358">presets.kubeletMetrics.insecureSkipVerify</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Skip verifying Kubelet's certificate.</td>
@@ -759,7 +759,7 @@ signozLogs: true</pre>
             <td id="presets--kubeletMetrics--extraMetadataLabels"><a href="./values.yaml#L361">presets.kubeletMetrics.extraMetadataLabels</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">- container.id
+                <div style="max-width: 300px;"><pre lang="yaml">- container.id
 - k8s.volume.type</pre>
 </div>
             </td>
@@ -769,7 +769,7 @@ signozLogs: true</pre>
             <td id="presets--kubeletMetrics--metricGroups"><a href="./values.yaml#L366">presets.kubeletMetrics.metricGroups</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">- container
+                <div style="max-width: 300px;"><pre lang="yaml">- container
 - pod
 - node
 - volume</pre>
@@ -781,7 +781,7 @@ signozLogs: true</pre>
             <td id="presets--kubeletMetrics--metrics"><a href="./values.yaml#L373">presets.kubeletMetrics.metrics</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">container.cpu.usage:
+                <div style="max-width: 300px;"><pre lang="yaml">container.cpu.usage:
     enabled: true
 container.uptime:
     enabled: true
@@ -828,7 +828,7 @@ k8s.pod.uptime:
             <td id="presets--kubernetesAttributes"><a href="./values.yaml#L405">presets.kubernetesAttributes</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">Please check out the values.yml for default values</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">Please check out the values.yml for default values</pre>
 </div>
             </td>
             <td>Processor for adding Kubernetes attributes to telemetry data.</td>
@@ -837,7 +837,7 @@ k8s.pod.uptime:
             <td id="presets--kubernetesAttributes--enabled"><a href="./values.yaml#L408">presets.kubernetesAttributes.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Enable the Kubernetes attributes processor.</td>
@@ -846,7 +846,7 @@ k8s.pod.uptime:
             <td id="presets--kubernetesAttributes--passthrough"><a href="./values.yaml#L411">presets.kubernetesAttributes.passthrough</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>If true, agents will not make k8s API calls, do discovery, or extract metadata.</td>
@@ -855,7 +855,7 @@ k8s.pod.uptime:
             <td id="presets--kubernetesAttributes--filter"><a href="./values.yaml#L414">presets.kubernetesAttributes.filter</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">node_from_env_var: K8S_NODE_NAME</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">node_from_env_var: K8S_NODE_NAME</pre>
 </div>
             </td>
             <td>Limit agents to query pods based on specific selectors to reduce resource usage.</td>
@@ -864,7 +864,7 @@ k8s.pod.uptime:
             <td id="presets--kubernetesAttributes--filter--node_from_env_var"><a href="./values.yaml#L417">presets.kubernetesAttributes.filter.node_from_env_var</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">K8S_NODE_NAME</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">K8S_NODE_NAME</pre>
 </div>
             </td>
             <td>Restrict each agent to query pods on the same node.</td>
@@ -873,7 +873,7 @@ k8s.pod.uptime:
             <td id="presets--kubernetesAttributes--podAssociation"><a href="./values.yaml#L420">presets.kubernetesAttributes.podAssociation</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">- sources:
+                <div style="max-width: 300px;"><pre lang="yaml">- sources:
     - from: resource_attribute
       name: k8s.pod.ip
 - sources:
@@ -889,7 +889,7 @@ k8s.pod.uptime:
             <td id="presets--kubernetesAttributes--extractMetadatas"><a href="./values.yaml#L431">presets.kubernetesAttributes.extractMetadatas</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">- k8s.namespace.name
+                <div style="max-width: 300px;"><pre lang="yaml">- k8s.namespace.name
 - k8s.deployment.name
 - k8s.statefulset.name
 - k8s.daemonset.name
@@ -908,7 +908,7 @@ k8s.pod.uptime:
             <td id="presets--kubernetesAttributes--extractLabels"><a href="./values.yaml#L445">presets.kubernetesAttributes.extractLabels</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
 </div>
             </td>
             <td>Pod labels to extract as attributes.</td>
@@ -917,7 +917,7 @@ k8s.pod.uptime:
             <td id="presets--kubernetesAttributes--extractAnnotations"><a href="./values.yaml#L448">presets.kubernetesAttributes.extractAnnotations</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
 </div>
             </td>
             <td>Pod annotations to extract as attributes.</td>
@@ -937,7 +937,7 @@ k8s.pod.uptime:
             <td id="presets--clusterMetrics"><a href="./values.yaml#L452">presets.clusterMetrics</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">Please check out the values.yml for default values</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">Please check out the values.yml for default values</pre>
 </div>
             </td>
             <td>Configuration for collecting cluster-level metrics.</td>
@@ -946,7 +946,7 @@ k8s.pod.uptime:
             <td id="presets--clusterMetrics--enabled"><a href="./values.yaml#L455">presets.clusterMetrics.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Enable cluster metrics collection.</td>
@@ -955,7 +955,7 @@ k8s.pod.uptime:
             <td id="presets--clusterMetrics--collectionInterval"><a href="./values.yaml#L458">presets.clusterMetrics.collectionInterval</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">30s</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">30s</pre>
 </div>
             </td>
             <td>Frequency at which to scrape cluster metrics.</td>
@@ -964,7 +964,7 @@ k8s.pod.uptime:
             <td id="presets--clusterMetrics--resourceAttributes"><a href="./values.yaml#L461">presets.clusterMetrics.resourceAttributes</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">container.runtime:
+                <div style="max-width: 300px;"><pre lang="yaml">container.runtime:
     enabled: true
 container.runtime.version:
     enabled: true
@@ -982,7 +982,7 @@ k8s.pod.qos_class:
             <td id="presets--clusterMetrics--nodeConditionsToReport"><a href="./values.yaml#L474">presets.clusterMetrics.nodeConditionsToReport</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">- Ready
+                <div style="max-width: 300px;"><pre lang="yaml">- Ready
 - MemoryPressure
 - DiskPressure
 - PIDPressure
@@ -995,7 +995,7 @@ k8s.pod.qos_class:
             <td id="presets--clusterMetrics--allocatableTypesToReport"><a href="./values.yaml#L482">presets.clusterMetrics.allocatableTypesToReport</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">- cpu
+                <div style="max-width: 300px;"><pre lang="yaml">- cpu
 - memory</pre>
 </div>
             </td>
@@ -1005,7 +1005,7 @@ k8s.pod.qos_class:
             <td id="presets--clusterMetrics--metrics"><a href="./values.yaml#L489">presets.clusterMetrics.metrics</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">k8s.node.condition:
+                <div style="max-width: 300px;"><pre lang="yaml">k8s.node.condition:
     enabled: true
 k8s.pod.status_reason:
     enabled: true</pre>
@@ -1028,7 +1028,7 @@ k8s.pod.status_reason:
             <td id="presets--prometheus"><a href="./values.yaml#L496">presets.prometheus</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">annotationsPrefix: signoz.io
+                <div style="max-width: 300px;"><pre lang="yaml">annotationsPrefix: signoz.io
 enabled: false
 includeContainerName: false
 includePodLabel: false
@@ -1043,7 +1043,7 @@ scrapeInterval: 60s</pre>
             <td id="presets--prometheus--enabled"><a href="./values.yaml#L499">presets.prometheus.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Enable Prometheus metrics scraping.</td>
@@ -1052,7 +1052,7 @@ scrapeInterval: 60s</pre>
             <td id="presets--prometheus--annotationsPrefix"><a href="./values.yaml#L502">presets.prometheus.annotationsPrefix</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">signoz.io</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">signoz.io</pre>
 </div>
             </td>
             <td>Prefix for the pod annotations used for metrics scraping (e.g., `signoz.io`).</td>
@@ -1061,7 +1061,7 @@ scrapeInterval: 60s</pre>
             <td id="presets--prometheus--scrapeInterval"><a href="./values.yaml#L505">presets.prometheus.scrapeInterval</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">60s</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">60s</pre>
 </div>
             </td>
             <td>How often to scrape metrics.</td>
@@ -1070,7 +1070,7 @@ scrapeInterval: 60s</pre>
             <td id="presets--prometheus--namespaceScoped"><a href="./values.yaml#L508">presets.prometheus.namespaceScoped</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Only scrape metrics from pods in the same namespace.</td>
@@ -1079,7 +1079,7 @@ scrapeInterval: 60s</pre>
             <td id="presets--prometheus--namespaces"><a href="./values.yaml#L511">presets.prometheus.namespaces</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
 </div>
             </td>
             <td>If set, only scrape metrics from pods in the specified namespaces.</td>
@@ -1088,7 +1088,7 @@ scrapeInterval: 60s</pre>
             <td id="presets--prometheus--includePodLabel"><a href="./values.yaml#L514">presets.prometheus.includePodLabel</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Include all pod labels in the metrics (can cause high cardinality).</td>
@@ -1097,7 +1097,7 @@ scrapeInterval: 60s</pre>
             <td id="presets--prometheus--includeContainerName"><a href="./values.yaml#L517">presets.prometheus.includeContainerName</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Include container name in metrics (not recommended for multi-container pods).</td>
@@ -1117,7 +1117,7 @@ scrapeInterval: 60s</pre>
             <td id="presets--resourceDetection"><a href="./values.yaml#L520">presets.resourceDetection</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
+                <div style="max-width: 300px;"><pre lang="yaml">enabled: true
 envResourceAttributes: ""
 override: false
 timeout: 2s</pre>
@@ -1129,7 +1129,7 @@ timeout: 2s</pre>
             <td id="presets--resourceDetection--enabled"><a href="./values.yaml#L523">presets.resourceDetection.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Enable the resource detection processor.</td>
@@ -1138,7 +1138,7 @@ timeout: 2s</pre>
             <td id="presets--resourceDetection--timeout"><a href="./values.yaml#L526">presets.resourceDetection.timeout</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">2s</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">2s</pre>
 </div>
             </td>
             <td>Timeout for resource detection.</td>
@@ -1147,7 +1147,7 @@ timeout: 2s</pre>
             <td id="presets--resourceDetection--override"><a href="./values.yaml#L529">presets.resourceDetection.override</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Whether to override existing resource attributes.</td>
@@ -1156,7 +1156,7 @@ timeout: 2s</pre>
             <td id="presets--resourceDetection--envResourceAttributes"><a href="./values.yaml#L532">presets.resourceDetection.envResourceAttributes</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">""</pre>
 </div>
             </td>
             <td>Additional resource attributes from environment variables.</td>
@@ -1176,7 +1176,7 @@ timeout: 2s</pre>
             <td id="presets--k8sEvents"><a href="./values.yaml#L535">presets.k8sEvents</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">authType: serviceAccount
+                <div style="max-width: 300px;"><pre lang="yaml">authType: serviceAccount
 enabled: true
 namespaces: []</pre>
 </div>
@@ -1187,7 +1187,7 @@ namespaces: []</pre>
             <td id="presets--k8sEvents--enabled"><a href="./values.yaml#L538">presets.k8sEvents.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Enable Kubernetes events collection.</td>
@@ -1196,7 +1196,7 @@ namespaces: []</pre>
             <td id="presets--k8sEvents--authType"><a href="./values.yaml#L541">presets.k8sEvents.authType</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">serviceAccount</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">serviceAccount</pre>
 </div>
             </td>
             <td>Authentication type: `serviceAccount` or `kubeconfig`.</td>
@@ -1205,7 +1205,7 @@ namespaces: []</pre>
             <td id="presets--k8sEvents--namespaces"><a href="./values.yaml#L544">presets.k8sEvents.namespaces</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
 </div>
             </td>
             <td>List of namespaces to watch for events. Empty list means all namespaces.</td>
@@ -1225,7 +1225,7 @@ namespaces: []</pre>
             <td id="otelAgent--enabled"><a href="./values.yaml#L551">otelAgent.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Enable the OtelAgent DaemonSet.</td>
@@ -1234,7 +1234,7 @@ namespaces: []</pre>
             <td id="otelAgent--name"><a href="./values.yaml#L554">otelAgent.name</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">otel-agent</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">otel-agent</pre>
 </div>
             </td>
             <td>Name of the OtelAgent DaemonSet.</td>
@@ -1243,7 +1243,7 @@ namespaces: []</pre>
             <td id="otelAgent--image"><a href="./values.yaml#L557">otelAgent.image</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">pullPolicy: IfNotPresent
+                <div style="max-width: 300px;"><pre lang="yaml">pullPolicy: IfNotPresent
 registry: docker.io
 repository: otel/opentelemetry-collector-contrib
 tag: 0.109.0</pre>
@@ -1255,7 +1255,7 @@ tag: 0.109.0</pre>
             <td id="otelAgent--image--registry"><a href="./values.yaml#L560">otelAgent.image.registry</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">docker.io</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">docker.io</pre>
 </div>
             </td>
             <td>Docker registry for the OtelAgent image.</td>
@@ -1264,7 +1264,7 @@ tag: 0.109.0</pre>
             <td id="otelAgent--image--repository"><a href="./values.yaml#L563">otelAgent.image.repository</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">otel/opentelemetry-collector-contrib</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">otel/opentelemetry-collector-contrib</pre>
 </div>
             </td>
             <td>Repository for the OtelAgent image.</td>
@@ -1273,7 +1273,7 @@ tag: 0.109.0</pre>
             <td id="otelAgent--image--tag"><a href="./values.yaml#L566">otelAgent.image.tag</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">0.109.0</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">0.109.0</pre>
 </div>
             </td>
             <td>Tag for the OtelAgent image.</td>
@@ -1282,7 +1282,7 @@ tag: 0.109.0</pre>
             <td id="otelAgent--image--pullPolicy"><a href="./values.yaml#L569">otelAgent.image.pullPolicy</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">IfNotPresent</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">IfNotPresent</pre>
 </div>
             </td>
             <td>Image pull policy for the OtelAgent.</td>
@@ -1291,7 +1291,7 @@ tag: 0.109.0</pre>
             <td id="otelAgent--imagePullSecrets"><a href="./values.yaml#L573">otelAgent.imagePullSecrets</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
 </div>
             </td>
             <td>Image Pull Secrets for the OtelAgent. Merged with `global.imagePullSecrets`.</td>
@@ -1300,7 +1300,7 @@ tag: 0.109.0</pre>
             <td id="otelAgent--command"><a href="./values.yaml#L578">otelAgent.command</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">extraArgs: []
+                <div style="max-width: 300px;"><pre lang="yaml">extraArgs: []
 name: /otelcol-contrib</pre>
 </div>
             </td>
@@ -1310,7 +1310,7 @@ name: /otelcol-contrib</pre>
             <td id="otelAgent--command--name"><a href="./values.yaml#L581">otelAgent.command.name</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">/otelcol-contrib</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">/otelcol-contrib</pre>
 </div>
             </td>
             <td>OtelAgent command name.</td>
@@ -1319,7 +1319,7 @@ name: /otelcol-contrib</pre>
             <td id="otelAgent--command--extraArgs"><a href="./values.yaml#L584">otelAgent.command.extraArgs</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
 </div>
             </td>
             <td>Extra arguments for the OtelAgent command.</td>
@@ -1328,7 +1328,7 @@ name: /otelcol-contrib</pre>
             <td id="otelAgent--configMap"><a href="./values.yaml#L588">otelAgent.configMap</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">create: true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">create: true</pre>
 </div>
             </td>
             <td>ConfigMap configuration for the OtelAgent.</td>
@@ -1337,7 +1337,7 @@ name: /otelcol-contrib</pre>
             <td id="otelAgent--configMap--create"><a href="./values.yaml#L591">otelAgent.configMap.create</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Specifies whether a ConfigMap should be created.</td>
@@ -1346,7 +1346,7 @@ name: /otelcol-contrib</pre>
             <td id="otelAgent--service"><a href="./values.yaml#L595">otelAgent.service</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
+                <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
 internalTrafficPolicy: Local
 type: ClusterIP</pre>
 </div>
@@ -1357,7 +1357,7 @@ type: ClusterIP</pre>
             <td id="otelAgent--service--annotations"><a href="./values.yaml#L598">otelAgent.service.annotations</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Annotations for the OtelAgent service.</td>
@@ -1366,7 +1366,7 @@ type: ClusterIP</pre>
             <td id="otelAgent--service--type"><a href="./values.yaml#L601">otelAgent.service.type</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">ClusterIP</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">ClusterIP</pre>
 </div>
             </td>
             <td>Service type: `ClusterIP`, `NodePort`, or `LoadBalancer`.</td>
@@ -1375,7 +1375,7 @@ type: ClusterIP</pre>
             <td id="otelAgent--service--internalTrafficPolicy"><a href="./values.yaml#L605">otelAgent.service.internalTrafficPolicy</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">Local</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">Local</pre>
 </div>
             </td>
             <td>Internal traffic policy: `Local` or `Cluster`. ref: https://kubernetes.io/docs/reference/networking/virtual-ips/#internal-traffic-policy</td>
@@ -1384,7 +1384,7 @@ type: ClusterIP</pre>
             <td id="otelAgent--serviceAccount"><a href="./values.yaml#L609">otelAgent.serviceAccount</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
+                <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
 create: true
 name: null</pre>
 </div>
@@ -1395,7 +1395,7 @@ name: null</pre>
             <td id="otelAgent--serviceAccount--create"><a href="./values.yaml#L612">otelAgent.serviceAccount.create</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Specifies whether a ServiceAccount should be created.</td>
@@ -1404,7 +1404,7 @@ name: null</pre>
             <td id="otelAgent--serviceAccount--annotations"><a href="./values.yaml#L615">otelAgent.serviceAccount.annotations</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Annotations for the ServiceAccount.</td>
@@ -1413,7 +1413,7 @@ name: null</pre>
             <td id="otelAgent--serviceAccount--name"><a href="./values.yaml#L618">otelAgent.serviceAccount.name</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">null</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">null</pre>
 </div>
             </td>
             <td>The name of the ServiceAccount to use. A name is generated if not set.</td>
@@ -1422,7 +1422,7 @@ name: null</pre>
             <td id="otelAgent--annotations"><a href="./values.yaml#L622">otelAgent.annotations</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Annotations for the OtelAgent DaemonSet.</td>
@@ -1431,7 +1431,7 @@ name: null</pre>
             <td id="otelAgent--podAnnotations"><a href="./values.yaml#L625">otelAgent.podAnnotations</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Annotations for the OtelAgent pods.</td>
@@ -1440,7 +1440,7 @@ name: null</pre>
             <td id="otelAgent--additionalEnvs"><a href="./values.yaml#L647">otelAgent.additionalEnvs</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Additional environment variables for the OtelAgent container. You can specify variables in two ways: 1. Flexible structure for advanced configurations (recommended):    Example:      additionalEnvs:        MY_KEY:          value: my-value        SECRET_KEY:          valueFrom:            secretKeyRef:              name: my-secret              key: my-key 2. Simple key-value pairs (backward-compatible):    Example:      additionalEnvs:        MY_KEY: my-value</td>
@@ -1449,7 +1449,7 @@ name: null</pre>
             <td id="otelAgent--minReadySeconds"><a href="./values.yaml#L651">otelAgent.minReadySeconds</a></td>
             <td>int</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">5</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">5</pre>
 </div>
             </td>
             <td>Minimum number of seconds for which a newly created Pod should be ready.</td>
@@ -1458,7 +1458,7 @@ name: null</pre>
             <td id="otelAgent--clusterRole"><a href="./values.yaml#L656">otelAgent.clusterRole</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">Please checkout the values.yml for default values</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">Please checkout the values.yml for default values</pre>
 </div>
             </td>
             <td>ClusterRole configuration for the OtelAgent.</td>
@@ -1467,7 +1467,7 @@ name: null</pre>
             <td id="otelAgent--clusterRole--create"><a href="./values.yaml#L659">otelAgent.clusterRole.create</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Specifies whether a ClusterRole should be created.</td>
@@ -1476,7 +1476,7 @@ name: null</pre>
             <td id="otelAgent--clusterRole--annotations"><a href="./values.yaml#L662">otelAgent.clusterRole.annotations</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Annotations for the ClusterRole.</td>
@@ -1485,7 +1485,7 @@ name: null</pre>
             <td id="otelAgent--clusterRole--name"><a href="./values.yaml#L665">otelAgent.clusterRole.name</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">""</pre>
 </div>
             </td>
             <td>The name of the ClusterRole to use. A name is generated if not set.</td>
@@ -1494,7 +1494,7 @@ name: null</pre>
             <td id="otelAgent--clusterRole--rules"><a href="./values.yaml#L670">otelAgent.clusterRole.rules</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">Please checkout the values.yml for default values</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">Please checkout the values.yml for default values</pre>
 </div>
             </td>
             <td>RBAC rules for the OtelAgent. ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/</td>
@@ -1503,7 +1503,7 @@ name: null</pre>
             <td id="otelAgent--clusterRole--clusterRoleBinding"><a href="./values.yaml#L701">otelAgent.clusterRole.clusterRoleBinding</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
+                <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
 name: ""</pre>
 </div>
             </td>
@@ -1513,7 +1513,7 @@ name: ""</pre>
             <td id="otelAgent--ports"><a href="./values.yaml#L712">otelAgent.ports</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">Please checkout the values.yml for default values</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">Please checkout the values.yml for default values</pre>
 </div>
             </td>
             <td>Port configurations for the OtelAgent.</td>
@@ -1522,7 +1522,7 @@ name: ""</pre>
             <td id="otelAgent--ports--otlp--enabled"><a href="./values.yaml#L717">otelAgent.ports.otlp.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Enable service port for OTLP gRPC.</td>
@@ -1531,7 +1531,7 @@ name: ""</pre>
             <td id="otelAgent--ports--otlp-http--enabled"><a href="./values.yaml#L732">otelAgent.ports.otlp-http.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Enable service port for OTLP HTTP.</td>
@@ -1540,7 +1540,7 @@ name: ""</pre>
             <td id="otelAgent--ports--zipkin--enabled"><a href="./values.yaml#L747">otelAgent.ports.zipkin.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Enable service port for Zipkin.</td>
@@ -1549,7 +1549,7 @@ name: ""</pre>
             <td id="otelAgent--ports--metrics--enabled"><a href="./values.yaml#L762">otelAgent.ports.metrics.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Enable service port for internal metrics.</td>
@@ -1558,7 +1558,7 @@ name: ""</pre>
             <td id="otelAgent--ports--zpages--enabled"><a href="./values.yaml#L777">otelAgent.ports.zpages.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Enable service port for ZPages.</td>
@@ -1567,7 +1567,7 @@ name: ""</pre>
             <td id="otelAgent--ports--health-check--enabled"><a href="./values.yaml#L792">otelAgent.ports.health-check.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Enable service port for health checks.</td>
@@ -1576,7 +1576,7 @@ name: ""</pre>
             <td id="otelAgent--ports--pprof--enabled"><a href="./values.yaml#L807">otelAgent.ports.pprof.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Enable service port for pprof.</td>
@@ -1585,7 +1585,7 @@ name: ""</pre>
             <td id="otelAgent--hostNetwork"><a href="./values.yaml#L821">otelAgent.hostNetwork</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Host networking requested for this pod. Use the host's network namespace. Please make sure while enabling hostNetwork that the host ports are available as it can lead to port conflicts.</td>
@@ -1594,7 +1594,7 @@ name: ""</pre>
             <td id="otelAgent--livenessProbe"><a href="./values.yaml#L825">otelAgent.livenessProbe</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
+                <div style="max-width: 300px;"><pre lang="yaml">enabled: true
 failureThreshold: 6
 initialDelaySeconds: 10
 path: /
@@ -1610,7 +1610,7 @@ timeoutSeconds: 5</pre>
             <td id="otelAgent--readinessProbe"><a href="./values.yaml#L846">otelAgent.readinessProbe</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
+                <div style="max-width: 300px;"><pre lang="yaml">enabled: true
 failureThreshold: 6
 initialDelaySeconds: 10
 path: /
@@ -1626,7 +1626,7 @@ timeoutSeconds: 5</pre>
             <td id="otelAgent--customLivenessProbe"><a href="./values.yaml#L866">otelAgent.customLivenessProbe</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Custom liveness probe configuration.</td>
@@ -1635,7 +1635,7 @@ timeoutSeconds: 5</pre>
             <td id="otelAgent--customReadinessProbe"><a href="./values.yaml#L869">otelAgent.customReadinessProbe</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Custom readiness probe configuration.</td>
@@ -1644,7 +1644,7 @@ timeoutSeconds: 5</pre>
             <td id="otelAgent--ingress"><a href="./values.yaml#L873">otelAgent.ingress</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
+                <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
 className: ""
 enabled: false
 hosts:
@@ -1662,7 +1662,7 @@ tls: []</pre>
             <td id="otelAgent--ingress--enabled"><a href="./values.yaml#L876">otelAgent.ingress.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Enable Ingress for the OtelAgent.</td>
@@ -1671,7 +1671,7 @@ tls: []</pre>
             <td id="otelAgent--ingress--className"><a href="./values.yaml#L879">otelAgent.ingress.className</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">""</pre>
 </div>
             </td>
             <td>Ingress Class Name to be used.</td>
@@ -1680,7 +1680,7 @@ tls: []</pre>
             <td id="otelAgent--ingress--annotations"><a href="./values.yaml#L882">otelAgent.ingress.annotations</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Annotations for the OtelAgent Ingress.</td>
@@ -1689,7 +1689,7 @@ tls: []</pre>
             <td id="otelAgent--ingress--hosts"><a href="./values.yaml#L890">otelAgent.ingress.hosts</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">- host: otel-agent.domain.com
+                <div style="max-width: 300px;"><pre lang="yaml">- host: otel-agent.domain.com
   paths:
     - path: /
       pathType: ImplementationSpecific
@@ -1702,7 +1702,7 @@ tls: []</pre>
             <td id="otelAgent--ingress--tls"><a href="./values.yaml#L898">otelAgent.ingress.tls</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
 </div>
             </td>
             <td>OtelAgent Ingress TLS configuration.</td>
@@ -1711,7 +1711,7 @@ tls: []</pre>
             <td id="otelAgent--resources"><a href="./values.yaml#L906">otelAgent.resources</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">requests:
+                <div style="max-width: 300px;"><pre lang="yaml">requests:
     cpu: 100m
     memory: 100Mi</pre>
 </div>
@@ -1722,7 +1722,7 @@ tls: []</pre>
             <td id="otelAgent--priorityClassName"><a href="./values.yaml#L917">otelAgent.priorityClassName</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">""</pre>
 </div>
             </td>
             <td>OtelAgent Priority Class name.</td>
@@ -1731,7 +1731,7 @@ tls: []</pre>
             <td id="otelAgent--nodeSelector"><a href="./values.yaml#L921">otelAgent.nodeSelector</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Node selector for OtelAgent pod assignment.</td>
@@ -1740,7 +1740,7 @@ tls: []</pre>
             <td id="otelAgent--tolerations"><a href="./values.yaml#L925">otelAgent.tolerations</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">- operator: Exists</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">- operator: Exists</pre>
 </div>
             </td>
             <td>Toleration labels for OtelAgent pod assignment.</td>
@@ -1749,7 +1749,7 @@ tls: []</pre>
             <td id="otelAgent--affinity"><a href="./values.yaml#L930">otelAgent.affinity</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Affinity settings for the OtelAgent pod.</td>
@@ -1758,7 +1758,7 @@ tls: []</pre>
             <td id="otelAgent--podSecurityContext"><a href="./values.yaml#L934">otelAgent.podSecurityContext</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Pod-level security configuration.</td>
@@ -1767,7 +1767,7 @@ tls: []</pre>
             <td id="otelAgent--securityContext"><a href="./values.yaml#L939">otelAgent.securityContext</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Container-level security configuration.</td>
@@ -1776,7 +1776,7 @@ tls: []</pre>
             <td id="otelAgent--config"><a href="./values.yaml#L950">otelAgent.config</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">Please Checkout the values.yml for default values</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">Please Checkout the values.yml for default values</pre>
 </div>
             </td>
             <td>Base configuration for the OtelAgent Collector.</td>
@@ -1785,7 +1785,7 @@ tls: []</pre>
             <td id="otelAgent--config--processors--batch"><a href="./values.yaml#L965">otelAgent.config.processors.batch</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">send_batch_size: 10000
+                <div style="max-width: 300px;"><pre lang="yaml">send_batch_size: 10000
 timeout: 200ms</pre>
 </div>
             </td>
@@ -1795,7 +1795,7 @@ timeout: 200ms</pre>
             <td id="otelAgent--extraVolumes"><a href="./values.yaml#L1007">otelAgent.extraVolumes</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
 </div>
             </td>
             <td>Additional volumes for the OtelAgent.</td>
@@ -1804,7 +1804,7 @@ timeout: 200ms</pre>
             <td id="otelAgent--extraVolumeMounts"><a href="./values.yaml#L1017">otelAgent.extraVolumeMounts</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
 </div>
             </td>
             <td>Additional volume mounts for the OtelAgent.</td>
@@ -1824,7 +1824,7 @@ timeout: 200ms</pre>
             <td id="otelDeployment--enabled"><a href="./values.yaml#L1029">otelDeployment.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Enable the OtelDeployment.</td>
@@ -1833,7 +1833,7 @@ timeout: 200ms</pre>
             <td id="otelDeployment--name"><a href="./values.yaml#L1032">otelDeployment.name</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">otel-deployment</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">otel-deployment</pre>
 </div>
             </td>
             <td>Name of the OtelDeployment.</td>
@@ -1842,7 +1842,7 @@ timeout: 200ms</pre>
             <td id="otelDeployment--image"><a href="./values.yaml#L1035">otelDeployment.image</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">pullPolicy: IfNotPresent
+                <div style="max-width: 300px;"><pre lang="yaml">pullPolicy: IfNotPresent
 registry: docker.io
 repository: otel/opentelemetry-collector-contrib
 tag: 0.109.0</pre>
@@ -1854,7 +1854,7 @@ tag: 0.109.0</pre>
             <td id="otelDeployment--image--registry"><a href="./values.yaml#L1038">otelDeployment.image.registry</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">docker.io</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">docker.io</pre>
 </div>
             </td>
             <td>Docker registry for the OtelDeployment image.</td>
@@ -1863,7 +1863,7 @@ tag: 0.109.0</pre>
             <td id="otelDeployment--image--repository"><a href="./values.yaml#L1041">otelDeployment.image.repository</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">otel/opentelemetry-collector-contrib</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">otel/opentelemetry-collector-contrib</pre>
 </div>
             </td>
             <td>Repository for the OtelDeployment image.</td>
@@ -1872,7 +1872,7 @@ tag: 0.109.0</pre>
             <td id="otelDeployment--image--tag"><a href="./values.yaml#L1044">otelDeployment.image.tag</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">0.109.0</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">0.109.0</pre>
 </div>
             </td>
             <td>Tag for the OtelDeployment image.</td>
@@ -1881,7 +1881,7 @@ tag: 0.109.0</pre>
             <td id="otelDeployment--image--pullPolicy"><a href="./values.yaml#L1047">otelDeployment.image.pullPolicy</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">IfNotPresent</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">IfNotPresent</pre>
 </div>
             </td>
             <td>Image pull policy for the OtelDeployment.</td>
@@ -1890,7 +1890,7 @@ tag: 0.109.0</pre>
             <td id="otelDeployment--imagePullSecrets"><a href="./values.yaml#L1051">otelDeployment.imagePullSecrets</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
 </div>
             </td>
             <td>Image Pull Secrets for the OtelDeployment. Merged with `global.imagePullSecrets`.</td>
@@ -1899,7 +1899,7 @@ tag: 0.109.0</pre>
             <td id="otelDeployment--command"><a href="./values.yaml#L1056">otelDeployment.command</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">extraArgs: []
+                <div style="max-width: 300px;"><pre lang="yaml">extraArgs: []
 name: /otelcol-contrib</pre>
 </div>
             </td>
@@ -1909,7 +1909,7 @@ name: /otelcol-contrib</pre>
             <td id="otelDeployment--command--name"><a href="./values.yaml#L1059">otelDeployment.command.name</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">/otelcol-contrib</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">/otelcol-contrib</pre>
 </div>
             </td>
             <td>OtelDeployment command name.</td>
@@ -1918,7 +1918,7 @@ name: /otelcol-contrib</pre>
             <td id="otelDeployment--command--extraArgs"><a href="./values.yaml#L1062">otelDeployment.command.extraArgs</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
 </div>
             </td>
             <td>Extra arguments for the OtelDeployment command.</td>
@@ -1927,7 +1927,7 @@ name: /otelcol-contrib</pre>
             <td id="otelDeployment--configMap"><a href="./values.yaml#L1066">otelDeployment.configMap</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">create: true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">create: true</pre>
 </div>
             </td>
             <td>ConfigMap configuration for the OtelDeployment.</td>
@@ -1936,7 +1936,7 @@ name: /otelcol-contrib</pre>
             <td id="otelDeployment--configMap--create"><a href="./values.yaml#L1069">otelDeployment.configMap.create</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Specifies whether a ConfigMap should be created.</td>
@@ -1945,7 +1945,7 @@ name: /otelcol-contrib</pre>
             <td id="otelDeployment--service"><a href="./values.yaml#L1073">otelDeployment.service</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
+                <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
 type: ClusterIP</pre>
 </div>
             </td>
@@ -1955,7 +1955,7 @@ type: ClusterIP</pre>
             <td id="otelDeployment--service--annotations"><a href="./values.yaml#L1076">otelDeployment.service.annotations</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Annotations for the OtelDeployment service.</td>
@@ -1964,7 +1964,7 @@ type: ClusterIP</pre>
             <td id="otelDeployment--service--type"><a href="./values.yaml#L1079">otelDeployment.service.type</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">ClusterIP</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">ClusterIP</pre>
 </div>
             </td>
             <td>Service type.</td>
@@ -1973,7 +1973,7 @@ type: ClusterIP</pre>
             <td id="otelDeployment--serviceAccount"><a href="./values.yaml#L1083">otelDeployment.serviceAccount</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
+                <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
 create: true
 name: null</pre>
 </div>
@@ -1984,7 +1984,7 @@ name: null</pre>
             <td id="otelDeployment--serviceAccount--create"><a href="./values.yaml#L1086">otelDeployment.serviceAccount.create</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Specifies whether a ServiceAccount should be created.</td>
@@ -1993,7 +1993,7 @@ name: null</pre>
             <td id="otelDeployment--serviceAccount--annotations"><a href="./values.yaml#L1089">otelDeployment.serviceAccount.annotations</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Annotations for the ServiceAccount.</td>
@@ -2002,7 +2002,7 @@ name: null</pre>
             <td id="otelDeployment--serviceAccount--name"><a href="./values.yaml#L1092">otelDeployment.serviceAccount.name</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">null</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">null</pre>
 </div>
             </td>
             <td>The name of the ServiceAccount to use. A name is generated if not set.</td>
@@ -2011,7 +2011,7 @@ name: null</pre>
             <td id="otelDeployment--annotations"><a href="./values.yaml#L1096">otelDeployment.annotations</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Annotations for the OtelDeployment.</td>
@@ -2020,7 +2020,7 @@ name: null</pre>
             <td id="otelDeployment--podAnnotations"><a href="./values.yaml#L1099">otelDeployment.podAnnotations</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Annotations for the OtelDeployment pods.</td>
@@ -2029,7 +2029,7 @@ name: null</pre>
             <td id="otelDeployment--additionalEnvs"><a href="./values.yaml#L1106">otelDeployment.additionalEnvs</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Additional environment variables for the OtelDeployment container.</td>
@@ -2038,7 +2038,7 @@ name: null</pre>
             <td id="otelDeployment--podSecurityContext"><a href="./values.yaml#L1110">otelDeployment.podSecurityContext</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Pod-level security configuration.</td>
@@ -2047,7 +2047,7 @@ name: null</pre>
             <td id="otelDeployment--securityContext"><a href="./values.yaml#L1115">otelDeployment.securityContext</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Container-level security configuration.</td>
@@ -2056,7 +2056,7 @@ name: null</pre>
             <td id="otelDeployment--minReadySeconds"><a href="./values.yaml#L1125">otelDeployment.minReadySeconds</a></td>
             <td>int</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">5</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">5</pre>
 </div>
             </td>
             <td>Minimum number of seconds for which a newly created Pod should be ready.</td>
@@ -2065,7 +2065,7 @@ name: null</pre>
             <td id="otelDeployment--progressDeadlineSeconds"><a href="./values.yaml#L1129">otelDeployment.progressDeadlineSeconds</a></td>
             <td>int</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">120</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">120</pre>
 </div>
             </td>
             <td>Seconds to wait for the Deployment to progress before it's considered failed.</td>
@@ -2074,7 +2074,7 @@ name: null</pre>
             <td id="otelDeployment--ports"><a href="./values.yaml#L1133">otelDeployment.ports</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">health-check:
+                <div style="max-width: 300px;"><pre lang="yaml">health-check:
     containerPort: 13133
     enabled: true
     nodePort: ""
@@ -2106,7 +2106,7 @@ zpages:
             <td id="otelDeployment--ports--metrics--enabled"><a href="./values.yaml#L1138">otelDeployment.ports.metrics.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Enable service port for internal metrics.</td>
@@ -2115,7 +2115,7 @@ zpages:
             <td id="otelDeployment--ports--zpages--enabled"><a href="./values.yaml#L1151">otelDeployment.ports.zpages.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Enable service port for ZPages.</td>
@@ -2124,7 +2124,7 @@ zpages:
             <td id="otelDeployment--ports--health-check--enabled"><a href="./values.yaml#L1164">otelDeployment.ports.health-check.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Enable service port for health checks.</td>
@@ -2133,7 +2133,7 @@ zpages:
             <td id="otelDeployment--ports--pprof--enabled"><a href="./values.yaml#L1177">otelDeployment.ports.pprof.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Enable service port for pprof.</td>
@@ -2142,7 +2142,7 @@ zpages:
             <td id="otelDeployment--livenessProbe"><a href="./values.yaml#L1189">otelDeployment.livenessProbe</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
+                <div style="max-width: 300px;"><pre lang="yaml">enabled: true
 failureThreshold: 6
 initialDelaySeconds: 10
 path: /
@@ -2158,7 +2158,7 @@ timeoutSeconds: 5</pre>
             <td id="otelDeployment--readinessProbe"><a href="./values.yaml#L1209">otelDeployment.readinessProbe</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
+                <div style="max-width: 300px;"><pre lang="yaml">enabled: true
 failureThreshold: 6
 initialDelaySeconds: 10
 path: /
@@ -2174,7 +2174,7 @@ timeoutSeconds: 5</pre>
             <td id="otelDeployment--customLivenessProbe"><a href="./values.yaml#L1229">otelDeployment.customLivenessProbe</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Custom liveness probe configuration.</td>
@@ -2183,7 +2183,7 @@ timeoutSeconds: 5</pre>
             <td id="otelDeployment--customReadinessProbe"><a href="./values.yaml#L1233">otelDeployment.customReadinessProbe</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Custom readiness probe configuration.</td>
@@ -2192,7 +2192,7 @@ timeoutSeconds: 5</pre>
             <td id="otelDeployment--ingress"><a href="./values.yaml#L1237">otelDeployment.ingress</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
+                <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
 className: ""
 enabled: false
 hosts:
@@ -2210,7 +2210,7 @@ tls: []</pre>
             <td id="otelDeployment--ingress--enabled"><a href="./values.yaml#L1240">otelDeployment.ingress.enabled</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">false</pre>
 </div>
             </td>
             <td>Enable Ingress for the OtelDeployment.</td>
@@ -2219,7 +2219,7 @@ tls: []</pre>
             <td id="otelDeployment--ingress--className"><a href="./values.yaml#L1243">otelDeployment.ingress.className</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">""</pre>
 </div>
             </td>
             <td>Ingress Class Name to be used.</td>
@@ -2228,7 +2228,7 @@ tls: []</pre>
             <td id="otelDeployment--ingress--annotations"><a href="./values.yaml#L1246">otelDeployment.ingress.annotations</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Annotations for the OtelDeployment Ingress.</td>
@@ -2237,7 +2237,7 @@ tls: []</pre>
             <td id="otelDeployment--ingress--hosts"><a href="./values.yaml#L1249">otelDeployment.ingress.hosts</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">- host: otel-deployment.domain.com
+                <div style="max-width: 300px;"><pre lang="yaml">- host: otel-deployment.domain.com
   paths:
     - path: /
       pathType: ImplementationSpecific
@@ -2250,7 +2250,7 @@ tls: []</pre>
             <td id="otelDeployment--ingress--tls"><a href="./values.yaml#L1257">otelDeployment.ingress.tls</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
 </div>
             </td>
             <td>OtelDeployment Ingress TLS configuration.</td>
@@ -2259,7 +2259,7 @@ tls: []</pre>
             <td id="otelDeployment--resources"><a href="./values.yaml#L1264">otelDeployment.resources</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">requests:
+                <div style="max-width: 300px;"><pre lang="yaml">requests:
     cpu: 100m
     memory: 100Mi</pre>
 </div>
@@ -2270,7 +2270,7 @@ tls: []</pre>
             <td id="otelDeployment--priorityClassName"><a href="./values.yaml#L1275">otelDeployment.priorityClassName</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">""</pre>
 </div>
             </td>
             <td>OtelDeployment Priority Class name.</td>
@@ -2279,7 +2279,7 @@ tls: []</pre>
             <td id="otelDeployment--nodeSelector"><a href="./values.yaml#L1279">otelDeployment.nodeSelector</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Node selector for OtelDeployment pod assignment.</td>
@@ -2288,7 +2288,7 @@ tls: []</pre>
             <td id="otelDeployment--tolerations"><a href="./values.yaml#L1283">otelDeployment.tolerations</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
 </div>
             </td>
             <td>Toleration labels for OtelDeployment pod assignment.</td>
@@ -2297,7 +2297,7 @@ tls: []</pre>
             <td id="otelDeployment--affinity"><a href="./values.yaml#L1287">otelDeployment.affinity</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Affinity settings for the OtelDeployment pod.</td>
@@ -2306,7 +2306,7 @@ tls: []</pre>
             <td id="otelDeployment--topologySpreadConstraints"><a href="./values.yaml#L1291">otelDeployment.topologySpreadConstraints</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
 </div>
             </td>
             <td>Describes how OtelDeployment pods ought to spread.</td>
@@ -2315,7 +2315,7 @@ tls: []</pre>
             <td id="otelDeployment--clusterRole"><a href="./values.yaml#L1296">otelDeployment.clusterRole</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">Please Checkout the values.yml for default values</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">Please Checkout the values.yml for default values</pre>
 </div>
             </td>
             <td>ClusterRole configuration for the OtelDeployment.</td>
@@ -2324,7 +2324,7 @@ tls: []</pre>
             <td id="otelDeployment--clusterRole--create"><a href="./values.yaml#L1299">otelDeployment.clusterRole.create</a></td>
             <td>bool</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">true</pre>
 </div>
             </td>
             <td>Specifies whether a ClusterRole should be created.</td>
@@ -2333,7 +2333,7 @@ tls: []</pre>
             <td id="otelDeployment--clusterRole--annotations"><a href="./values.yaml#L1302">otelDeployment.clusterRole.annotations</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
 </div>
             </td>
             <td>Annotations for the ClusterRole.</td>
@@ -2342,7 +2342,7 @@ tls: []</pre>
             <td id="otelDeployment--clusterRole--name"><a href="./values.yaml#L1305">otelDeployment.clusterRole.name</a></td>
             <td>string</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">""</pre>
 </div>
             </td>
             <td>The name of the ClusterRole to use. A name is generated if not set.</td>
@@ -2351,7 +2351,7 @@ tls: []</pre>
             <td id="otelDeployment--clusterRole--rules"><a href="./values.yaml#L1309">otelDeployment.clusterRole.rules</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">Please checkout the values.yml for default values</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">Please checkout the values.yml for default values</pre>
 </div>
             </td>
             <td>RBAC rules for the OtelDeployment.</td>
@@ -2360,7 +2360,7 @@ tls: []</pre>
             <td id="otelDeployment--clusterRole--clusterRoleBinding"><a href="./values.yaml#L1339">otelDeployment.clusterRole.clusterRoleBinding</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
+                <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
 name: ""</pre>
 </div>
             </td>
@@ -2370,7 +2370,7 @@ name: ""</pre>
             <td id="otelDeployment--config"><a href="./values.yaml#L1350">otelDeployment.config</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">Please Checkout the values.yml for default values</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">Please Checkout the values.yml for default values</pre>
 </div>
             </td>
             <td>Base configuration for the OtelDeployment Collector.</td>
@@ -2379,7 +2379,7 @@ name: ""</pre>
             <td id="otelDeployment--config--processors--batch"><a href="./values.yaml#L1357">otelDeployment.config.processors.batch</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">send_batch_size: 10000
+                <div style="max-width: 300px;"><pre lang="yaml">send_batch_size: 10000
 timeout: 1s</pre>
 </div>
             </td>
@@ -2389,7 +2389,7 @@ timeout: 1s</pre>
             <td id="otelDeployment--extraVolumes"><a href="./values.yaml#L1397">otelDeployment.extraVolumes</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
 </div>
             </td>
             <td>Additional volumes for the OtelDeployment.</td>
@@ -2398,7 +2398,7 @@ timeout: 1s</pre>
             <td id="otelDeployment--extraVolumeMounts"><a href="./values.yaml#L1407">otelDeployment.extraVolumeMounts</a></td>
             <td>list</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
 </div>
             </td>
             <td>Additional volume mounts for the OtelDeployment.</td>

--- a/charts/k8s-infra/README.md
+++ b/charts/k8s-infra/README.md
@@ -382,7 +382,7 @@ verbosity: basic</pre>
             <td>Configuration for the OTLP exporter.</td>
         </tr>
         <tr>
-            <td id="presets--selfTelemetry"><a href="./values.yaml#L131">presets.selfTelemetry</a></td>
+            <td id="presets--selfTelemetry"><a href="./values.yaml#L136">presets.selfTelemetry</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">apiKeyExistingSecretKey: ""
@@ -402,7 +402,7 @@ traces:
             <td>Configuration for sending the collector's own telemetry data.</td>
         </tr>
         <tr>
-            <td id="presets--selfTelemetry--endpoint"><a href="./values.yaml#L134">presets.selfTelemetry.endpoint</a></td>
+            <td id="presets--selfTelemetry--endpoint"><a href="./values.yaml#L139">presets.selfTelemetry.endpoint</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -411,7 +411,7 @@ traces:
             <td>OTLP HTTP endpoint to send own telemetry data to.</td>
         </tr>
         <tr>
-            <td id="presets--selfTelemetry--traces--enabled"><a href="./values.yaml#L155">presets.selfTelemetry.traces.enabled</a></td>
+            <td id="presets--selfTelemetry--traces--enabled"><a href="./values.yaml#L160">presets.selfTelemetry.traces.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -420,7 +420,7 @@ traces:
             <td>Enable self-telemetry for traces.</td>
         </tr>
         <tr>
-            <td id="presets--selfTelemetry--metrics--enabled"><a href="./values.yaml#L161">presets.selfTelemetry.metrics.enabled</a></td>
+            <td id="presets--selfTelemetry--metrics--enabled"><a href="./values.yaml#L166">presets.selfTelemetry.metrics.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -429,7 +429,7 @@ traces:
             <td>Enable self-telemetry for metrics.</td>
         </tr>
         <tr>
-            <td id="presets--selfTelemetry--logs"><a href="./values.yaml#L164">presets.selfTelemetry.logs</a></td>
+            <td id="presets--selfTelemetry--logs"><a href="./values.yaml#L169">presets.selfTelemetry.logs</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: false</pre>
@@ -438,7 +438,7 @@ traces:
             <td>Configuration for self-telemetry logs.</td>
         </tr>
         <tr>
-            <td id="presets--selfTelemetry--logs--enabled"><a href="./values.yaml#L167">presets.selfTelemetry.logs.enabled</a></td>
+            <td id="presets--selfTelemetry--logs--enabled"><a href="./values.yaml#L172">presets.selfTelemetry.logs.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -447,7 +447,7 @@ traces:
             <td>Enable self-telemetry for logs.</td>
         </tr>
         <tr>
-            <td id="presets--logsCollection"><a href="./values.yaml#L170">presets.logsCollection</a></td>
+            <td id="presets--logsCollection"><a href="./values.yaml#L175">presets.logsCollection</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">blacklist:
@@ -481,7 +481,7 @@ whitelist:
             <td>Configuration for collecting logs from pods.</td>
         </tr>
         <tr>
-            <td id="presets--logsCollection--enabled"><a href="./values.yaml#L173">presets.logsCollection.enabled</a></td>
+            <td id="presets--logsCollection--enabled"><a href="./values.yaml#L178">presets.logsCollection.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -490,7 +490,7 @@ whitelist:
             <td>Enable log collection.</td>
         </tr>
         <tr>
-            <td id="presets--logsCollection--startAt"><a href="./values.yaml#L176">presets.logsCollection.startAt</a></td>
+            <td id="presets--logsCollection--startAt"><a href="./values.yaml#L181">presets.logsCollection.startAt</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">end</pre>
@@ -499,7 +499,7 @@ whitelist:
             <td>Where to start reading logs from: `end` or `beginning`.</td>
         </tr>
         <tr>
-            <td id="presets--logsCollection--whitelist"><a href="./values.yaml#L213">presets.logsCollection.whitelist</a></td>
+            <td id="presets--logsCollection--whitelist"><a href="./values.yaml#L218">presets.logsCollection.whitelist</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">additionalInclude: []
@@ -513,7 +513,7 @@ signozLogs: true</pre>
             <td>Whitelist certain log files to be collected. If enabled, `include` is ignored.</td>
         </tr>
         <tr>
-            <td id="presets--logsCollection--whitelist--enabled"><a href="./values.yaml#L216">presets.logsCollection.whitelist.enabled</a></td>
+            <td id="presets--logsCollection--whitelist--enabled"><a href="./values.yaml#L221">presets.logsCollection.whitelist.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -522,7 +522,7 @@ signozLogs: true</pre>
             <td>Enable the whitelist.</td>
         </tr>
         <tr>
-            <td id="presets--logsCollection--whitelist--signozLogs"><a href="./values.yaml#L219">presets.logsCollection.whitelist.signozLogs</a></td>
+            <td id="presets--logsCollection--whitelist--signozLogs"><a href="./values.yaml#L224">presets.logsCollection.whitelist.signozLogs</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -531,7 +531,7 @@ signozLogs: true</pre>
             <td>Include SigNoz's own logs.</td>
         </tr>
         <tr>
-            <td id="presets--logsCollection--whitelist--namespaces"><a href="./values.yaml#L222">presets.logsCollection.whitelist.namespaces</a></td>
+            <td id="presets--logsCollection--whitelist--namespaces"><a href="./values.yaml#L227">presets.logsCollection.whitelist.namespaces</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -540,7 +540,7 @@ signozLogs: true</pre>
             <td>List of namespaces to include in log collection.</td>
         </tr>
         <tr>
-            <td id="presets--logsCollection--whitelist--pods"><a href="./values.yaml#L225">presets.logsCollection.whitelist.pods</a></td>
+            <td id="presets--logsCollection--whitelist--pods"><a href="./values.yaml#L230">presets.logsCollection.whitelist.pods</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -549,7 +549,7 @@ signozLogs: true</pre>
             <td>List of pod names to include.</td>
         </tr>
         <tr>
-            <td id="presets--logsCollection--whitelist--containers"><a href="./values.yaml#L228">presets.logsCollection.whitelist.containers</a></td>
+            <td id="presets--logsCollection--whitelist--containers"><a href="./values.yaml#L233">presets.logsCollection.whitelist.containers</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -558,7 +558,7 @@ signozLogs: true</pre>
             <td>List of container names to include.</td>
         </tr>
         <tr>
-            <td id="presets--logsCollection--whitelist--additionalInclude"><a href="./values.yaml#L231">presets.logsCollection.whitelist.additionalInclude</a></td>
+            <td id="presets--logsCollection--whitelist--additionalInclude"><a href="./values.yaml#L236">presets.logsCollection.whitelist.additionalInclude</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -567,7 +567,7 @@ signozLogs: true</pre>
             <td>List of additional file path patterns to include.</td>
         </tr>
         <tr>
-            <td id="presets--logsCollection--operators"><a href="./values.yaml#L234">presets.logsCollection.operators</a></td>
+            <td id="presets--logsCollection--operators"><a href="./values.yaml#L239">presets.logsCollection.operators</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- id: container-parser
@@ -577,7 +577,7 @@ signozLogs: true</pre>
             <td>A list of log processing operators.</td>
         </tr>
         <tr>
-            <td id="presets--hostMetrics"><a href="./values.yaml#L239">presets.hostMetrics</a></td>
+            <td id="presets--hostMetrics"><a href="./values.yaml#L244">presets.hostMetrics</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">collectionInterval: 30s
@@ -657,7 +657,7 @@ scrapers:
             <td>Configuration for collecting host-level metrics from nodes.</td>
         </tr>
         <tr>
-            <td id="presets--hostMetrics--enabled"><a href="./values.yaml#L242">presets.hostMetrics.enabled</a></td>
+            <td id="presets--hostMetrics--enabled"><a href="./values.yaml#L247">presets.hostMetrics.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -666,7 +666,7 @@ scrapers:
             <td>Enable host metrics collection.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics"><a href="./values.yaml#L320">presets.kubeletMetrics</a></td>
+            <td id="presets--kubeletMetrics"><a href="./values.yaml#L325">presets.kubeletMetrics</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">authType: serviceAccount
@@ -716,7 +716,7 @@ metrics:
             <td>Configuration for collecting metrics from Kubelet.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics--enabled"><a href="./values.yaml#L323">presets.kubeletMetrics.enabled</a></td>
+            <td id="presets--kubeletMetrics--enabled"><a href="./values.yaml#L328">presets.kubeletMetrics.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -725,7 +725,7 @@ metrics:
             <td>Enable Kubelet metrics collection.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics--endpoint"><a href="./values.yaml#L332">presets.kubeletMetrics.endpoint</a></td>
+            <td id="presets--kubeletMetrics--endpoint"><a href="./values.yaml#L337">presets.kubeletMetrics.endpoint</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">${env:K8S_HOST_IP}:10250</pre>
@@ -734,7 +734,7 @@ metrics:
             <td>Kubelet endpoint.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics--insecureSkipVerify"><a href="./values.yaml#L335">presets.kubeletMetrics.insecureSkipVerify</a></td>
+            <td id="presets--kubeletMetrics--insecureSkipVerify"><a href="./values.yaml#L340">presets.kubeletMetrics.insecureSkipVerify</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -743,7 +743,7 @@ metrics:
             <td>Skip verifying Kubelet's certificate.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics--extraMetadataLabels"><a href="./values.yaml#L338">presets.kubeletMetrics.extraMetadataLabels</a></td>
+            <td id="presets--kubeletMetrics--extraMetadataLabels"><a href="./values.yaml#L343">presets.kubeletMetrics.extraMetadataLabels</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- container.id
@@ -753,7 +753,7 @@ metrics:
             <td>List of extra metadata labels to collect.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics--metricGroups"><a href="./values.yaml#L343">presets.kubeletMetrics.metricGroups</a></td>
+            <td id="presets--kubeletMetrics--metricGroups"><a href="./values.yaml#L348">presets.kubeletMetrics.metricGroups</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- container
@@ -765,7 +765,7 @@ metrics:
             <td>Groups of metrics to collect from Kubelet.</td>
         </tr>
         <tr>
-            <td id="presets--kubernetesAttributes"><a href="./values.yaml#L381">presets.kubernetesAttributes</a></td>
+            <td id="presets--kubernetesAttributes"><a href="./values.yaml#L386">presets.kubernetesAttributes</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
@@ -800,7 +800,7 @@ podAssociation:
             <td>Processor for adding Kubernetes attributes to telemetry data.</td>
         </tr>
         <tr>
-            <td id="presets--kubernetesAttributes--enabled"><a href="./values.yaml#L384">presets.kubernetesAttributes.enabled</a></td>
+            <td id="presets--kubernetesAttributes--enabled"><a href="./values.yaml#L389">presets.kubernetesAttributes.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -809,7 +809,7 @@ podAssociation:
             <td>Enable the Kubernetes attributes processor.</td>
         </tr>
         <tr>
-            <td id="presets--clusterMetrics"><a href="./values.yaml#L427">presets.clusterMetrics</a></td>
+            <td id="presets--clusterMetrics"><a href="./values.yaml#L432">presets.clusterMetrics</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">allocatableTypesToReport:
@@ -844,7 +844,7 @@ resourceAttributes:
             <td>Configuration for collecting cluster-level metrics.</td>
         </tr>
         <tr>
-            <td id="presets--clusterMetrics--enabled"><a href="./values.yaml#L430">presets.clusterMetrics.enabled</a></td>
+            <td id="presets--clusterMetrics--enabled"><a href="./values.yaml#L435">presets.clusterMetrics.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -853,7 +853,7 @@ resourceAttributes:
             <td>Enable cluster metrics collection.</td>
         </tr>
         <tr>
-            <td id="presets--clusterMetrics--resourceAttributes"><a href="./values.yaml#L436">presets.clusterMetrics.resourceAttributes</a></td>
+            <td id="presets--clusterMetrics--resourceAttributes"><a href="./values.yaml#L441">presets.clusterMetrics.resourceAttributes</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">container.runtime:
@@ -871,7 +871,7 @@ k8s.pod.qos_class:
             <td>Resource attributes to report.</td>
         </tr>
         <tr>
-            <td id="presets--clusterMetrics--nodeConditionsToReport"><a href="./values.yaml#L449">presets.clusterMetrics.nodeConditionsToReport</a></td>
+            <td id="presets--clusterMetrics--nodeConditionsToReport"><a href="./values.yaml#L454">presets.clusterMetrics.nodeConditionsToReport</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- Ready
@@ -884,7 +884,7 @@ k8s.pod.qos_class:
             <td>Node conditions to report as metrics.</td>
         </tr>
         <tr>
-            <td id="presets--clusterMetrics--allocatableTypesToReport"><a href="./values.yaml#L457">presets.clusterMetrics.allocatableTypesToReport</a></td>
+            <td id="presets--clusterMetrics--allocatableTypesToReport"><a href="./values.yaml#L462">presets.clusterMetrics.allocatableTypesToReport</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- cpu
@@ -894,7 +894,7 @@ k8s.pod.qos_class:
             <td>Allocatable resource types to report.</td>
         </tr>
         <tr>
-            <td id="presets--clusterMetrics--metrics"><a href="./values.yaml#L464">presets.clusterMetrics.metrics</a></td>
+            <td id="presets--clusterMetrics--metrics"><a href="./values.yaml#L469">presets.clusterMetrics.metrics</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">k8s.node.condition:
@@ -906,7 +906,7 @@ k8s.pod.status_reason:
             <td>Fine-grained control over which cluster metrics are enabled.</td>
         </tr>
         <tr>
-            <td id="presets--prometheus"><a href="./values.yaml#L471">presets.prometheus</a></td>
+            <td id="presets--prometheus"><a href="./values.yaml#L476">presets.prometheus</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotationsPrefix: signoz.io
@@ -921,7 +921,7 @@ scrapeInterval: 60s</pre>
             <td>Configuration for scraping Prometheus metrics from pod annotations.</td>
         </tr>
         <tr>
-            <td id="presets--prometheus--enabled"><a href="./values.yaml#L474">presets.prometheus.enabled</a></td>
+            <td id="presets--prometheus--enabled"><a href="./values.yaml#L479">presets.prometheus.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -930,7 +930,7 @@ scrapeInterval: 60s</pre>
             <td>Enable Prometheus metrics scraping.</td>
         </tr>
         <tr>
-            <td id="presets--resourceDetection"><a href="./values.yaml#L495">presets.resourceDetection</a></td>
+            <td id="presets--resourceDetection"><a href="./values.yaml#L500">presets.resourceDetection</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
@@ -942,7 +942,7 @@ timeout: 2s</pre>
             <td>Processor for detecting resource information from the environment (e.g., cloud provider, k8s).</td>
         </tr>
         <tr>
-            <td id="presets--k8sEvents"><a href="./values.yaml#L510">presets.k8sEvents</a></td>
+            <td id="presets--k8sEvents"><a href="./values.yaml#L515">presets.k8sEvents</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">authType: serviceAccount
@@ -953,7 +953,7 @@ namespaces: []</pre>
             <td>Configuration for collecting Kubernetes events as logs.</td>
         </tr>
         <tr>
-            <td id="presets--k8sEvents--enabled"><a href="./values.yaml#L513">presets.k8sEvents.enabled</a></td>
+            <td id="presets--k8sEvents--enabled"><a href="./values.yaml#L518">presets.k8sEvents.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -962,7 +962,7 @@ namespaces: []</pre>
             <td>Enable Kubernetes events collection.</td>
         </tr>
         <tr>
-            <td id="presets--k8sEvents--authType"><a href="./values.yaml#L516">presets.k8sEvents.authType</a></td>
+            <td id="presets--k8sEvents--authType"><a href="./values.yaml#L521">presets.k8sEvents.authType</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">serviceAccount</pre>
@@ -971,7 +971,7 @@ namespaces: []</pre>
             <td>Authentication type: `serviceAccount` or `kubeconfig`.</td>
         </tr>
         <tr>
-            <td id="presets--k8sEvents--namespaces"><a href="./values.yaml#L519">presets.k8sEvents.namespaces</a></td>
+            <td id="presets--k8sEvents--namespaces"><a href="./values.yaml#L524">presets.k8sEvents.namespaces</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -991,7 +991,7 @@ namespaces: []</pre>
     </thead>
     <tbody>
         <tr>
-            <td id="otelAgent--enabled"><a href="./values.yaml#L526">otelAgent.enabled</a></td>
+            <td id="otelAgent--enabled"><a href="./values.yaml#L531">otelAgent.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1000,7 +1000,7 @@ namespaces: []</pre>
             <td>Enable the OtelAgent DaemonSet.</td>
         </tr>
         <tr>
-            <td id="otelAgent--name"><a href="./values.yaml#L529">otelAgent.name</a></td>
+            <td id="otelAgent--name"><a href="./values.yaml#L534">otelAgent.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">otel-agent</pre>
@@ -1009,7 +1009,7 @@ namespaces: []</pre>
             <td>Name of the OtelAgent DaemonSet.</td>
         </tr>
         <tr>
-            <td id="otelAgent--image"><a href="./values.yaml#L532">otelAgent.image</a></td>
+            <td id="otelAgent--image"><a href="./values.yaml#L537">otelAgent.image</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">pullPolicy: IfNotPresent
@@ -1021,7 +1021,7 @@ tag: 0.109.0</pre>
             <td>Image configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--image--registry"><a href="./values.yaml#L535">otelAgent.image.registry</a></td>
+            <td id="otelAgent--image--registry"><a href="./values.yaml#L540">otelAgent.image.registry</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">docker.io</pre>
@@ -1030,7 +1030,7 @@ tag: 0.109.0</pre>
             <td>Docker registry for the OtelAgent image.</td>
         </tr>
         <tr>
-            <td id="otelAgent--image--repository"><a href="./values.yaml#L538">otelAgent.image.repository</a></td>
+            <td id="otelAgent--image--repository"><a href="./values.yaml#L543">otelAgent.image.repository</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">otel/opentelemetry-collector-contrib</pre>
@@ -1039,7 +1039,7 @@ tag: 0.109.0</pre>
             <td>Repository for the OtelAgent image.</td>
         </tr>
         <tr>
-            <td id="otelAgent--image--tag"><a href="./values.yaml#L541">otelAgent.image.tag</a></td>
+            <td id="otelAgent--image--tag"><a href="./values.yaml#L546">otelAgent.image.tag</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">0.109.0</pre>
@@ -1048,7 +1048,7 @@ tag: 0.109.0</pre>
             <td>Tag for the OtelAgent image.</td>
         </tr>
         <tr>
-            <td id="otelAgent--image--pullPolicy"><a href="./values.yaml#L544">otelAgent.image.pullPolicy</a></td>
+            <td id="otelAgent--image--pullPolicy"><a href="./values.yaml#L549">otelAgent.image.pullPolicy</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">IfNotPresent</pre>
@@ -1057,7 +1057,7 @@ tag: 0.109.0</pre>
             <td>Image pull policy for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--imagePullSecrets"><a href="./values.yaml#L548">otelAgent.imagePullSecrets</a></td>
+            <td id="otelAgent--imagePullSecrets"><a href="./values.yaml#L553">otelAgent.imagePullSecrets</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1066,7 +1066,7 @@ tag: 0.109.0</pre>
             <td>Image Pull Secrets for the OtelAgent. Merged with `global.imagePullSecrets`.</td>
         </tr>
         <tr>
-            <td id="otelAgent--command"><a href="./values.yaml#L553">otelAgent.command</a></td>
+            <td id="otelAgent--command"><a href="./values.yaml#L558">otelAgent.command</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">extraArgs: []
@@ -1076,7 +1076,7 @@ name: /otelcol-contrib</pre>
             <td>Command and arguments for the OtelAgent container.</td>
         </tr>
         <tr>
-            <td id="otelAgent--command--name"><a href="./values.yaml#L556">otelAgent.command.name</a></td>
+            <td id="otelAgent--command--name"><a href="./values.yaml#L561">otelAgent.command.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">/otelcol-contrib</pre>
@@ -1085,7 +1085,7 @@ name: /otelcol-contrib</pre>
             <td>OtelAgent command name.</td>
         </tr>
         <tr>
-            <td id="otelAgent--command--extraArgs"><a href="./values.yaml#L559">otelAgent.command.extraArgs</a></td>
+            <td id="otelAgent--command--extraArgs"><a href="./values.yaml#L564">otelAgent.command.extraArgs</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1094,7 +1094,7 @@ name: /otelcol-contrib</pre>
             <td>Extra arguments for the OtelAgent command.</td>
         </tr>
         <tr>
-            <td id="otelAgent--configMap"><a href="./values.yaml#L563">otelAgent.configMap</a></td>
+            <td id="otelAgent--configMap"><a href="./values.yaml#L568">otelAgent.configMap</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">create: true</pre>
@@ -1103,7 +1103,7 @@ name: /otelcol-contrib</pre>
             <td>ConfigMap configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--configMap--create"><a href="./values.yaml#L566">otelAgent.configMap.create</a></td>
+            <td id="otelAgent--configMap--create"><a href="./values.yaml#L571">otelAgent.configMap.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1112,7 +1112,7 @@ name: /otelcol-contrib</pre>
             <td>Specifies whether a ConfigMap should be created.</td>
         </tr>
         <tr>
-            <td id="otelAgent--service"><a href="./values.yaml#L570">otelAgent.service</a></td>
+            <td id="otelAgent--service"><a href="./values.yaml#L575">otelAgent.service</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1123,7 +1123,7 @@ type: ClusterIP</pre>
             <td>Service configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--service--annotations"><a href="./values.yaml#L573">otelAgent.service.annotations</a></td>
+            <td id="otelAgent--service--annotations"><a href="./values.yaml#L578">otelAgent.service.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1132,7 +1132,7 @@ type: ClusterIP</pre>
             <td>Annotations for the OtelAgent service.</td>
         </tr>
         <tr>
-            <td id="otelAgent--service--type"><a href="./values.yaml#L576">otelAgent.service.type</a></td>
+            <td id="otelAgent--service--type"><a href="./values.yaml#L581">otelAgent.service.type</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">ClusterIP</pre>
@@ -1141,7 +1141,7 @@ type: ClusterIP</pre>
             <td>Service type: `ClusterIP`, `NodePort`, or `LoadBalancer`.</td>
         </tr>
         <tr>
-            <td id="otelAgent--service--internalTrafficPolicy"><a href="./values.yaml#L580">otelAgent.service.internalTrafficPolicy</a></td>
+            <td id="otelAgent--service--internalTrafficPolicy"><a href="./values.yaml#L585">otelAgent.service.internalTrafficPolicy</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Local</pre>
@@ -1150,7 +1150,7 @@ type: ClusterIP</pre>
             <td>Internal traffic policy: `Local` or `Cluster`. ref: https://kubernetes.io/docs/reference/networking/virtual-ips/#internal-traffic-policy</td>
         </tr>
         <tr>
-            <td id="otelAgent--serviceAccount"><a href="./values.yaml#L584">otelAgent.serviceAccount</a></td>
+            <td id="otelAgent--serviceAccount"><a href="./values.yaml#L589">otelAgent.serviceAccount</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1161,7 +1161,7 @@ name: null</pre>
             <td>ServiceAccount configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--serviceAccount--create"><a href="./values.yaml#L587">otelAgent.serviceAccount.create</a></td>
+            <td id="otelAgent--serviceAccount--create"><a href="./values.yaml#L592">otelAgent.serviceAccount.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1170,7 +1170,7 @@ name: null</pre>
             <td>Specifies whether a ServiceAccount should be created.</td>
         </tr>
         <tr>
-            <td id="otelAgent--serviceAccount--annotations"><a href="./values.yaml#L590">otelAgent.serviceAccount.annotations</a></td>
+            <td id="otelAgent--serviceAccount--annotations"><a href="./values.yaml#L595">otelAgent.serviceAccount.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1179,7 +1179,7 @@ name: null</pre>
             <td>Annotations for the ServiceAccount.</td>
         </tr>
         <tr>
-            <td id="otelAgent--serviceAccount--name"><a href="./values.yaml#L593">otelAgent.serviceAccount.name</a></td>
+            <td id="otelAgent--serviceAccount--name"><a href="./values.yaml#L598">otelAgent.serviceAccount.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">null</pre>
@@ -1188,7 +1188,7 @@ name: null</pre>
             <td>The name of the ServiceAccount to use. A name is generated if not set.</td>
         </tr>
         <tr>
-            <td id="otelAgent--annotations"><a href="./values.yaml#L597">otelAgent.annotations</a></td>
+            <td id="otelAgent--annotations"><a href="./values.yaml#L602">otelAgent.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1197,7 +1197,7 @@ name: null</pre>
             <td>Annotations for the OtelAgent DaemonSet.</td>
         </tr>
         <tr>
-            <td id="otelAgent--podAnnotations"><a href="./values.yaml#L600">otelAgent.podAnnotations</a></td>
+            <td id="otelAgent--podAnnotations"><a href="./values.yaml#L605">otelAgent.podAnnotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1206,7 +1206,7 @@ name: null</pre>
             <td>Annotations for the OtelAgent pods.</td>
         </tr>
         <tr>
-            <td id="otelAgent--additionalEnvs"><a href="./values.yaml#L622">otelAgent.additionalEnvs</a></td>
+            <td id="otelAgent--additionalEnvs"><a href="./values.yaml#L627">otelAgent.additionalEnvs</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1215,7 +1215,7 @@ name: null</pre>
             <td>Additional environment variables for the OtelAgent container. You can specify variables in two ways: 1. Flexible structure for advanced configurations (recommended):    Example:      additionalEnvs:        MY_KEY:          value: my-value        SECRET_KEY:          valueFrom:            secretKeyRef:              name: my-secret              key: my-key 2. Simple key-value pairs (backward-compatible):    Example:      additionalEnvs:        MY_KEY: my-value</td>
         </tr>
         <tr>
-            <td id="otelAgent--minReadySeconds"><a href="./values.yaml#L626">otelAgent.minReadySeconds</a></td>
+            <td id="otelAgent--minReadySeconds"><a href="./values.yaml#L631">otelAgent.minReadySeconds</a></td>
             <td>int</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">5</pre>
@@ -1224,7 +1224,7 @@ name: null</pre>
             <td>Minimum number of seconds for which a newly created Pod should be ready.</td>
         </tr>
         <tr>
-            <td id="otelAgent--clusterRole"><a href="./values.yaml#L631">otelAgent.clusterRole</a></td>
+            <td id="otelAgent--clusterRole"><a href="./values.yaml#L636">otelAgent.clusterRole</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please checkout the values.yml for default values</pre>
@@ -1233,7 +1233,7 @@ name: null</pre>
             <td>ClusterRole configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--clusterRole--create"><a href="./values.yaml#L634">otelAgent.clusterRole.create</a></td>
+            <td id="otelAgent--clusterRole--create"><a href="./values.yaml#L639">otelAgent.clusterRole.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1242,7 +1242,7 @@ name: null</pre>
             <td>Specifies whether a ClusterRole should be created.</td>
         </tr>
         <tr>
-            <td id="otelAgent--clusterRole--annotations"><a href="./values.yaml#L637">otelAgent.clusterRole.annotations</a></td>
+            <td id="otelAgent--clusterRole--annotations"><a href="./values.yaml#L642">otelAgent.clusterRole.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1251,7 +1251,7 @@ name: null</pre>
             <td>Annotations for the ClusterRole.</td>
         </tr>
         <tr>
-            <td id="otelAgent--clusterRole--name"><a href="./values.yaml#L640">otelAgent.clusterRole.name</a></td>
+            <td id="otelAgent--clusterRole--name"><a href="./values.yaml#L645">otelAgent.clusterRole.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -1260,7 +1260,7 @@ name: null</pre>
             <td>The name of the ClusterRole to use. A name is generated if not set.</td>
         </tr>
         <tr>
-            <td id="otelAgent--clusterRole--rules"><a href="./values.yaml#L645">otelAgent.clusterRole.rules</a></td>
+            <td id="otelAgent--clusterRole--rules"><a href="./values.yaml#L650">otelAgent.clusterRole.rules</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please checkout the values.yml for default values</pre>
@@ -1269,7 +1269,7 @@ name: null</pre>
             <td>RBAC rules for the OtelAgent. ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/</td>
         </tr>
         <tr>
-            <td id="otelAgent--clusterRole--clusterRoleBinding"><a href="./values.yaml#L676">otelAgent.clusterRole.clusterRoleBinding</a></td>
+            <td id="otelAgent--clusterRole--clusterRoleBinding"><a href="./values.yaml#L681">otelAgent.clusterRole.clusterRoleBinding</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1279,7 +1279,7 @@ name: ""</pre>
             <td>ClusterRoleBinding configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports"><a href="./values.yaml#L687">otelAgent.ports</a></td>
+            <td id="otelAgent--ports"><a href="./values.yaml#L692">otelAgent.ports</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please checkout the values.yml for default values</pre>
@@ -1288,7 +1288,7 @@ name: ""</pre>
             <td>Port configurations for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--otlp--enabled"><a href="./values.yaml#L692">otelAgent.ports.otlp.enabled</a></td>
+            <td id="otelAgent--ports--otlp--enabled"><a href="./values.yaml#L697">otelAgent.ports.otlp.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1297,7 +1297,7 @@ name: ""</pre>
             <td>Enable service port for OTLP gRPC.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--otlp-http--enabled"><a href="./values.yaml#L707">otelAgent.ports.otlp-http.enabled</a></td>
+            <td id="otelAgent--ports--otlp-http--enabled"><a href="./values.yaml#L712">otelAgent.ports.otlp-http.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1306,7 +1306,7 @@ name: ""</pre>
             <td>Enable service port for OTLP HTTP.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--zipkin--enabled"><a href="./values.yaml#L722">otelAgent.ports.zipkin.enabled</a></td>
+            <td id="otelAgent--ports--zipkin--enabled"><a href="./values.yaml#L727">otelAgent.ports.zipkin.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1315,7 +1315,7 @@ name: ""</pre>
             <td>Enable service port for Zipkin.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--metrics--enabled"><a href="./values.yaml#L737">otelAgent.ports.metrics.enabled</a></td>
+            <td id="otelAgent--ports--metrics--enabled"><a href="./values.yaml#L742">otelAgent.ports.metrics.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1324,7 +1324,7 @@ name: ""</pre>
             <td>Enable service port for internal metrics.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--zpages--enabled"><a href="./values.yaml#L752">otelAgent.ports.zpages.enabled</a></td>
+            <td id="otelAgent--ports--zpages--enabled"><a href="./values.yaml#L757">otelAgent.ports.zpages.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1333,7 +1333,7 @@ name: ""</pre>
             <td>Enable service port for ZPages.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--health-check--enabled"><a href="./values.yaml#L767">otelAgent.ports.health-check.enabled</a></td>
+            <td id="otelAgent--ports--health-check--enabled"><a href="./values.yaml#L772">otelAgent.ports.health-check.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1342,7 +1342,7 @@ name: ""</pre>
             <td>Enable service port for health checks.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--pprof--enabled"><a href="./values.yaml#L782">otelAgent.ports.pprof.enabled</a></td>
+            <td id="otelAgent--ports--pprof--enabled"><a href="./values.yaml#L787">otelAgent.ports.pprof.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1351,7 +1351,7 @@ name: ""</pre>
             <td>Enable service port for pprof.</td>
         </tr>
         <tr>
-            <td id="otelAgent--hostNetwork"><a href="./values.yaml#L796">otelAgent.hostNetwork</a></td>
+            <td id="otelAgent--hostNetwork"><a href="./values.yaml#L801">otelAgent.hostNetwork</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1360,7 +1360,7 @@ name: ""</pre>
             <td>Host networking requested for this pod. Use the host's network namespace. Please make sure while enabling hostNetwork that the host ports are available as it can lead to port conflicts.</td>
         </tr>
         <tr>
-            <td id="otelAgent--livenessProbe"><a href="./values.yaml#L800">otelAgent.livenessProbe</a></td>
+            <td id="otelAgent--livenessProbe"><a href="./values.yaml#L805">otelAgent.livenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
@@ -1376,7 +1376,7 @@ timeoutSeconds: 5</pre>
             <td>Configure liveness probe. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command</td>
         </tr>
         <tr>
-            <td id="otelAgent--readinessProbe"><a href="./values.yaml#L821">otelAgent.readinessProbe</a></td>
+            <td id="otelAgent--readinessProbe"><a href="./values.yaml#L826">otelAgent.readinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
@@ -1392,7 +1392,7 @@ timeoutSeconds: 5</pre>
             <td>Configure readiness probe. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes</td>
         </tr>
         <tr>
-            <td id="otelAgent--customLivenessProbe"><a href="./values.yaml#L841">otelAgent.customLivenessProbe</a></td>
+            <td id="otelAgent--customLivenessProbe"><a href="./values.yaml#L846">otelAgent.customLivenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1401,7 +1401,7 @@ timeoutSeconds: 5</pre>
             <td>Custom liveness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--customReadinessProbe"><a href="./values.yaml#L844">otelAgent.customReadinessProbe</a></td>
+            <td id="otelAgent--customReadinessProbe"><a href="./values.yaml#L849">otelAgent.customReadinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1410,7 +1410,7 @@ timeoutSeconds: 5</pre>
             <td>Custom readiness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress"><a href="./values.yaml#L848">otelAgent.ingress</a></td>
+            <td id="otelAgent--ingress"><a href="./values.yaml#L853">otelAgent.ingress</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1428,7 +1428,7 @@ tls: []</pre>
             <td>Ingress configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--enabled"><a href="./values.yaml#L851">otelAgent.ingress.enabled</a></td>
+            <td id="otelAgent--ingress--enabled"><a href="./values.yaml#L856">otelAgent.ingress.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1437,7 +1437,7 @@ tls: []</pre>
             <td>Enable Ingress for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--className"><a href="./values.yaml#L854">otelAgent.ingress.className</a></td>
+            <td id="otelAgent--ingress--className"><a href="./values.yaml#L859">otelAgent.ingress.className</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -1446,7 +1446,7 @@ tls: []</pre>
             <td>Ingress Class Name to be used.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--annotations"><a href="./values.yaml#L857">otelAgent.ingress.annotations</a></td>
+            <td id="otelAgent--ingress--annotations"><a href="./values.yaml#L862">otelAgent.ingress.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1455,7 +1455,7 @@ tls: []</pre>
             <td>Annotations for the OtelAgent Ingress.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--hosts"><a href="./values.yaml#L865">otelAgent.ingress.hosts</a></td>
+            <td id="otelAgent--ingress--hosts"><a href="./values.yaml#L870">otelAgent.ingress.hosts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- host: otel-agent.domain.com
@@ -1468,7 +1468,7 @@ tls: []</pre>
             <td>OtelAgent Ingress hostnames with their path details.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--tls"><a href="./values.yaml#L873">otelAgent.ingress.tls</a></td>
+            <td id="otelAgent--ingress--tls"><a href="./values.yaml#L878">otelAgent.ingress.tls</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1477,7 +1477,7 @@ tls: []</pre>
             <td>OtelAgent Ingress TLS configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--resources"><a href="./values.yaml#L881">otelAgent.resources</a></td>
+            <td id="otelAgent--resources"><a href="./values.yaml#L886">otelAgent.resources</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">requests:
@@ -1488,7 +1488,7 @@ tls: []</pre>
             <td>Configure resource requests and limits for the OtelAgent. ref: http://kubernetes.io/docs/user-guide/compute-resources/</td>
         </tr>
         <tr>
-            <td id="otelAgent--priorityClassName"><a href="./values.yaml#L892">otelAgent.priorityClassName</a></td>
+            <td id="otelAgent--priorityClassName"><a href="./values.yaml#L897">otelAgent.priorityClassName</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -1497,7 +1497,7 @@ tls: []</pre>
             <td>OtelAgent Priority Class name.</td>
         </tr>
         <tr>
-            <td id="otelAgent--nodeSelector"><a href="./values.yaml#L896">otelAgent.nodeSelector</a></td>
+            <td id="otelAgent--nodeSelector"><a href="./values.yaml#L901">otelAgent.nodeSelector</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1506,7 +1506,7 @@ tls: []</pre>
             <td>Node selector for OtelAgent pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelAgent--tolerations"><a href="./values.yaml#L900">otelAgent.tolerations</a></td>
+            <td id="otelAgent--tolerations"><a href="./values.yaml#L905">otelAgent.tolerations</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- operator: Exists</pre>
@@ -1515,7 +1515,7 @@ tls: []</pre>
             <td>Toleration labels for OtelAgent pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelAgent--affinity"><a href="./values.yaml#L905">otelAgent.affinity</a></td>
+            <td id="otelAgent--affinity"><a href="./values.yaml#L910">otelAgent.affinity</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1524,7 +1524,7 @@ tls: []</pre>
             <td>Affinity settings for the OtelAgent pod.</td>
         </tr>
         <tr>
-            <td id="otelAgent--podSecurityContext"><a href="./values.yaml#L909">otelAgent.podSecurityContext</a></td>
+            <td id="otelAgent--podSecurityContext"><a href="./values.yaml#L914">otelAgent.podSecurityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1533,7 +1533,7 @@ tls: []</pre>
             <td>Pod-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--securityContext"><a href="./values.yaml#L914">otelAgent.securityContext</a></td>
+            <td id="otelAgent--securityContext"><a href="./values.yaml#L919">otelAgent.securityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1542,7 +1542,7 @@ tls: []</pre>
             <td>Container-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--config"><a href="./values.yaml#L925">otelAgent.config</a></td>
+            <td id="otelAgent--config"><a href="./values.yaml#L930">otelAgent.config</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please Checkout the values.yml for default values</pre>
@@ -1551,7 +1551,7 @@ tls: []</pre>
             <td>Base configuration for the OtelAgent Collector.</td>
         </tr>
         <tr>
-            <td id="otelAgent--config--processors--batch"><a href="./values.yaml#L940">otelAgent.config.processors.batch</a></td>
+            <td id="otelAgent--config--processors--batch"><a href="./values.yaml#L945">otelAgent.config.processors.batch</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">send_batch_size: 10000
@@ -1561,7 +1561,7 @@ timeout: 200ms</pre>
             <td>Batch processor config. ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md</td>
         </tr>
         <tr>
-            <td id="otelAgent--extraVolumes"><a href="./values.yaml#L982">otelAgent.extraVolumes</a></td>
+            <td id="otelAgent--extraVolumes"><a href="./values.yaml#L987">otelAgent.extraVolumes</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1570,7 +1570,7 @@ timeout: 200ms</pre>
             <td>Additional volumes for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--extraVolumeMounts"><a href="./values.yaml#L992">otelAgent.extraVolumeMounts</a></td>
+            <td id="otelAgent--extraVolumeMounts"><a href="./values.yaml#L997">otelAgent.extraVolumeMounts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1590,7 +1590,7 @@ timeout: 200ms</pre>
     </thead>
     <tbody>
         <tr>
-            <td id="otelDeployment--enabled"><a href="./values.yaml#L1004">otelDeployment.enabled</a></td>
+            <td id="otelDeployment--enabled"><a href="./values.yaml#L1009">otelDeployment.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1599,7 +1599,7 @@ timeout: 200ms</pre>
             <td>Enable the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--name"><a href="./values.yaml#L1007">otelDeployment.name</a></td>
+            <td id="otelDeployment--name"><a href="./values.yaml#L1012">otelDeployment.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">otel-deployment</pre>
@@ -1608,7 +1608,7 @@ timeout: 200ms</pre>
             <td>Name of the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image"><a href="./values.yaml#L1010">otelDeployment.image</a></td>
+            <td id="otelDeployment--image"><a href="./values.yaml#L1015">otelDeployment.image</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">pullPolicy: IfNotPresent
@@ -1620,7 +1620,7 @@ tag: 0.109.0</pre>
             <td>Image configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--registry"><a href="./values.yaml#L1013">otelDeployment.image.registry</a></td>
+            <td id="otelDeployment--image--registry"><a href="./values.yaml#L1018">otelDeployment.image.registry</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">docker.io</pre>
@@ -1629,7 +1629,7 @@ tag: 0.109.0</pre>
             <td>Docker registry for the OtelDeployment image.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--repository"><a href="./values.yaml#L1016">otelDeployment.image.repository</a></td>
+            <td id="otelDeployment--image--repository"><a href="./values.yaml#L1021">otelDeployment.image.repository</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">otel/opentelemetry-collector-contrib</pre>
@@ -1638,7 +1638,7 @@ tag: 0.109.0</pre>
             <td>Repository for the OtelDeployment image.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--tag"><a href="./values.yaml#L1019">otelDeployment.image.tag</a></td>
+            <td id="otelDeployment--image--tag"><a href="./values.yaml#L1024">otelDeployment.image.tag</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">0.109.0</pre>
@@ -1647,7 +1647,7 @@ tag: 0.109.0</pre>
             <td>Tag for the OtelDeployment image.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--pullPolicy"><a href="./values.yaml#L1022">otelDeployment.image.pullPolicy</a></td>
+            <td id="otelDeployment--image--pullPolicy"><a href="./values.yaml#L1027">otelDeployment.image.pullPolicy</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">IfNotPresent</pre>
@@ -1656,7 +1656,7 @@ tag: 0.109.0</pre>
             <td>Image pull policy for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--imagePullSecrets"><a href="./values.yaml#L1026">otelDeployment.imagePullSecrets</a></td>
+            <td id="otelDeployment--imagePullSecrets"><a href="./values.yaml#L1031">otelDeployment.imagePullSecrets</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1665,7 +1665,7 @@ tag: 0.109.0</pre>
             <td>Image Pull Secrets for the OtelDeployment. Merged with `global.imagePullSecrets`.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--command"><a href="./values.yaml#L1031">otelDeployment.command</a></td>
+            <td id="otelDeployment--command"><a href="./values.yaml#L1036">otelDeployment.command</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">extraArgs: []
@@ -1675,7 +1675,7 @@ name: /otelcol-contrib</pre>
             <td>Command and arguments for the OtelDeployment container.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--command--name"><a href="./values.yaml#L1034">otelDeployment.command.name</a></td>
+            <td id="otelDeployment--command--name"><a href="./values.yaml#L1039">otelDeployment.command.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">/otelcol-contrib</pre>
@@ -1684,7 +1684,7 @@ name: /otelcol-contrib</pre>
             <td>OtelDeployment command name.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--command--extraArgs"><a href="./values.yaml#L1037">otelDeployment.command.extraArgs</a></td>
+            <td id="otelDeployment--command--extraArgs"><a href="./values.yaml#L1042">otelDeployment.command.extraArgs</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1693,7 +1693,7 @@ name: /otelcol-contrib</pre>
             <td>Extra arguments for the OtelDeployment command.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--configMap"><a href="./values.yaml#L1041">otelDeployment.configMap</a></td>
+            <td id="otelDeployment--configMap"><a href="./values.yaml#L1046">otelDeployment.configMap</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">create: true</pre>
@@ -1702,7 +1702,7 @@ name: /otelcol-contrib</pre>
             <td>ConfigMap configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--configMap--create"><a href="./values.yaml#L1044">otelDeployment.configMap.create</a></td>
+            <td id="otelDeployment--configMap--create"><a href="./values.yaml#L1049">otelDeployment.configMap.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1711,7 +1711,7 @@ name: /otelcol-contrib</pre>
             <td>Specifies whether a ConfigMap should be created.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--service"><a href="./values.yaml#L1048">otelDeployment.service</a></td>
+            <td id="otelDeployment--service"><a href="./values.yaml#L1053">otelDeployment.service</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1721,7 +1721,7 @@ type: ClusterIP</pre>
             <td>Service configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--service--annotations"><a href="./values.yaml#L1051">otelDeployment.service.annotations</a></td>
+            <td id="otelDeployment--service--annotations"><a href="./values.yaml#L1056">otelDeployment.service.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1730,7 +1730,7 @@ type: ClusterIP</pre>
             <td>Annotations for the OtelDeployment service.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--service--type"><a href="./values.yaml#L1054">otelDeployment.service.type</a></td>
+            <td id="otelDeployment--service--type"><a href="./values.yaml#L1059">otelDeployment.service.type</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">ClusterIP</pre>
@@ -1739,7 +1739,7 @@ type: ClusterIP</pre>
             <td>Service type.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount"><a href="./values.yaml#L1058">otelDeployment.serviceAccount</a></td>
+            <td id="otelDeployment--serviceAccount"><a href="./values.yaml#L1063">otelDeployment.serviceAccount</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1750,7 +1750,7 @@ name: null</pre>
             <td>ServiceAccount configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount--create"><a href="./values.yaml#L1061">otelDeployment.serviceAccount.create</a></td>
+            <td id="otelDeployment--serviceAccount--create"><a href="./values.yaml#L1066">otelDeployment.serviceAccount.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1759,7 +1759,7 @@ name: null</pre>
             <td>Specifies whether a ServiceAccount should be created.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount--annotations"><a href="./values.yaml#L1064">otelDeployment.serviceAccount.annotations</a></td>
+            <td id="otelDeployment--serviceAccount--annotations"><a href="./values.yaml#L1069">otelDeployment.serviceAccount.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1768,7 +1768,7 @@ name: null</pre>
             <td>Annotations for the ServiceAccount.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount--name"><a href="./values.yaml#L1067">otelDeployment.serviceAccount.name</a></td>
+            <td id="otelDeployment--serviceAccount--name"><a href="./values.yaml#L1072">otelDeployment.serviceAccount.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">null</pre>
@@ -1777,7 +1777,7 @@ name: null</pre>
             <td>The name of the ServiceAccount to use. A name is generated if not set.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--annotations"><a href="./values.yaml#L1071">otelDeployment.annotations</a></td>
+            <td id="otelDeployment--annotations"><a href="./values.yaml#L1076">otelDeployment.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1786,7 +1786,7 @@ name: null</pre>
             <td>Annotations for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--podAnnotations"><a href="./values.yaml#L1074">otelDeployment.podAnnotations</a></td>
+            <td id="otelDeployment--podAnnotations"><a href="./values.yaml#L1079">otelDeployment.podAnnotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1795,7 +1795,7 @@ name: null</pre>
             <td>Annotations for the OtelDeployment pods.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--additionalEnvs"><a href="./values.yaml#L1081">otelDeployment.additionalEnvs</a></td>
+            <td id="otelDeployment--additionalEnvs"><a href="./values.yaml#L1086">otelDeployment.additionalEnvs</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1804,7 +1804,7 @@ name: null</pre>
             <td>Additional environment variables for the OtelDeployment container.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--podSecurityContext"><a href="./values.yaml#L1085">otelDeployment.podSecurityContext</a></td>
+            <td id="otelDeployment--podSecurityContext"><a href="./values.yaml#L1090">otelDeployment.podSecurityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1813,7 +1813,7 @@ name: null</pre>
             <td>Pod-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--securityContext"><a href="./values.yaml#L1090">otelDeployment.securityContext</a></td>
+            <td id="otelDeployment--securityContext"><a href="./values.yaml#L1095">otelDeployment.securityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1822,7 +1822,7 @@ name: null</pre>
             <td>Container-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--minReadySeconds"><a href="./values.yaml#L1100">otelDeployment.minReadySeconds</a></td>
+            <td id="otelDeployment--minReadySeconds"><a href="./values.yaml#L1105">otelDeployment.minReadySeconds</a></td>
             <td>int</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">5</pre>
@@ -1831,7 +1831,7 @@ name: null</pre>
             <td>Minimum number of seconds for which a newly created Pod should be ready.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--progressDeadlineSeconds"><a href="./values.yaml#L1104">otelDeployment.progressDeadlineSeconds</a></td>
+            <td id="otelDeployment--progressDeadlineSeconds"><a href="./values.yaml#L1109">otelDeployment.progressDeadlineSeconds</a></td>
             <td>int</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">120</pre>
@@ -1840,7 +1840,7 @@ name: null</pre>
             <td>Seconds to wait for the Deployment to progress before it's considered failed.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports"><a href="./values.yaml#L1108">otelDeployment.ports</a></td>
+            <td id="otelDeployment--ports"><a href="./values.yaml#L1113">otelDeployment.ports</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">health-check:
@@ -1872,7 +1872,7 @@ zpages:
             <td>Port configurations for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--metrics--enabled"><a href="./values.yaml#L1113">otelDeployment.ports.metrics.enabled</a></td>
+            <td id="otelDeployment--ports--metrics--enabled"><a href="./values.yaml#L1118">otelDeployment.ports.metrics.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1881,7 +1881,7 @@ zpages:
             <td>Enable service port for internal metrics.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--zpages--enabled"><a href="./values.yaml#L1126">otelDeployment.ports.zpages.enabled</a></td>
+            <td id="otelDeployment--ports--zpages--enabled"><a href="./values.yaml#L1131">otelDeployment.ports.zpages.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1890,7 +1890,7 @@ zpages:
             <td>Enable service port for ZPages.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--health-check--enabled"><a href="./values.yaml#L1139">otelDeployment.ports.health-check.enabled</a></td>
+            <td id="otelDeployment--ports--health-check--enabled"><a href="./values.yaml#L1144">otelDeployment.ports.health-check.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1899,7 +1899,7 @@ zpages:
             <td>Enable service port for health checks.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--pprof--enabled"><a href="./values.yaml#L1152">otelDeployment.ports.pprof.enabled</a></td>
+            <td id="otelDeployment--ports--pprof--enabled"><a href="./values.yaml#L1157">otelDeployment.ports.pprof.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1908,7 +1908,7 @@ zpages:
             <td>Enable service port for pprof.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--livenessProbe"><a href="./values.yaml#L1164">otelDeployment.livenessProbe</a></td>
+            <td id="otelDeployment--livenessProbe"><a href="./values.yaml#L1169">otelDeployment.livenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
@@ -1924,7 +1924,7 @@ timeoutSeconds: 5</pre>
             <td>Configure liveness probe.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--readinessProbe"><a href="./values.yaml#L1184">otelDeployment.readinessProbe</a></td>
+            <td id="otelDeployment--readinessProbe"><a href="./values.yaml#L1189">otelDeployment.readinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
@@ -1940,7 +1940,7 @@ timeoutSeconds: 5</pre>
             <td>Configure readiness probe.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--customLivenessProbe"><a href="./values.yaml#L1204">otelDeployment.customLivenessProbe</a></td>
+            <td id="otelDeployment--customLivenessProbe"><a href="./values.yaml#L1209">otelDeployment.customLivenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1949,7 +1949,7 @@ timeoutSeconds: 5</pre>
             <td>Custom liveness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--customReadinessProbe"><a href="./values.yaml#L1208">otelDeployment.customReadinessProbe</a></td>
+            <td id="otelDeployment--customReadinessProbe"><a href="./values.yaml#L1213">otelDeployment.customReadinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1958,7 +1958,7 @@ timeoutSeconds: 5</pre>
             <td>Custom readiness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress"><a href="./values.yaml#L1212">otelDeployment.ingress</a></td>
+            <td id="otelDeployment--ingress"><a href="./values.yaml#L1217">otelDeployment.ingress</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1976,7 +1976,7 @@ tls: []</pre>
             <td>Ingress configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--enabled"><a href="./values.yaml#L1215">otelDeployment.ingress.enabled</a></td>
+            <td id="otelDeployment--ingress--enabled"><a href="./values.yaml#L1220">otelDeployment.ingress.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1985,7 +1985,7 @@ tls: []</pre>
             <td>Enable Ingress for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--className"><a href="./values.yaml#L1218">otelDeployment.ingress.className</a></td>
+            <td id="otelDeployment--ingress--className"><a href="./values.yaml#L1223">otelDeployment.ingress.className</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -1994,7 +1994,7 @@ tls: []</pre>
             <td>Ingress Class Name to be used.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--annotations"><a href="./values.yaml#L1221">otelDeployment.ingress.annotations</a></td>
+            <td id="otelDeployment--ingress--annotations"><a href="./values.yaml#L1226">otelDeployment.ingress.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -2003,7 +2003,7 @@ tls: []</pre>
             <td>Annotations for the OtelDeployment Ingress.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--hosts"><a href="./values.yaml#L1224">otelDeployment.ingress.hosts</a></td>
+            <td id="otelDeployment--ingress--hosts"><a href="./values.yaml#L1229">otelDeployment.ingress.hosts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- host: otel-deployment.domain.com
@@ -2016,7 +2016,7 @@ tls: []</pre>
             <td>OtelDeployment Ingress hostnames.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--tls"><a href="./values.yaml#L1232">otelDeployment.ingress.tls</a></td>
+            <td id="otelDeployment--ingress--tls"><a href="./values.yaml#L1237">otelDeployment.ingress.tls</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -2025,7 +2025,7 @@ tls: []</pre>
             <td>OtelDeployment Ingress TLS configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--resources"><a href="./values.yaml#L1239">otelDeployment.resources</a></td>
+            <td id="otelDeployment--resources"><a href="./values.yaml#L1244">otelDeployment.resources</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">requests:
@@ -2036,7 +2036,7 @@ tls: []</pre>
             <td>Configure resource requests and limits for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--priorityClassName"><a href="./values.yaml#L1250">otelDeployment.priorityClassName</a></td>
+            <td id="otelDeployment--priorityClassName"><a href="./values.yaml#L1255">otelDeployment.priorityClassName</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -2045,7 +2045,7 @@ tls: []</pre>
             <td>OtelDeployment Priority Class name.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--nodeSelector"><a href="./values.yaml#L1254">otelDeployment.nodeSelector</a></td>
+            <td id="otelDeployment--nodeSelector"><a href="./values.yaml#L1259">otelDeployment.nodeSelector</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -2054,7 +2054,7 @@ tls: []</pre>
             <td>Node selector for OtelDeployment pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--tolerations"><a href="./values.yaml#L1258">otelDeployment.tolerations</a></td>
+            <td id="otelDeployment--tolerations"><a href="./values.yaml#L1263">otelDeployment.tolerations</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -2063,7 +2063,7 @@ tls: []</pre>
             <td>Toleration labels for OtelDeployment pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--affinity"><a href="./values.yaml#L1262">otelDeployment.affinity</a></td>
+            <td id="otelDeployment--affinity"><a href="./values.yaml#L1267">otelDeployment.affinity</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -2072,7 +2072,7 @@ tls: []</pre>
             <td>Affinity settings for the OtelDeployment pod.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--topologySpreadConstraints"><a href="./values.yaml#L1266">otelDeployment.topologySpreadConstraints</a></td>
+            <td id="otelDeployment--topologySpreadConstraints"><a href="./values.yaml#L1271">otelDeployment.topologySpreadConstraints</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -2081,7 +2081,7 @@ tls: []</pre>
             <td>Describes how OtelDeployment pods ought to spread.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole"><a href="./values.yaml#L1271">otelDeployment.clusterRole</a></td>
+            <td id="otelDeployment--clusterRole"><a href="./values.yaml#L1276">otelDeployment.clusterRole</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please Checkout the values.yml for default values</pre>
@@ -2090,7 +2090,7 @@ tls: []</pre>
             <td>ClusterRole configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--create"><a href="./values.yaml#L1274">otelDeployment.clusterRole.create</a></td>
+            <td id="otelDeployment--clusterRole--create"><a href="./values.yaml#L1279">otelDeployment.clusterRole.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -2099,7 +2099,7 @@ tls: []</pre>
             <td>Specifies whether a ClusterRole should be created.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--annotations"><a href="./values.yaml#L1277">otelDeployment.clusterRole.annotations</a></td>
+            <td id="otelDeployment--clusterRole--annotations"><a href="./values.yaml#L1282">otelDeployment.clusterRole.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -2108,7 +2108,7 @@ tls: []</pre>
             <td>Annotations for the ClusterRole.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--name"><a href="./values.yaml#L1280">otelDeployment.clusterRole.name</a></td>
+            <td id="otelDeployment--clusterRole--name"><a href="./values.yaml#L1285">otelDeployment.clusterRole.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -2117,7 +2117,7 @@ tls: []</pre>
             <td>The name of the ClusterRole to use. A name is generated if not set.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--rules"><a href="./values.yaml#L1284">otelDeployment.clusterRole.rules</a></td>
+            <td id="otelDeployment--clusterRole--rules"><a href="./values.yaml#L1289">otelDeployment.clusterRole.rules</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please checkout the values.yml for default values</pre>
@@ -2126,7 +2126,7 @@ tls: []</pre>
             <td>RBAC rules for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--clusterRoleBinding"><a href="./values.yaml#L1314">otelDeployment.clusterRole.clusterRoleBinding</a></td>
+            <td id="otelDeployment--clusterRole--clusterRoleBinding"><a href="./values.yaml#L1319">otelDeployment.clusterRole.clusterRoleBinding</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -2136,7 +2136,7 @@ name: ""</pre>
             <td>ClusterRoleBinding configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--config"><a href="./values.yaml#L1325">otelDeployment.config</a></td>
+            <td id="otelDeployment--config"><a href="./values.yaml#L1330">otelDeployment.config</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please Checkout the values.yml for default values</pre>
@@ -2145,7 +2145,7 @@ name: ""</pre>
             <td>Base configuration for the OtelDeployment Collector.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--config--processors--batch"><a href="./values.yaml#L1332">otelDeployment.config.processors.batch</a></td>
+            <td id="otelDeployment--config--processors--batch"><a href="./values.yaml#L1337">otelDeployment.config.processors.batch</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">send_batch_size: 10000
@@ -2155,7 +2155,7 @@ timeout: 1s</pre>
             <td>Batch processor config.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--extraVolumes"><a href="./values.yaml#L1372">otelDeployment.extraVolumes</a></td>
+            <td id="otelDeployment--extraVolumes"><a href="./values.yaml#L1377">otelDeployment.extraVolumes</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -2164,7 +2164,7 @@ timeout: 1s</pre>
             <td>Additional volumes for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--extraVolumeMounts"><a href="./values.yaml#L1382">otelDeployment.extraVolumeMounts</a></td>
+            <td id="otelDeployment--extraVolumeMounts"><a href="./values.yaml#L1387">otelDeployment.extraVolumeMounts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>

--- a/charts/k8s-infra/README.md
+++ b/charts/k8s-infra/README.md
@@ -1,7 +1,7 @@
 
 # K8s-Infra
 
-![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.109.0](https://img.shields.io/badge/AppVersion-0.109.0-informational?style=flat-square)
+![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.109.0](https://img.shields.io/badge/AppVersion-0.109.0-informational?style=flat-square)
 
 Monitoring your Kubernetes cluster is essential for ensuring performance, stability, and reliability. The SigNoz k8s-infra Helm chart provides a comprehensive solution for collecting and analyzing metrics, logs, and events from your entire Kubernetes environment.
 

--- a/charts/k8s-infra/README.md
+++ b/charts/k8s-infra/README.md
@@ -18,7 +18,7 @@ The `k8s-infra` chart provides Kubernetes infrastructure observability by deploy
 
 It enables collection of metrics, logs, and events from your Kubernetes cluster, making it easier to monitor and troubleshoot your infrastructure with SigNoz.
 
-Refer to the documentation for a more detailed explanation of [k8s-infra](https://signoz.io/docs/infrastructure-monitoring/k8s-infra-architecture).
+Refer to the documentation for a more detailed explanation of [k8s-infra](https://signoz.io/docs/collection-agents/k8s/k8s-infra/overview/)
 ### Prerequisites
 
 - Kubernetes 1.16+
@@ -360,6 +360,17 @@ storageClass: null</pre>
             </td>
             <td>Presets to easily set up OtelCollector configurations. For more details, see the documentation: https://signoz.io/docs/metrics-management/k8s-infra-otel-config</td>
         </tr>
+    </tbody>
+</table>
+<h3>Logging Exporter Presets</h3>
+<table>
+    <thead>
+        <th>Key</th>
+        <th>Type</th>
+        <th>Default</th>
+        <th>Description</th>
+    </thead>
+    <tbody>
         <tr>
             <td id="presets--loggingExporter"><a href="./values.yaml#L110">presets.loggingExporter</a></td>
             <td>object</td>
@@ -372,6 +383,17 @@ verbosity: basic</pre>
             </td>
             <td>Configuration for the logging exporter, used for debugging telemetry data.</td>
         </tr>
+    </tbody>
+</table>
+<h3>OTLP Exporter Presets</h3>
+<table>
+    <thead>
+        <th>Key</th>
+        <th>Type</th>
+        <th>Default</th>
+        <th>Description</th>
+    </thead>
+    <tbody>
         <tr>
             <td id="presets--otlpExporter"><a href="./values.yaml#L125">presets.otlpExporter</a></td>
             <td>object</td>
@@ -379,10 +401,30 @@ verbosity: basic</pre>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true</pre>
 </div>
             </td>
-            <td>Configuration for the OTLP exporter.</td>
+            <td>OTLP Exporter for the OTLP exporter.</td>
         </tr>
         <tr>
-            <td id="presets--selfTelemetry"><a href="./values.yaml#L136">presets.selfTelemetry</a></td>
+            <td id="presets--otlphttpExporter"><a href="./values.yaml#L132">presets.otlphttpExporter</a></td>
+            <td>object</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">enabled: false</pre>
+</div>
+            </td>
+            <td>OTLP HTTP Exporter to which data will be sent. Set this to true to enable the OTLP HTTP exporter, which uses the HTTP endpoint instead of the gRPC endpoint.</td>
+        </tr>
+    </tbody>
+</table>
+<h3>Self Telemetry Presets</h3>
+<table>
+    <thead>
+        <th>Key</th>
+        <th>Type</th>
+        <th>Default</th>
+        <th>Description</th>
+    </thead>
+    <tbody>
+        <tr>
+            <td id="presets--selfTelemetry"><a href="./values.yaml#L138">presets.selfTelemetry</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">apiKeyExistingSecretKey: ""
@@ -402,7 +444,7 @@ traces:
             <td>Configuration for sending the collector's own telemetry data.</td>
         </tr>
         <tr>
-            <td id="presets--selfTelemetry--endpoint"><a href="./values.yaml#L139">presets.selfTelemetry.endpoint</a></td>
+            <td id="presets--selfTelemetry--endpoint"><a href="./values.yaml#L141">presets.selfTelemetry.endpoint</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -411,7 +453,7 @@ traces:
             <td>OTLP HTTP endpoint to send own telemetry data to.</td>
         </tr>
         <tr>
-            <td id="presets--selfTelemetry--traces--enabled"><a href="./values.yaml#L160">presets.selfTelemetry.traces.enabled</a></td>
+            <td id="presets--selfTelemetry--traces--enabled"><a href="./values.yaml#L162">presets.selfTelemetry.traces.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -420,7 +462,7 @@ traces:
             <td>Enable self-telemetry for traces.</td>
         </tr>
         <tr>
-            <td id="presets--selfTelemetry--metrics--enabled"><a href="./values.yaml#L166">presets.selfTelemetry.metrics.enabled</a></td>
+            <td id="presets--selfTelemetry--metrics--enabled"><a href="./values.yaml#L168">presets.selfTelemetry.metrics.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -429,7 +471,7 @@ traces:
             <td>Enable self-telemetry for metrics.</td>
         </tr>
         <tr>
-            <td id="presets--selfTelemetry--logs"><a href="./values.yaml#L169">presets.selfTelemetry.logs</a></td>
+            <td id="presets--selfTelemetry--logs"><a href="./values.yaml#L171">presets.selfTelemetry.logs</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: false</pre>
@@ -438,7 +480,7 @@ traces:
             <td>Configuration for self-telemetry logs.</td>
         </tr>
         <tr>
-            <td id="presets--selfTelemetry--logs--enabled"><a href="./values.yaml#L172">presets.selfTelemetry.logs.enabled</a></td>
+            <td id="presets--selfTelemetry--logs--enabled"><a href="./values.yaml#L174">presets.selfTelemetry.logs.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -446,42 +488,28 @@ traces:
             </td>
             <td>Enable self-telemetry for logs.</td>
         </tr>
+    </tbody>
+</table>
+<h3>Logs Collection Presets</h3>
+<table>
+    <thead>
+        <th>Key</th>
+        <th>Type</th>
+        <th>Default</th>
+        <th>Description</th>
+    </thead>
+    <tbody>
         <tr>
-            <td id="presets--logsCollection"><a href="./values.yaml#L175">presets.logsCollection</a></td>
+            <td id="presets--logsCollection"><a href="./values.yaml#L178">presets.logsCollection</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">blacklist:
-    additionalExclude: []
-    containers: []
-    enabled: true
-    namespaces:
-        - kube-system
-    pods:
-        - hotrod
-        - locust
-    signozLogs: true
-enabled: true
-include:
-    - /var/log/pods/*/*/*.log
-includeFileName: false
-includeFilePath: true
-operators:
-    - id: container-parser
-      type: container
-startAt: end
-whitelist:
-    additionalInclude: []
-    containers: []
-    enabled: false
-    namespaces: []
-    pods: []
-    signozLogs: true</pre>
+                <div style="max-width: 300px;"><pre lang="tpl/array">Please check out the values.yml for default values</pre>
 </div>
             </td>
             <td>Configuration for collecting logs from pods.</td>
         </tr>
         <tr>
-            <td id="presets--logsCollection--enabled"><a href="./values.yaml#L178">presets.logsCollection.enabled</a></td>
+            <td id="presets--logsCollection--enabled"><a href="./values.yaml#L181">presets.logsCollection.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -490,7 +518,7 @@ whitelist:
             <td>Enable log collection.</td>
         </tr>
         <tr>
-            <td id="presets--logsCollection--startAt"><a href="./values.yaml#L181">presets.logsCollection.startAt</a></td>
+            <td id="presets--logsCollection--startAt"><a href="./values.yaml#L184">presets.logsCollection.startAt</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">end</pre>
@@ -499,7 +527,51 @@ whitelist:
             <td>Where to start reading logs from: `end` or `beginning`.</td>
         </tr>
         <tr>
-            <td id="presets--logsCollection--whitelist"><a href="./values.yaml#L218">presets.logsCollection.whitelist</a></td>
+            <td id="presets--logsCollection--includeFilePath"><a href="./values.yaml#L187">presets.logsCollection.includeFilePath</a></td>
+            <td>bool</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+</div>
+            </td>
+            <td>Include the log file path as an attribute.</td>
+        </tr>
+        <tr>
+            <td id="presets--logsCollection--includeFileName"><a href="./values.yaml#L190">presets.logsCollection.includeFileName</a></td>
+            <td>bool</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+</div>
+            </td>
+            <td>Include the log file name as an attribute.</td>
+        </tr>
+        <tr>
+            <td id="presets--logsCollection--include"><a href="./values.yaml#L193">presets.logsCollection.include</a></td>
+            <td>list</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">- /var/log/pods/*/*/*.log</pre>
+</div>
+            </td>
+            <td>Include path patterns for log files to be collected. By default, all container logs are collected.</td>
+        </tr>
+        <tr>
+            <td id="presets--logsCollection--blacklist"><a href="./values.yaml#L197">presets.logsCollection.blacklist</a></td>
+            <td>object</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">additionalExclude: []
+containers: []
+enabled: true
+namespaces:
+    - kube-system
+pods:
+    - hotrod
+    - locust
+signozLogs: true</pre>
+</div>
+            </td>
+            <td>Exclude certain log files from being collected.</td>
+        </tr>
+        <tr>
+            <td id="presets--logsCollection--whitelist"><a href="./values.yaml#L221">presets.logsCollection.whitelist</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">additionalInclude: []
@@ -513,61 +585,7 @@ signozLogs: true</pre>
             <td>Whitelist certain log files to be collected. If enabled, `include` is ignored.</td>
         </tr>
         <tr>
-            <td id="presets--logsCollection--whitelist--enabled"><a href="./values.yaml#L221">presets.logsCollection.whitelist.enabled</a></td>
-            <td>bool</td>
-            <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
-</div>
-            </td>
-            <td>Enable the whitelist.</td>
-        </tr>
-        <tr>
-            <td id="presets--logsCollection--whitelist--signozLogs"><a href="./values.yaml#L224">presets.logsCollection.whitelist.signozLogs</a></td>
-            <td>bool</td>
-            <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
-</div>
-            </td>
-            <td>Include SigNoz's own logs.</td>
-        </tr>
-        <tr>
-            <td id="presets--logsCollection--whitelist--namespaces"><a href="./values.yaml#L227">presets.logsCollection.whitelist.namespaces</a></td>
-            <td>list</td>
-            <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
-</div>
-            </td>
-            <td>List of namespaces to include in log collection.</td>
-        </tr>
-        <tr>
-            <td id="presets--logsCollection--whitelist--pods"><a href="./values.yaml#L230">presets.logsCollection.whitelist.pods</a></td>
-            <td>list</td>
-            <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
-</div>
-            </td>
-            <td>List of pod names to include.</td>
-        </tr>
-        <tr>
-            <td id="presets--logsCollection--whitelist--containers"><a href="./values.yaml#L233">presets.logsCollection.whitelist.containers</a></td>
-            <td>list</td>
-            <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
-</div>
-            </td>
-            <td>List of container names to include.</td>
-        </tr>
-        <tr>
-            <td id="presets--logsCollection--whitelist--additionalInclude"><a href="./values.yaml#L236">presets.logsCollection.whitelist.additionalInclude</a></td>
-            <td>list</td>
-            <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
-</div>
-            </td>
-            <td>List of additional file path patterns to include.</td>
-        </tr>
-        <tr>
-            <td id="presets--logsCollection--operators"><a href="./values.yaml#L239">presets.logsCollection.operators</a></td>
+            <td id="presets--logsCollection--operators"><a href="./values.yaml#L242">presets.logsCollection.operators</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- id: container-parser
@@ -576,88 +594,28 @@ signozLogs: true</pre>
             </td>
             <td>A list of log processing operators.</td>
         </tr>
+    </tbody>
+</table>
+<h3>Host Metrics Presets</h3>
+<table>
+    <thead>
+        <th>Key</th>
+        <th>Type</th>
+        <th>Default</th>
+        <th>Description</th>
+    </thead>
+    <tbody>
         <tr>
-            <td id="presets--hostMetrics"><a href="./values.yaml#L244">presets.hostMetrics</a></td>
+            <td id="presets--hostMetrics"><a href="./values.yaml#L248">presets.hostMetrics</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">collectionInterval: 30s
-enabled: true
-scrapers:
-    cpu: {}
-    disk:
-        exclude:
-            devices:
-                - ^ram\d+$
-                - ^zram\d+$
-                - ^loop\d+$
-                - ^fd\d+$
-                - ^hd[a-z]\d+$
-                - ^sd[a-z]\d+$
-                - ^vd[a-z]\d+$
-                - ^xvd[a-z]\d+$
-                - ^nvme\d+n\d+p\d+$
-            match_type: regexp
-    filesystem:
-        exclude_fs_types:
-            fs_types:
-                - autofs
-                - binfmt_misc
-                - bpf
-                - cgroup2?
-                - configfs
-                - debugfs
-                - devpts
-                - devtmpfs
-                - fusectl
-                - hugetlbfs
-                - iso9660
-                - mqueue
-                - nsfs
-                - overlay
-                - proc
-                - procfs
-                - pstore
-                - rpc_pipefs
-                - securityfs
-                - selinuxfs
-                - squashfs
-                - sysfs
-                - tracefs
-            match_type: strict
-        exclude_mount_points:
-            match_type: regexp
-            mount_points:
-                - /dev/*
-                - /proc/*
-                - /sys/*
-                - /run/credentials/*
-                - /run/k3s/containerd/*
-                - /var/lib/docker/*
-                - /var/lib/containers/storage/*
-                - /var/lib/kubelet/*
-                - /snap/*
-    load: {}
-    memory: {}
-    network:
-        exclude:
-            interfaces:
-                - ^veth.*$
-                - ^docker.*$
-                - ^br-.*$
-                - ^flannel.*$
-                - ^cali.*$
-                - ^cbr.*$
-                - ^cni.*$
-                - ^dummy.*$
-                - ^tailscale.*$
-                - ^lo$
-            match_type: regexp</pre>
+                <div style="max-width: 300px;"><pre lang="tpl/array">Please check out the values.yml for default values</pre>
 </div>
             </td>
             <td>Configuration for collecting host-level metrics from nodes.</td>
         </tr>
         <tr>
-            <td id="presets--hostMetrics--enabled"><a href="./values.yaml#L247">presets.hostMetrics.enabled</a></td>
+            <td id="presets--hostMetrics--enabled"><a href="./values.yaml#L251">presets.hostMetrics.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -666,57 +624,113 @@ scrapers:
             <td>Enable host metrics collection.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics"><a href="./values.yaml#L325">presets.kubeletMetrics</a></td>
+            <td id="presets--hostMetrics--collectionInterval"><a href="./values.yaml#L254">presets.hostMetrics.collectionInterval</a></td>
+            <td>string</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">30s</pre>
+</div>
+            </td>
+            <td>Frequency at which to scrape host metrics.</td>
+        </tr>
+        <tr>
+            <td id="presets--hostMetrics--scrapers"><a href="./values.yaml#L258">presets.hostMetrics.scrapers</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">authType: serviceAccount
-collectionInterval: 30s
-enabled: true
-endpoint: ${env:K8S_HOST_IP}:10250
-extraMetadataLabels:
-    - container.id
-    - k8s.volume.type
-insecureSkipVerify: true
-metricGroups:
-    - container
-    - pod
-    - node
-    - volume
-metrics:
-    container.cpu.usage:
-        enabled: true
-    container.uptime:
-        enabled: true
-    k8s.container.cpu_limit_utilization:
-        enabled: true
-    k8s.container.cpu_request_utilization:
-        enabled: true
-    k8s.container.memory_limit_utilization:
-        enabled: true
-    k8s.container.memory_request_utilization:
-        enabled: true
-    k8s.node.cpu.usage:
-        enabled: true
-    k8s.node.uptime:
-        enabled: true
-    k8s.pod.cpu.usage:
-        enabled: true
-    k8s.pod.cpu_limit_utilization:
-        enabled: true
-    k8s.pod.cpu_request_utilization:
-        enabled: true
-    k8s.pod.memory_limit_utilization:
-        enabled: true
-    k8s.pod.memory_request_utilization:
-        enabled: true
-    k8s.pod.uptime:
-        enabled: true</pre>
+                <div style="max-width: 300px;"><pre lang="tpl/array">Please check out the values.yml for default values</pre>
+</div>
+            </td>
+            <td>Fine-grained control over which host metric scrapers are enabled.</td>
+        </tr>
+        <tr>
+            <td id="presets--hostMetrics--scrapers--cpu"><a href="./values.yaml#L261">presets.hostMetrics.scrapers.cpu</a></td>
+            <td>object</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+</div>
+            </td>
+            <td>Enable CPU metrics collection.</td>
+        </tr>
+        <tr>
+            <td id="presets--hostMetrics--scrapers--load"><a href="./values.yaml#L264">presets.hostMetrics.scrapers.load</a></td>
+            <td>object</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+</div>
+            </td>
+            <td>Enable load metrics collection.</td>
+        </tr>
+        <tr>
+            <td id="presets--hostMetrics--scrapers--memory"><a href="./values.yaml#L267">presets.hostMetrics.scrapers.memory</a></td>
+            <td>object</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
+</div>
+            </td>
+            <td>Enable memory metrics collection.</td>
+        </tr>
+        <tr>
+            <td id="presets--hostMetrics--scrapers--disk"><a href="./values.yaml#L270">presets.hostMetrics.scrapers.disk</a></td>
+            <td>object</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">exclude:
+    devices:
+        - ^ram\d+$
+        - ^zram\d+$
+        - ^loop\d+$
+        - ^fd\d+$
+        - ^hd[a-z]\d+$
+        - ^sd[a-z]\d+$
+        - ^vd[a-z]\d+$
+        - ^xvd[a-z]\d+$
+        - ^nvme\d+n\d+p\d+$
+    match_type: regexp</pre>
+</div>
+            </td>
+            <td>Enable disk metrics collection.</td>
+        </tr>
+        <tr>
+            <td id="presets--hostMetrics--scrapers--network"><a href="./values.yaml#L326">presets.hostMetrics.scrapers.network</a></td>
+            <td>object</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">exclude:
+    interfaces:
+        - ^veth.*$
+        - ^docker.*$
+        - ^br-.*$
+        - ^flannel.*$
+        - ^cali.*$
+        - ^cbr.*$
+        - ^cni.*$
+        - ^dummy.*$
+        - ^tailscale.*$
+        - ^lo$
+    match_type: regexp</pre>
+</div>
+            </td>
+            <td>Enable network metrics collection.</td>
+        </tr>
+    </tbody>
+</table>
+<h3>Kubelet Metrics Presets</h3>
+<table>
+    <thead>
+        <th>Key</th>
+        <th>Type</th>
+        <th>Default</th>
+        <th>Description</th>
+    </thead>
+    <tbody>
+        <tr>
+            <td id="presets--kubeletMetrics"><a href="./values.yaml#L343">presets.kubeletMetrics</a></td>
+            <td>object</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">Please check out the values.yml for default values</pre>
 </div>
             </td>
             <td>Configuration for collecting metrics from Kubelet.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics--enabled"><a href="./values.yaml#L328">presets.kubeletMetrics.enabled</a></td>
+            <td id="presets--kubeletMetrics--enabled"><a href="./values.yaml#L346">presets.kubeletMetrics.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -725,7 +739,25 @@ metrics:
             <td>Enable Kubelet metrics collection.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics--endpoint"><a href="./values.yaml#L337">presets.kubeletMetrics.endpoint</a></td>
+            <td id="presets--kubeletMetrics--collectionInterval"><a href="./values.yaml#L349">presets.kubeletMetrics.collectionInterval</a></td>
+            <td>string</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">30s</pre>
+</div>
+            </td>
+            <td>Frequency at which to scrape Kubelet metrics.</td>
+        </tr>
+        <tr>
+            <td id="presets--kubeletMetrics--authType"><a href="./values.yaml#L352">presets.kubeletMetrics.authType</a></td>
+            <td>string</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">serviceAccount</pre>
+</div>
+            </td>
+            <td>Authentication type to use with Kubelet: `serviceAccount` or `tls`.</td>
+        </tr>
+        <tr>
+            <td id="presets--kubeletMetrics--endpoint"><a href="./values.yaml#L355">presets.kubeletMetrics.endpoint</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">${env:K8S_HOST_IP}:10250</pre>
@@ -734,7 +766,7 @@ metrics:
             <td>Kubelet endpoint.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics--insecureSkipVerify"><a href="./values.yaml#L340">presets.kubeletMetrics.insecureSkipVerify</a></td>
+            <td id="presets--kubeletMetrics--insecureSkipVerify"><a href="./values.yaml#L358">presets.kubeletMetrics.insecureSkipVerify</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -743,7 +775,7 @@ metrics:
             <td>Skip verifying Kubelet's certificate.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics--extraMetadataLabels"><a href="./values.yaml#L343">presets.kubeletMetrics.extraMetadataLabels</a></td>
+            <td id="presets--kubeletMetrics--extraMetadataLabels"><a href="./values.yaml#L361">presets.kubeletMetrics.extraMetadataLabels</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- container.id
@@ -753,7 +785,7 @@ metrics:
             <td>List of extra metadata labels to collect.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics--metricGroups"><a href="./values.yaml#L348">presets.kubeletMetrics.metricGroups</a></td>
+            <td id="presets--kubeletMetrics--metricGroups"><a href="./values.yaml#L366">presets.kubeletMetrics.metricGroups</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- container
@@ -765,42 +797,63 @@ metrics:
             <td>Groups of metrics to collect from Kubelet.</td>
         </tr>
         <tr>
-            <td id="presets--kubernetesAttributes"><a href="./values.yaml#L386">presets.kubernetesAttributes</a></td>
+            <td id="presets--kubeletMetrics--metrics"><a href="./values.yaml#L373">presets.kubeletMetrics.metrics</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
-extractAnnotations: []
-extractLabels: []
-extractMetadatas:
-    - k8s.namespace.name
-    - k8s.deployment.name
-    - k8s.statefulset.name
-    - k8s.daemonset.name
-    - k8s.cronjob.name
-    - k8s.job.name
-    - k8s.node.name
-    - k8s.node.uid
-    - k8s.pod.name
-    - k8s.pod.uid
-    - k8s.pod.start_time
-filter:
-    node_from_env_var: K8S_NODE_NAME
-passthrough: false
-podAssociation:
-    - sources:
-        - from: resource_attribute
-          name: k8s.pod.ip
-    - sources:
-        - from: resource_attribute
-          name: k8s.pod.uid
-    - sources:
-        - from: connection</pre>
+                <div style="max-width: 300px;"><pre lang="tpl/array">container.cpu.usage:
+    enabled: true
+container.uptime:
+    enabled: true
+k8s.container.cpu_limit_utilization:
+    enabled: true
+k8s.container.cpu_request_utilization:
+    enabled: true
+k8s.container.memory_limit_utilization:
+    enabled: true
+k8s.container.memory_request_utilization:
+    enabled: true
+k8s.node.cpu.usage:
+    enabled: true
+k8s.node.uptime:
+    enabled: true
+k8s.pod.cpu.usage:
+    enabled: true
+k8s.pod.cpu_limit_utilization:
+    enabled: true
+k8s.pod.cpu_request_utilization:
+    enabled: true
+k8s.pod.memory_limit_utilization:
+    enabled: true
+k8s.pod.memory_request_utilization:
+    enabled: true
+k8s.pod.uptime:
+    enabled: true</pre>
+</div>
+            </td>
+            <td>Fine-grained control over which Kubelet metrics are enabled.</td>
+        </tr>
+    </tbody>
+</table>
+<h3>Kubernetes Attributes Processor Presets</h3>
+<table>
+    <thead>
+        <th>Key</th>
+        <th>Type</th>
+        <th>Default</th>
+        <th>Description</th>
+    </thead>
+    <tbody>
+        <tr>
+            <td id="presets--kubernetesAttributes"><a href="./values.yaml#L405">presets.kubernetesAttributes</a></td>
+            <td>object</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">Please check out the values.yml for default values</pre>
 </div>
             </td>
             <td>Processor for adding Kubernetes attributes to telemetry data.</td>
         </tr>
         <tr>
-            <td id="presets--kubernetesAttributes--enabled"><a href="./values.yaml#L389">presets.kubernetesAttributes.enabled</a></td>
+            <td id="presets--kubernetesAttributes--enabled"><a href="./values.yaml#L408">presets.kubernetesAttributes.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -809,42 +862,107 @@ podAssociation:
             <td>Enable the Kubernetes attributes processor.</td>
         </tr>
         <tr>
-            <td id="presets--clusterMetrics"><a href="./values.yaml#L432">presets.clusterMetrics</a></td>
+            <td id="presets--kubernetesAttributes--passthrough"><a href="./values.yaml#L411">presets.kubernetesAttributes.passthrough</a></td>
+            <td>bool</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+</div>
+            </td>
+            <td>If true, agents will not make k8s API calls, do discovery, or extract metadata.</td>
+        </tr>
+        <tr>
+            <td id="presets--kubernetesAttributes--filter"><a href="./values.yaml#L414">presets.kubernetesAttributes.filter</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="tpl/array">allocatableTypesToReport:
-    - cpu
-    - memory
-collectionInterval: 30s
-enabled: true
-metrics:
-    k8s.node.condition:
-        enabled: true
-    k8s.pod.status_reason:
-        enabled: true
-nodeConditionsToReport:
-    - Ready
-    - MemoryPressure
-    - DiskPressure
-    - PIDPressure
-    - NetworkUnavailable
-resourceAttributes:
-    container.runtime:
-        enabled: true
-    container.runtime.version:
-        enabled: true
-    k8s.container.status.last_terminated_reason:
-        enabled: true
-    k8s.kubelet.version:
-        enabled: true
-    k8s.pod.qos_class:
-        enabled: true</pre>
+                <div style="max-width: 300px;"><pre lang="tpl/array">node_from_env_var: K8S_NODE_NAME</pre>
+</div>
+            </td>
+            <td>Limit agents to query pods based on specific selectors to reduce resource usage.</td>
+        </tr>
+        <tr>
+            <td id="presets--kubernetesAttributes--filter--node_from_env_var"><a href="./values.yaml#L417">presets.kubernetesAttributes.filter.node_from_env_var</a></td>
+            <td>string</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">K8S_NODE_NAME</pre>
+</div>
+            </td>
+            <td>Restrict each agent to query pods on the same node.</td>
+        </tr>
+        <tr>
+            <td id="presets--kubernetesAttributes--podAssociation"><a href="./values.yaml#L420">presets.kubernetesAttributes.podAssociation</a></td>
+            <td>list</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">- sources:
+    - from: resource_attribute
+      name: k8s.pod.ip
+- sources:
+    - from: resource_attribute
+      name: k8s.pod.uid
+- sources:
+    - from: connection</pre>
+</div>
+            </td>
+            <td>Rules for tagging telemetry with pod metadata.</td>
+        </tr>
+        <tr>
+            <td id="presets--kubernetesAttributes--extractMetadatas"><a href="./values.yaml#L431">presets.kubernetesAttributes.extractMetadatas</a></td>
+            <td>list</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">- k8s.namespace.name
+- k8s.deployment.name
+- k8s.statefulset.name
+- k8s.daemonset.name
+- k8s.cronjob.name
+- k8s.job.name
+- k8s.node.name
+- k8s.node.uid
+- k8s.pod.name
+- k8s.pod.uid
+- k8s.pod.start_time</pre>
+</div>
+            </td>
+            <td>Pod/namespace metadata to extract from a list of default metadata fields.</td>
+        </tr>
+        <tr>
+            <td id="presets--kubernetesAttributes--extractLabels"><a href="./values.yaml#L445">presets.kubernetesAttributes.extractLabels</a></td>
+            <td>list</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+</div>
+            </td>
+            <td>Pod labels to extract as attributes.</td>
+        </tr>
+        <tr>
+            <td id="presets--kubernetesAttributes--extractAnnotations"><a href="./values.yaml#L448">presets.kubernetesAttributes.extractAnnotations</a></td>
+            <td>list</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+</div>
+            </td>
+            <td>Pod annotations to extract as attributes.</td>
+        </tr>
+    </tbody>
+</table>
+<h3>Cluster Metrics Presets</h3>
+<table>
+    <thead>
+        <th>Key</th>
+        <th>Type</th>
+        <th>Default</th>
+        <th>Description</th>
+    </thead>
+    <tbody>
+        <tr>
+            <td id="presets--clusterMetrics"><a href="./values.yaml#L452">presets.clusterMetrics</a></td>
+            <td>object</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">Please check out the values.yml for default values</pre>
 </div>
             </td>
             <td>Configuration for collecting cluster-level metrics.</td>
         </tr>
         <tr>
-            <td id="presets--clusterMetrics--enabled"><a href="./values.yaml#L435">presets.clusterMetrics.enabled</a></td>
+            <td id="presets--clusterMetrics--enabled"><a href="./values.yaml#L455">presets.clusterMetrics.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -853,7 +971,16 @@ resourceAttributes:
             <td>Enable cluster metrics collection.</td>
         </tr>
         <tr>
-            <td id="presets--clusterMetrics--resourceAttributes"><a href="./values.yaml#L441">presets.clusterMetrics.resourceAttributes</a></td>
+            <td id="presets--clusterMetrics--collectionInterval"><a href="./values.yaml#L458">presets.clusterMetrics.collectionInterval</a></td>
+            <td>string</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">30s</pre>
+</div>
+            </td>
+            <td>Frequency at which to scrape cluster metrics.</td>
+        </tr>
+        <tr>
+            <td id="presets--clusterMetrics--resourceAttributes"><a href="./values.yaml#L461">presets.clusterMetrics.resourceAttributes</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">container.runtime:
@@ -871,7 +998,7 @@ k8s.pod.qos_class:
             <td>Resource attributes to report.</td>
         </tr>
         <tr>
-            <td id="presets--clusterMetrics--nodeConditionsToReport"><a href="./values.yaml#L454">presets.clusterMetrics.nodeConditionsToReport</a></td>
+            <td id="presets--clusterMetrics--nodeConditionsToReport"><a href="./values.yaml#L474">presets.clusterMetrics.nodeConditionsToReport</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- Ready
@@ -884,7 +1011,7 @@ k8s.pod.qos_class:
             <td>Node conditions to report as metrics.</td>
         </tr>
         <tr>
-            <td id="presets--clusterMetrics--allocatableTypesToReport"><a href="./values.yaml#L462">presets.clusterMetrics.allocatableTypesToReport</a></td>
+            <td id="presets--clusterMetrics--allocatableTypesToReport"><a href="./values.yaml#L482">presets.clusterMetrics.allocatableTypesToReport</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- cpu
@@ -894,7 +1021,7 @@ k8s.pod.qos_class:
             <td>Allocatable resource types to report.</td>
         </tr>
         <tr>
-            <td id="presets--clusterMetrics--metrics"><a href="./values.yaml#L469">presets.clusterMetrics.metrics</a></td>
+            <td id="presets--clusterMetrics--metrics"><a href="./values.yaml#L489">presets.clusterMetrics.metrics</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">k8s.node.condition:
@@ -905,8 +1032,19 @@ k8s.pod.status_reason:
             </td>
             <td>Fine-grained control over which cluster metrics are enabled.</td>
         </tr>
+    </tbody>
+</table>
+<h3>Prometheus Metrics Presets</h3>
+<table>
+    <thead>
+        <th>Key</th>
+        <th>Type</th>
+        <th>Default</th>
+        <th>Description</th>
+    </thead>
+    <tbody>
         <tr>
-            <td id="presets--prometheus"><a href="./values.yaml#L476">presets.prometheus</a></td>
+            <td id="presets--prometheus"><a href="./values.yaml#L496">presets.prometheus</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotationsPrefix: signoz.io
@@ -921,7 +1059,7 @@ scrapeInterval: 60s</pre>
             <td>Configuration for scraping Prometheus metrics from pod annotations.</td>
         </tr>
         <tr>
-            <td id="presets--prometheus--enabled"><a href="./values.yaml#L479">presets.prometheus.enabled</a></td>
+            <td id="presets--prometheus--enabled"><a href="./values.yaml#L499">presets.prometheus.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -930,7 +1068,72 @@ scrapeInterval: 60s</pre>
             <td>Enable Prometheus metrics scraping.</td>
         </tr>
         <tr>
-            <td id="presets--resourceDetection"><a href="./values.yaml#L500">presets.resourceDetection</a></td>
+            <td id="presets--prometheus--annotationsPrefix"><a href="./values.yaml#L502">presets.prometheus.annotationsPrefix</a></td>
+            <td>string</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">signoz.io</pre>
+</div>
+            </td>
+            <td>Prefix for the pod annotations used for metrics scraping (e.g., `signoz.io`).</td>
+        </tr>
+        <tr>
+            <td id="presets--prometheus--scrapeInterval"><a href="./values.yaml#L505">presets.prometheus.scrapeInterval</a></td>
+            <td>string</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">60s</pre>
+</div>
+            </td>
+            <td>How often to scrape metrics.</td>
+        </tr>
+        <tr>
+            <td id="presets--prometheus--namespaceScoped"><a href="./values.yaml#L508">presets.prometheus.namespaceScoped</a></td>
+            <td>bool</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+</div>
+            </td>
+            <td>Only scrape metrics from pods in the same namespace.</td>
+        </tr>
+        <tr>
+            <td id="presets--prometheus--namespaces"><a href="./values.yaml#L511">presets.prometheus.namespaces</a></td>
+            <td>list</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
+</div>
+            </td>
+            <td>If set, only scrape metrics from pods in the specified namespaces.</td>
+        </tr>
+        <tr>
+            <td id="presets--prometheus--includePodLabel"><a href="./values.yaml#L514">presets.prometheus.includePodLabel</a></td>
+            <td>bool</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+</div>
+            </td>
+            <td>Include all pod labels in the metrics (can cause high cardinality).</td>
+        </tr>
+        <tr>
+            <td id="presets--prometheus--includeContainerName"><a href="./values.yaml#L517">presets.prometheus.includeContainerName</a></td>
+            <td>bool</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+</div>
+            </td>
+            <td>Include container name in metrics (not recommended for multi-container pods).</td>
+        </tr>
+    </tbody>
+</table>
+<h3>Resource Detection Processor Presets</h3>
+<table>
+    <thead>
+        <th>Key</th>
+        <th>Type</th>
+        <th>Default</th>
+        <th>Description</th>
+    </thead>
+    <tbody>
+        <tr>
+            <td id="presets--resourceDetection"><a href="./values.yaml#L520">presets.resourceDetection</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
@@ -942,7 +1145,54 @@ timeout: 2s</pre>
             <td>Processor for detecting resource information from the environment (e.g., cloud provider, k8s).</td>
         </tr>
         <tr>
-            <td id="presets--k8sEvents"><a href="./values.yaml#L515">presets.k8sEvents</a></td>
+            <td id="presets--resourceDetection--enabled"><a href="./values.yaml#L523">presets.resourceDetection.enabled</a></td>
+            <td>bool</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
+</div>
+            </td>
+            <td>Enable the resource detection processor.</td>
+        </tr>
+        <tr>
+            <td id="presets--resourceDetection--timeout"><a href="./values.yaml#L526">presets.resourceDetection.timeout</a></td>
+            <td>string</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">2s</pre>
+</div>
+            </td>
+            <td>Timeout for resource detection.</td>
+        </tr>
+        <tr>
+            <td id="presets--resourceDetection--override"><a href="./values.yaml#L529">presets.resourceDetection.override</a></td>
+            <td>bool</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
+</div>
+            </td>
+            <td>Whether to override existing resource attributes.</td>
+        </tr>
+        <tr>
+            <td id="presets--resourceDetection--envResourceAttributes"><a href="./values.yaml#L532">presets.resourceDetection.envResourceAttributes</a></td>
+            <td>string</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
+</div>
+            </td>
+            <td>Additional resource attributes from environment variables.</td>
+        </tr>
+    </tbody>
+</table>
+<h3>Kubernetes Events Collection Presets</h3>
+<table>
+    <thead>
+        <th>Key</th>
+        <th>Type</th>
+        <th>Default</th>
+        <th>Description</th>
+    </thead>
+    <tbody>
+        <tr>
+            <td id="presets--k8sEvents"><a href="./values.yaml#L535">presets.k8sEvents</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">authType: serviceAccount
@@ -953,7 +1203,7 @@ namespaces: []</pre>
             <td>Configuration for collecting Kubernetes events as logs.</td>
         </tr>
         <tr>
-            <td id="presets--k8sEvents--enabled"><a href="./values.yaml#L518">presets.k8sEvents.enabled</a></td>
+            <td id="presets--k8sEvents--enabled"><a href="./values.yaml#L538">presets.k8sEvents.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -962,7 +1212,7 @@ namespaces: []</pre>
             <td>Enable Kubernetes events collection.</td>
         </tr>
         <tr>
-            <td id="presets--k8sEvents--authType"><a href="./values.yaml#L521">presets.k8sEvents.authType</a></td>
+            <td id="presets--k8sEvents--authType"><a href="./values.yaml#L541">presets.k8sEvents.authType</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">serviceAccount</pre>
@@ -971,7 +1221,7 @@ namespaces: []</pre>
             <td>Authentication type: `serviceAccount` or `kubeconfig`.</td>
         </tr>
         <tr>
-            <td id="presets--k8sEvents--namespaces"><a href="./values.yaml#L524">presets.k8sEvents.namespaces</a></td>
+            <td id="presets--k8sEvents--namespaces"><a href="./values.yaml#L544">presets.k8sEvents.namespaces</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -991,7 +1241,7 @@ namespaces: []</pre>
     </thead>
     <tbody>
         <tr>
-            <td id="otelAgent--enabled"><a href="./values.yaml#L531">otelAgent.enabled</a></td>
+            <td id="otelAgent--enabled"><a href="./values.yaml#L551">otelAgent.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1000,7 +1250,7 @@ namespaces: []</pre>
             <td>Enable the OtelAgent DaemonSet.</td>
         </tr>
         <tr>
-            <td id="otelAgent--name"><a href="./values.yaml#L534">otelAgent.name</a></td>
+            <td id="otelAgent--name"><a href="./values.yaml#L554">otelAgent.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">otel-agent</pre>
@@ -1009,7 +1259,7 @@ namespaces: []</pre>
             <td>Name of the OtelAgent DaemonSet.</td>
         </tr>
         <tr>
-            <td id="otelAgent--image"><a href="./values.yaml#L537">otelAgent.image</a></td>
+            <td id="otelAgent--image"><a href="./values.yaml#L557">otelAgent.image</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">pullPolicy: IfNotPresent
@@ -1021,7 +1271,7 @@ tag: 0.109.0</pre>
             <td>Image configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--image--registry"><a href="./values.yaml#L540">otelAgent.image.registry</a></td>
+            <td id="otelAgent--image--registry"><a href="./values.yaml#L560">otelAgent.image.registry</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">docker.io</pre>
@@ -1030,7 +1280,7 @@ tag: 0.109.0</pre>
             <td>Docker registry for the OtelAgent image.</td>
         </tr>
         <tr>
-            <td id="otelAgent--image--repository"><a href="./values.yaml#L543">otelAgent.image.repository</a></td>
+            <td id="otelAgent--image--repository"><a href="./values.yaml#L563">otelAgent.image.repository</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">otel/opentelemetry-collector-contrib</pre>
@@ -1039,7 +1289,7 @@ tag: 0.109.0</pre>
             <td>Repository for the OtelAgent image.</td>
         </tr>
         <tr>
-            <td id="otelAgent--image--tag"><a href="./values.yaml#L546">otelAgent.image.tag</a></td>
+            <td id="otelAgent--image--tag"><a href="./values.yaml#L566">otelAgent.image.tag</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">0.109.0</pre>
@@ -1048,7 +1298,7 @@ tag: 0.109.0</pre>
             <td>Tag for the OtelAgent image.</td>
         </tr>
         <tr>
-            <td id="otelAgent--image--pullPolicy"><a href="./values.yaml#L549">otelAgent.image.pullPolicy</a></td>
+            <td id="otelAgent--image--pullPolicy"><a href="./values.yaml#L569">otelAgent.image.pullPolicy</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">IfNotPresent</pre>
@@ -1057,7 +1307,7 @@ tag: 0.109.0</pre>
             <td>Image pull policy for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--imagePullSecrets"><a href="./values.yaml#L553">otelAgent.imagePullSecrets</a></td>
+            <td id="otelAgent--imagePullSecrets"><a href="./values.yaml#L573">otelAgent.imagePullSecrets</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1066,7 +1316,7 @@ tag: 0.109.0</pre>
             <td>Image Pull Secrets for the OtelAgent. Merged with `global.imagePullSecrets`.</td>
         </tr>
         <tr>
-            <td id="otelAgent--command"><a href="./values.yaml#L558">otelAgent.command</a></td>
+            <td id="otelAgent--command"><a href="./values.yaml#L578">otelAgent.command</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">extraArgs: []
@@ -1076,7 +1326,7 @@ name: /otelcol-contrib</pre>
             <td>Command and arguments for the OtelAgent container.</td>
         </tr>
         <tr>
-            <td id="otelAgent--command--name"><a href="./values.yaml#L561">otelAgent.command.name</a></td>
+            <td id="otelAgent--command--name"><a href="./values.yaml#L581">otelAgent.command.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">/otelcol-contrib</pre>
@@ -1085,7 +1335,7 @@ name: /otelcol-contrib</pre>
             <td>OtelAgent command name.</td>
         </tr>
         <tr>
-            <td id="otelAgent--command--extraArgs"><a href="./values.yaml#L564">otelAgent.command.extraArgs</a></td>
+            <td id="otelAgent--command--extraArgs"><a href="./values.yaml#L584">otelAgent.command.extraArgs</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1094,7 +1344,7 @@ name: /otelcol-contrib</pre>
             <td>Extra arguments for the OtelAgent command.</td>
         </tr>
         <tr>
-            <td id="otelAgent--configMap"><a href="./values.yaml#L568">otelAgent.configMap</a></td>
+            <td id="otelAgent--configMap"><a href="./values.yaml#L588">otelAgent.configMap</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">create: true</pre>
@@ -1103,7 +1353,7 @@ name: /otelcol-contrib</pre>
             <td>ConfigMap configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--configMap--create"><a href="./values.yaml#L571">otelAgent.configMap.create</a></td>
+            <td id="otelAgent--configMap--create"><a href="./values.yaml#L591">otelAgent.configMap.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1112,7 +1362,7 @@ name: /otelcol-contrib</pre>
             <td>Specifies whether a ConfigMap should be created.</td>
         </tr>
         <tr>
-            <td id="otelAgent--service"><a href="./values.yaml#L575">otelAgent.service</a></td>
+            <td id="otelAgent--service"><a href="./values.yaml#L595">otelAgent.service</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1123,7 +1373,7 @@ type: ClusterIP</pre>
             <td>Service configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--service--annotations"><a href="./values.yaml#L578">otelAgent.service.annotations</a></td>
+            <td id="otelAgent--service--annotations"><a href="./values.yaml#L598">otelAgent.service.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1132,7 +1382,7 @@ type: ClusterIP</pre>
             <td>Annotations for the OtelAgent service.</td>
         </tr>
         <tr>
-            <td id="otelAgent--service--type"><a href="./values.yaml#L581">otelAgent.service.type</a></td>
+            <td id="otelAgent--service--type"><a href="./values.yaml#L601">otelAgent.service.type</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">ClusterIP</pre>
@@ -1141,7 +1391,7 @@ type: ClusterIP</pre>
             <td>Service type: `ClusterIP`, `NodePort`, or `LoadBalancer`.</td>
         </tr>
         <tr>
-            <td id="otelAgent--service--internalTrafficPolicy"><a href="./values.yaml#L585">otelAgent.service.internalTrafficPolicy</a></td>
+            <td id="otelAgent--service--internalTrafficPolicy"><a href="./values.yaml#L605">otelAgent.service.internalTrafficPolicy</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Local</pre>
@@ -1150,7 +1400,7 @@ type: ClusterIP</pre>
             <td>Internal traffic policy: `Local` or `Cluster`. ref: https://kubernetes.io/docs/reference/networking/virtual-ips/#internal-traffic-policy</td>
         </tr>
         <tr>
-            <td id="otelAgent--serviceAccount"><a href="./values.yaml#L589">otelAgent.serviceAccount</a></td>
+            <td id="otelAgent--serviceAccount"><a href="./values.yaml#L609">otelAgent.serviceAccount</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1161,7 +1411,7 @@ name: null</pre>
             <td>ServiceAccount configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--serviceAccount--create"><a href="./values.yaml#L592">otelAgent.serviceAccount.create</a></td>
+            <td id="otelAgent--serviceAccount--create"><a href="./values.yaml#L612">otelAgent.serviceAccount.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1170,7 +1420,7 @@ name: null</pre>
             <td>Specifies whether a ServiceAccount should be created.</td>
         </tr>
         <tr>
-            <td id="otelAgent--serviceAccount--annotations"><a href="./values.yaml#L595">otelAgent.serviceAccount.annotations</a></td>
+            <td id="otelAgent--serviceAccount--annotations"><a href="./values.yaml#L615">otelAgent.serviceAccount.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1179,7 +1429,7 @@ name: null</pre>
             <td>Annotations for the ServiceAccount.</td>
         </tr>
         <tr>
-            <td id="otelAgent--serviceAccount--name"><a href="./values.yaml#L598">otelAgent.serviceAccount.name</a></td>
+            <td id="otelAgent--serviceAccount--name"><a href="./values.yaml#L618">otelAgent.serviceAccount.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">null</pre>
@@ -1188,7 +1438,7 @@ name: null</pre>
             <td>The name of the ServiceAccount to use. A name is generated if not set.</td>
         </tr>
         <tr>
-            <td id="otelAgent--annotations"><a href="./values.yaml#L602">otelAgent.annotations</a></td>
+            <td id="otelAgent--annotations"><a href="./values.yaml#L622">otelAgent.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1197,7 +1447,7 @@ name: null</pre>
             <td>Annotations for the OtelAgent DaemonSet.</td>
         </tr>
         <tr>
-            <td id="otelAgent--podAnnotations"><a href="./values.yaml#L605">otelAgent.podAnnotations</a></td>
+            <td id="otelAgent--podAnnotations"><a href="./values.yaml#L625">otelAgent.podAnnotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1206,7 +1456,7 @@ name: null</pre>
             <td>Annotations for the OtelAgent pods.</td>
         </tr>
         <tr>
-            <td id="otelAgent--additionalEnvs"><a href="./values.yaml#L627">otelAgent.additionalEnvs</a></td>
+            <td id="otelAgent--additionalEnvs"><a href="./values.yaml#L647">otelAgent.additionalEnvs</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1215,7 +1465,7 @@ name: null</pre>
             <td>Additional environment variables for the OtelAgent container. You can specify variables in two ways: 1. Flexible structure for advanced configurations (recommended):    Example:      additionalEnvs:        MY_KEY:          value: my-value        SECRET_KEY:          valueFrom:            secretKeyRef:              name: my-secret              key: my-key 2. Simple key-value pairs (backward-compatible):    Example:      additionalEnvs:        MY_KEY: my-value</td>
         </tr>
         <tr>
-            <td id="otelAgent--minReadySeconds"><a href="./values.yaml#L631">otelAgent.minReadySeconds</a></td>
+            <td id="otelAgent--minReadySeconds"><a href="./values.yaml#L651">otelAgent.minReadySeconds</a></td>
             <td>int</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">5</pre>
@@ -1224,7 +1474,7 @@ name: null</pre>
             <td>Minimum number of seconds for which a newly created Pod should be ready.</td>
         </tr>
         <tr>
-            <td id="otelAgent--clusterRole"><a href="./values.yaml#L636">otelAgent.clusterRole</a></td>
+            <td id="otelAgent--clusterRole"><a href="./values.yaml#L656">otelAgent.clusterRole</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please checkout the values.yml for default values</pre>
@@ -1233,7 +1483,7 @@ name: null</pre>
             <td>ClusterRole configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--clusterRole--create"><a href="./values.yaml#L639">otelAgent.clusterRole.create</a></td>
+            <td id="otelAgent--clusterRole--create"><a href="./values.yaml#L659">otelAgent.clusterRole.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1242,7 +1492,7 @@ name: null</pre>
             <td>Specifies whether a ClusterRole should be created.</td>
         </tr>
         <tr>
-            <td id="otelAgent--clusterRole--annotations"><a href="./values.yaml#L642">otelAgent.clusterRole.annotations</a></td>
+            <td id="otelAgent--clusterRole--annotations"><a href="./values.yaml#L662">otelAgent.clusterRole.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1251,7 +1501,7 @@ name: null</pre>
             <td>Annotations for the ClusterRole.</td>
         </tr>
         <tr>
-            <td id="otelAgent--clusterRole--name"><a href="./values.yaml#L645">otelAgent.clusterRole.name</a></td>
+            <td id="otelAgent--clusterRole--name"><a href="./values.yaml#L665">otelAgent.clusterRole.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -1260,7 +1510,7 @@ name: null</pre>
             <td>The name of the ClusterRole to use. A name is generated if not set.</td>
         </tr>
         <tr>
-            <td id="otelAgent--clusterRole--rules"><a href="./values.yaml#L650">otelAgent.clusterRole.rules</a></td>
+            <td id="otelAgent--clusterRole--rules"><a href="./values.yaml#L670">otelAgent.clusterRole.rules</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please checkout the values.yml for default values</pre>
@@ -1269,7 +1519,7 @@ name: null</pre>
             <td>RBAC rules for the OtelAgent. ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/</td>
         </tr>
         <tr>
-            <td id="otelAgent--clusterRole--clusterRoleBinding"><a href="./values.yaml#L681">otelAgent.clusterRole.clusterRoleBinding</a></td>
+            <td id="otelAgent--clusterRole--clusterRoleBinding"><a href="./values.yaml#L701">otelAgent.clusterRole.clusterRoleBinding</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1279,7 +1529,7 @@ name: ""</pre>
             <td>ClusterRoleBinding configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports"><a href="./values.yaml#L692">otelAgent.ports</a></td>
+            <td id="otelAgent--ports"><a href="./values.yaml#L712">otelAgent.ports</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please checkout the values.yml for default values</pre>
@@ -1288,7 +1538,7 @@ name: ""</pre>
             <td>Port configurations for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--otlp--enabled"><a href="./values.yaml#L697">otelAgent.ports.otlp.enabled</a></td>
+            <td id="otelAgent--ports--otlp--enabled"><a href="./values.yaml#L717">otelAgent.ports.otlp.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1297,7 +1547,7 @@ name: ""</pre>
             <td>Enable service port for OTLP gRPC.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--otlp-http--enabled"><a href="./values.yaml#L712">otelAgent.ports.otlp-http.enabled</a></td>
+            <td id="otelAgent--ports--otlp-http--enabled"><a href="./values.yaml#L732">otelAgent.ports.otlp-http.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1306,7 +1556,7 @@ name: ""</pre>
             <td>Enable service port for OTLP HTTP.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--zipkin--enabled"><a href="./values.yaml#L727">otelAgent.ports.zipkin.enabled</a></td>
+            <td id="otelAgent--ports--zipkin--enabled"><a href="./values.yaml#L747">otelAgent.ports.zipkin.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1315,7 +1565,7 @@ name: ""</pre>
             <td>Enable service port for Zipkin.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--metrics--enabled"><a href="./values.yaml#L742">otelAgent.ports.metrics.enabled</a></td>
+            <td id="otelAgent--ports--metrics--enabled"><a href="./values.yaml#L762">otelAgent.ports.metrics.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1324,7 +1574,7 @@ name: ""</pre>
             <td>Enable service port for internal metrics.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--zpages--enabled"><a href="./values.yaml#L757">otelAgent.ports.zpages.enabled</a></td>
+            <td id="otelAgent--ports--zpages--enabled"><a href="./values.yaml#L777">otelAgent.ports.zpages.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1333,7 +1583,7 @@ name: ""</pre>
             <td>Enable service port for ZPages.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--health-check--enabled"><a href="./values.yaml#L772">otelAgent.ports.health-check.enabled</a></td>
+            <td id="otelAgent--ports--health-check--enabled"><a href="./values.yaml#L792">otelAgent.ports.health-check.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1342,7 +1592,7 @@ name: ""</pre>
             <td>Enable service port for health checks.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--pprof--enabled"><a href="./values.yaml#L787">otelAgent.ports.pprof.enabled</a></td>
+            <td id="otelAgent--ports--pprof--enabled"><a href="./values.yaml#L807">otelAgent.ports.pprof.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1351,7 +1601,7 @@ name: ""</pre>
             <td>Enable service port for pprof.</td>
         </tr>
         <tr>
-            <td id="otelAgent--hostNetwork"><a href="./values.yaml#L801">otelAgent.hostNetwork</a></td>
+            <td id="otelAgent--hostNetwork"><a href="./values.yaml#L821">otelAgent.hostNetwork</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1360,7 +1610,7 @@ name: ""</pre>
             <td>Host networking requested for this pod. Use the host's network namespace. Please make sure while enabling hostNetwork that the host ports are available as it can lead to port conflicts.</td>
         </tr>
         <tr>
-            <td id="otelAgent--livenessProbe"><a href="./values.yaml#L805">otelAgent.livenessProbe</a></td>
+            <td id="otelAgent--livenessProbe"><a href="./values.yaml#L825">otelAgent.livenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
@@ -1376,7 +1626,7 @@ timeoutSeconds: 5</pre>
             <td>Configure liveness probe. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command</td>
         </tr>
         <tr>
-            <td id="otelAgent--readinessProbe"><a href="./values.yaml#L826">otelAgent.readinessProbe</a></td>
+            <td id="otelAgent--readinessProbe"><a href="./values.yaml#L846">otelAgent.readinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
@@ -1392,7 +1642,7 @@ timeoutSeconds: 5</pre>
             <td>Configure readiness probe. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes</td>
         </tr>
         <tr>
-            <td id="otelAgent--customLivenessProbe"><a href="./values.yaml#L846">otelAgent.customLivenessProbe</a></td>
+            <td id="otelAgent--customLivenessProbe"><a href="./values.yaml#L866">otelAgent.customLivenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1401,7 +1651,7 @@ timeoutSeconds: 5</pre>
             <td>Custom liveness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--customReadinessProbe"><a href="./values.yaml#L849">otelAgent.customReadinessProbe</a></td>
+            <td id="otelAgent--customReadinessProbe"><a href="./values.yaml#L869">otelAgent.customReadinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1410,7 +1660,7 @@ timeoutSeconds: 5</pre>
             <td>Custom readiness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress"><a href="./values.yaml#L853">otelAgent.ingress</a></td>
+            <td id="otelAgent--ingress"><a href="./values.yaml#L873">otelAgent.ingress</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1428,7 +1678,7 @@ tls: []</pre>
             <td>Ingress configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--enabled"><a href="./values.yaml#L856">otelAgent.ingress.enabled</a></td>
+            <td id="otelAgent--ingress--enabled"><a href="./values.yaml#L876">otelAgent.ingress.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1437,7 +1687,7 @@ tls: []</pre>
             <td>Enable Ingress for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--className"><a href="./values.yaml#L859">otelAgent.ingress.className</a></td>
+            <td id="otelAgent--ingress--className"><a href="./values.yaml#L879">otelAgent.ingress.className</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -1446,7 +1696,7 @@ tls: []</pre>
             <td>Ingress Class Name to be used.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--annotations"><a href="./values.yaml#L862">otelAgent.ingress.annotations</a></td>
+            <td id="otelAgent--ingress--annotations"><a href="./values.yaml#L882">otelAgent.ingress.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1455,7 +1705,7 @@ tls: []</pre>
             <td>Annotations for the OtelAgent Ingress.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--hosts"><a href="./values.yaml#L870">otelAgent.ingress.hosts</a></td>
+            <td id="otelAgent--ingress--hosts"><a href="./values.yaml#L890">otelAgent.ingress.hosts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- host: otel-agent.domain.com
@@ -1468,7 +1718,7 @@ tls: []</pre>
             <td>OtelAgent Ingress hostnames with their path details.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--tls"><a href="./values.yaml#L878">otelAgent.ingress.tls</a></td>
+            <td id="otelAgent--ingress--tls"><a href="./values.yaml#L898">otelAgent.ingress.tls</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1477,7 +1727,7 @@ tls: []</pre>
             <td>OtelAgent Ingress TLS configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--resources"><a href="./values.yaml#L886">otelAgent.resources</a></td>
+            <td id="otelAgent--resources"><a href="./values.yaml#L906">otelAgent.resources</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">requests:
@@ -1488,7 +1738,7 @@ tls: []</pre>
             <td>Configure resource requests and limits for the OtelAgent. ref: http://kubernetes.io/docs/user-guide/compute-resources/</td>
         </tr>
         <tr>
-            <td id="otelAgent--priorityClassName"><a href="./values.yaml#L897">otelAgent.priorityClassName</a></td>
+            <td id="otelAgent--priorityClassName"><a href="./values.yaml#L917">otelAgent.priorityClassName</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -1497,7 +1747,7 @@ tls: []</pre>
             <td>OtelAgent Priority Class name.</td>
         </tr>
         <tr>
-            <td id="otelAgent--nodeSelector"><a href="./values.yaml#L901">otelAgent.nodeSelector</a></td>
+            <td id="otelAgent--nodeSelector"><a href="./values.yaml#L921">otelAgent.nodeSelector</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1506,7 +1756,7 @@ tls: []</pre>
             <td>Node selector for OtelAgent pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelAgent--tolerations"><a href="./values.yaml#L905">otelAgent.tolerations</a></td>
+            <td id="otelAgent--tolerations"><a href="./values.yaml#L925">otelAgent.tolerations</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- operator: Exists</pre>
@@ -1515,7 +1765,7 @@ tls: []</pre>
             <td>Toleration labels for OtelAgent pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelAgent--affinity"><a href="./values.yaml#L910">otelAgent.affinity</a></td>
+            <td id="otelAgent--affinity"><a href="./values.yaml#L930">otelAgent.affinity</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1524,7 +1774,7 @@ tls: []</pre>
             <td>Affinity settings for the OtelAgent pod.</td>
         </tr>
         <tr>
-            <td id="otelAgent--podSecurityContext"><a href="./values.yaml#L914">otelAgent.podSecurityContext</a></td>
+            <td id="otelAgent--podSecurityContext"><a href="./values.yaml#L934">otelAgent.podSecurityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1533,7 +1783,7 @@ tls: []</pre>
             <td>Pod-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--securityContext"><a href="./values.yaml#L919">otelAgent.securityContext</a></td>
+            <td id="otelAgent--securityContext"><a href="./values.yaml#L939">otelAgent.securityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1542,7 +1792,7 @@ tls: []</pre>
             <td>Container-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--config"><a href="./values.yaml#L930">otelAgent.config</a></td>
+            <td id="otelAgent--config"><a href="./values.yaml#L950">otelAgent.config</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please Checkout the values.yml for default values</pre>
@@ -1551,7 +1801,7 @@ tls: []</pre>
             <td>Base configuration for the OtelAgent Collector.</td>
         </tr>
         <tr>
-            <td id="otelAgent--config--processors--batch"><a href="./values.yaml#L945">otelAgent.config.processors.batch</a></td>
+            <td id="otelAgent--config--processors--batch"><a href="./values.yaml#L965">otelAgent.config.processors.batch</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">send_batch_size: 10000
@@ -1561,7 +1811,7 @@ timeout: 200ms</pre>
             <td>Batch processor config. ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md</td>
         </tr>
         <tr>
-            <td id="otelAgent--extraVolumes"><a href="./values.yaml#L987">otelAgent.extraVolumes</a></td>
+            <td id="otelAgent--extraVolumes"><a href="./values.yaml#L1007">otelAgent.extraVolumes</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1570,7 +1820,7 @@ timeout: 200ms</pre>
             <td>Additional volumes for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--extraVolumeMounts"><a href="./values.yaml#L997">otelAgent.extraVolumeMounts</a></td>
+            <td id="otelAgent--extraVolumeMounts"><a href="./values.yaml#L1017">otelAgent.extraVolumeMounts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1590,7 +1840,7 @@ timeout: 200ms</pre>
     </thead>
     <tbody>
         <tr>
-            <td id="otelDeployment--enabled"><a href="./values.yaml#L1009">otelDeployment.enabled</a></td>
+            <td id="otelDeployment--enabled"><a href="./values.yaml#L1029">otelDeployment.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1599,7 +1849,7 @@ timeout: 200ms</pre>
             <td>Enable the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--name"><a href="./values.yaml#L1012">otelDeployment.name</a></td>
+            <td id="otelDeployment--name"><a href="./values.yaml#L1032">otelDeployment.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">otel-deployment</pre>
@@ -1608,7 +1858,7 @@ timeout: 200ms</pre>
             <td>Name of the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image"><a href="./values.yaml#L1015">otelDeployment.image</a></td>
+            <td id="otelDeployment--image"><a href="./values.yaml#L1035">otelDeployment.image</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">pullPolicy: IfNotPresent
@@ -1620,7 +1870,7 @@ tag: 0.109.0</pre>
             <td>Image configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--registry"><a href="./values.yaml#L1018">otelDeployment.image.registry</a></td>
+            <td id="otelDeployment--image--registry"><a href="./values.yaml#L1038">otelDeployment.image.registry</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">docker.io</pre>
@@ -1629,7 +1879,7 @@ tag: 0.109.0</pre>
             <td>Docker registry for the OtelDeployment image.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--repository"><a href="./values.yaml#L1021">otelDeployment.image.repository</a></td>
+            <td id="otelDeployment--image--repository"><a href="./values.yaml#L1041">otelDeployment.image.repository</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">otel/opentelemetry-collector-contrib</pre>
@@ -1638,7 +1888,7 @@ tag: 0.109.0</pre>
             <td>Repository for the OtelDeployment image.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--tag"><a href="./values.yaml#L1024">otelDeployment.image.tag</a></td>
+            <td id="otelDeployment--image--tag"><a href="./values.yaml#L1044">otelDeployment.image.tag</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">0.109.0</pre>
@@ -1647,7 +1897,7 @@ tag: 0.109.0</pre>
             <td>Tag for the OtelDeployment image.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--pullPolicy"><a href="./values.yaml#L1027">otelDeployment.image.pullPolicy</a></td>
+            <td id="otelDeployment--image--pullPolicy"><a href="./values.yaml#L1047">otelDeployment.image.pullPolicy</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">IfNotPresent</pre>
@@ -1656,7 +1906,7 @@ tag: 0.109.0</pre>
             <td>Image pull policy for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--imagePullSecrets"><a href="./values.yaml#L1031">otelDeployment.imagePullSecrets</a></td>
+            <td id="otelDeployment--imagePullSecrets"><a href="./values.yaml#L1051">otelDeployment.imagePullSecrets</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1665,7 +1915,7 @@ tag: 0.109.0</pre>
             <td>Image Pull Secrets for the OtelDeployment. Merged with `global.imagePullSecrets`.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--command"><a href="./values.yaml#L1036">otelDeployment.command</a></td>
+            <td id="otelDeployment--command"><a href="./values.yaml#L1056">otelDeployment.command</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">extraArgs: []
@@ -1675,7 +1925,7 @@ name: /otelcol-contrib</pre>
             <td>Command and arguments for the OtelDeployment container.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--command--name"><a href="./values.yaml#L1039">otelDeployment.command.name</a></td>
+            <td id="otelDeployment--command--name"><a href="./values.yaml#L1059">otelDeployment.command.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">/otelcol-contrib</pre>
@@ -1684,7 +1934,7 @@ name: /otelcol-contrib</pre>
             <td>OtelDeployment command name.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--command--extraArgs"><a href="./values.yaml#L1042">otelDeployment.command.extraArgs</a></td>
+            <td id="otelDeployment--command--extraArgs"><a href="./values.yaml#L1062">otelDeployment.command.extraArgs</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1693,7 +1943,7 @@ name: /otelcol-contrib</pre>
             <td>Extra arguments for the OtelDeployment command.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--configMap"><a href="./values.yaml#L1046">otelDeployment.configMap</a></td>
+            <td id="otelDeployment--configMap"><a href="./values.yaml#L1066">otelDeployment.configMap</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">create: true</pre>
@@ -1702,7 +1952,7 @@ name: /otelcol-contrib</pre>
             <td>ConfigMap configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--configMap--create"><a href="./values.yaml#L1049">otelDeployment.configMap.create</a></td>
+            <td id="otelDeployment--configMap--create"><a href="./values.yaml#L1069">otelDeployment.configMap.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1711,7 +1961,7 @@ name: /otelcol-contrib</pre>
             <td>Specifies whether a ConfigMap should be created.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--service"><a href="./values.yaml#L1053">otelDeployment.service</a></td>
+            <td id="otelDeployment--service"><a href="./values.yaml#L1073">otelDeployment.service</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1721,7 +1971,7 @@ type: ClusterIP</pre>
             <td>Service configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--service--annotations"><a href="./values.yaml#L1056">otelDeployment.service.annotations</a></td>
+            <td id="otelDeployment--service--annotations"><a href="./values.yaml#L1076">otelDeployment.service.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1730,7 +1980,7 @@ type: ClusterIP</pre>
             <td>Annotations for the OtelDeployment service.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--service--type"><a href="./values.yaml#L1059">otelDeployment.service.type</a></td>
+            <td id="otelDeployment--service--type"><a href="./values.yaml#L1079">otelDeployment.service.type</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">ClusterIP</pre>
@@ -1739,7 +1989,7 @@ type: ClusterIP</pre>
             <td>Service type.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount"><a href="./values.yaml#L1063">otelDeployment.serviceAccount</a></td>
+            <td id="otelDeployment--serviceAccount"><a href="./values.yaml#L1083">otelDeployment.serviceAccount</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1750,7 +2000,7 @@ name: null</pre>
             <td>ServiceAccount configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount--create"><a href="./values.yaml#L1066">otelDeployment.serviceAccount.create</a></td>
+            <td id="otelDeployment--serviceAccount--create"><a href="./values.yaml#L1086">otelDeployment.serviceAccount.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1759,7 +2009,7 @@ name: null</pre>
             <td>Specifies whether a ServiceAccount should be created.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount--annotations"><a href="./values.yaml#L1069">otelDeployment.serviceAccount.annotations</a></td>
+            <td id="otelDeployment--serviceAccount--annotations"><a href="./values.yaml#L1089">otelDeployment.serviceAccount.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1768,7 +2018,7 @@ name: null</pre>
             <td>Annotations for the ServiceAccount.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount--name"><a href="./values.yaml#L1072">otelDeployment.serviceAccount.name</a></td>
+            <td id="otelDeployment--serviceAccount--name"><a href="./values.yaml#L1092">otelDeployment.serviceAccount.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">null</pre>
@@ -1777,7 +2027,7 @@ name: null</pre>
             <td>The name of the ServiceAccount to use. A name is generated if not set.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--annotations"><a href="./values.yaml#L1076">otelDeployment.annotations</a></td>
+            <td id="otelDeployment--annotations"><a href="./values.yaml#L1096">otelDeployment.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1786,7 +2036,7 @@ name: null</pre>
             <td>Annotations for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--podAnnotations"><a href="./values.yaml#L1079">otelDeployment.podAnnotations</a></td>
+            <td id="otelDeployment--podAnnotations"><a href="./values.yaml#L1099">otelDeployment.podAnnotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1795,7 +2045,7 @@ name: null</pre>
             <td>Annotations for the OtelDeployment pods.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--additionalEnvs"><a href="./values.yaml#L1086">otelDeployment.additionalEnvs</a></td>
+            <td id="otelDeployment--additionalEnvs"><a href="./values.yaml#L1106">otelDeployment.additionalEnvs</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1804,7 +2054,7 @@ name: null</pre>
             <td>Additional environment variables for the OtelDeployment container.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--podSecurityContext"><a href="./values.yaml#L1090">otelDeployment.podSecurityContext</a></td>
+            <td id="otelDeployment--podSecurityContext"><a href="./values.yaml#L1110">otelDeployment.podSecurityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1813,7 +2063,7 @@ name: null</pre>
             <td>Pod-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--securityContext"><a href="./values.yaml#L1095">otelDeployment.securityContext</a></td>
+            <td id="otelDeployment--securityContext"><a href="./values.yaml#L1115">otelDeployment.securityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1822,7 +2072,7 @@ name: null</pre>
             <td>Container-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--minReadySeconds"><a href="./values.yaml#L1105">otelDeployment.minReadySeconds</a></td>
+            <td id="otelDeployment--minReadySeconds"><a href="./values.yaml#L1125">otelDeployment.minReadySeconds</a></td>
             <td>int</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">5</pre>
@@ -1831,7 +2081,7 @@ name: null</pre>
             <td>Minimum number of seconds for which a newly created Pod should be ready.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--progressDeadlineSeconds"><a href="./values.yaml#L1109">otelDeployment.progressDeadlineSeconds</a></td>
+            <td id="otelDeployment--progressDeadlineSeconds"><a href="./values.yaml#L1129">otelDeployment.progressDeadlineSeconds</a></td>
             <td>int</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">120</pre>
@@ -1840,7 +2090,7 @@ name: null</pre>
             <td>Seconds to wait for the Deployment to progress before it's considered failed.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports"><a href="./values.yaml#L1113">otelDeployment.ports</a></td>
+            <td id="otelDeployment--ports"><a href="./values.yaml#L1133">otelDeployment.ports</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">health-check:
@@ -1872,7 +2122,7 @@ zpages:
             <td>Port configurations for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--metrics--enabled"><a href="./values.yaml#L1118">otelDeployment.ports.metrics.enabled</a></td>
+            <td id="otelDeployment--ports--metrics--enabled"><a href="./values.yaml#L1138">otelDeployment.ports.metrics.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1881,7 +2131,7 @@ zpages:
             <td>Enable service port for internal metrics.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--zpages--enabled"><a href="./values.yaml#L1131">otelDeployment.ports.zpages.enabled</a></td>
+            <td id="otelDeployment--ports--zpages--enabled"><a href="./values.yaml#L1151">otelDeployment.ports.zpages.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1890,7 +2140,7 @@ zpages:
             <td>Enable service port for ZPages.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--health-check--enabled"><a href="./values.yaml#L1144">otelDeployment.ports.health-check.enabled</a></td>
+            <td id="otelDeployment--ports--health-check--enabled"><a href="./values.yaml#L1164">otelDeployment.ports.health-check.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1899,7 +2149,7 @@ zpages:
             <td>Enable service port for health checks.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--pprof--enabled"><a href="./values.yaml#L1157">otelDeployment.ports.pprof.enabled</a></td>
+            <td id="otelDeployment--ports--pprof--enabled"><a href="./values.yaml#L1177">otelDeployment.ports.pprof.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1908,7 +2158,7 @@ zpages:
             <td>Enable service port for pprof.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--livenessProbe"><a href="./values.yaml#L1169">otelDeployment.livenessProbe</a></td>
+            <td id="otelDeployment--livenessProbe"><a href="./values.yaml#L1189">otelDeployment.livenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
@@ -1924,7 +2174,7 @@ timeoutSeconds: 5</pre>
             <td>Configure liveness probe.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--readinessProbe"><a href="./values.yaml#L1189">otelDeployment.readinessProbe</a></td>
+            <td id="otelDeployment--readinessProbe"><a href="./values.yaml#L1209">otelDeployment.readinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
@@ -1940,7 +2190,7 @@ timeoutSeconds: 5</pre>
             <td>Configure readiness probe.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--customLivenessProbe"><a href="./values.yaml#L1209">otelDeployment.customLivenessProbe</a></td>
+            <td id="otelDeployment--customLivenessProbe"><a href="./values.yaml#L1229">otelDeployment.customLivenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1949,7 +2199,7 @@ timeoutSeconds: 5</pre>
             <td>Custom liveness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--customReadinessProbe"><a href="./values.yaml#L1213">otelDeployment.customReadinessProbe</a></td>
+            <td id="otelDeployment--customReadinessProbe"><a href="./values.yaml#L1233">otelDeployment.customReadinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1958,7 +2208,7 @@ timeoutSeconds: 5</pre>
             <td>Custom readiness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress"><a href="./values.yaml#L1217">otelDeployment.ingress</a></td>
+            <td id="otelDeployment--ingress"><a href="./values.yaml#L1237">otelDeployment.ingress</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1976,7 +2226,7 @@ tls: []</pre>
             <td>Ingress configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--enabled"><a href="./values.yaml#L1220">otelDeployment.ingress.enabled</a></td>
+            <td id="otelDeployment--ingress--enabled"><a href="./values.yaml#L1240">otelDeployment.ingress.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1985,7 +2235,7 @@ tls: []</pre>
             <td>Enable Ingress for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--className"><a href="./values.yaml#L1223">otelDeployment.ingress.className</a></td>
+            <td id="otelDeployment--ingress--className"><a href="./values.yaml#L1243">otelDeployment.ingress.className</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -1994,7 +2244,7 @@ tls: []</pre>
             <td>Ingress Class Name to be used.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--annotations"><a href="./values.yaml#L1226">otelDeployment.ingress.annotations</a></td>
+            <td id="otelDeployment--ingress--annotations"><a href="./values.yaml#L1246">otelDeployment.ingress.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -2003,7 +2253,7 @@ tls: []</pre>
             <td>Annotations for the OtelDeployment Ingress.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--hosts"><a href="./values.yaml#L1229">otelDeployment.ingress.hosts</a></td>
+            <td id="otelDeployment--ingress--hosts"><a href="./values.yaml#L1249">otelDeployment.ingress.hosts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- host: otel-deployment.domain.com
@@ -2016,7 +2266,7 @@ tls: []</pre>
             <td>OtelDeployment Ingress hostnames.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--tls"><a href="./values.yaml#L1237">otelDeployment.ingress.tls</a></td>
+            <td id="otelDeployment--ingress--tls"><a href="./values.yaml#L1257">otelDeployment.ingress.tls</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -2025,7 +2275,7 @@ tls: []</pre>
             <td>OtelDeployment Ingress TLS configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--resources"><a href="./values.yaml#L1244">otelDeployment.resources</a></td>
+            <td id="otelDeployment--resources"><a href="./values.yaml#L1264">otelDeployment.resources</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">requests:
@@ -2036,7 +2286,7 @@ tls: []</pre>
             <td>Configure resource requests and limits for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--priorityClassName"><a href="./values.yaml#L1255">otelDeployment.priorityClassName</a></td>
+            <td id="otelDeployment--priorityClassName"><a href="./values.yaml#L1275">otelDeployment.priorityClassName</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -2045,7 +2295,7 @@ tls: []</pre>
             <td>OtelDeployment Priority Class name.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--nodeSelector"><a href="./values.yaml#L1259">otelDeployment.nodeSelector</a></td>
+            <td id="otelDeployment--nodeSelector"><a href="./values.yaml#L1279">otelDeployment.nodeSelector</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -2054,7 +2304,7 @@ tls: []</pre>
             <td>Node selector for OtelDeployment pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--tolerations"><a href="./values.yaml#L1263">otelDeployment.tolerations</a></td>
+            <td id="otelDeployment--tolerations"><a href="./values.yaml#L1283">otelDeployment.tolerations</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -2063,7 +2313,7 @@ tls: []</pre>
             <td>Toleration labels for OtelDeployment pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--affinity"><a href="./values.yaml#L1267">otelDeployment.affinity</a></td>
+            <td id="otelDeployment--affinity"><a href="./values.yaml#L1287">otelDeployment.affinity</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -2072,7 +2322,7 @@ tls: []</pre>
             <td>Affinity settings for the OtelDeployment pod.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--topologySpreadConstraints"><a href="./values.yaml#L1271">otelDeployment.topologySpreadConstraints</a></td>
+            <td id="otelDeployment--topologySpreadConstraints"><a href="./values.yaml#L1291">otelDeployment.topologySpreadConstraints</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -2081,7 +2331,7 @@ tls: []</pre>
             <td>Describes how OtelDeployment pods ought to spread.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole"><a href="./values.yaml#L1276">otelDeployment.clusterRole</a></td>
+            <td id="otelDeployment--clusterRole"><a href="./values.yaml#L1296">otelDeployment.clusterRole</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please Checkout the values.yml for default values</pre>
@@ -2090,7 +2340,7 @@ tls: []</pre>
             <td>ClusterRole configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--create"><a href="./values.yaml#L1279">otelDeployment.clusterRole.create</a></td>
+            <td id="otelDeployment--clusterRole--create"><a href="./values.yaml#L1299">otelDeployment.clusterRole.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -2099,7 +2349,7 @@ tls: []</pre>
             <td>Specifies whether a ClusterRole should be created.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--annotations"><a href="./values.yaml#L1282">otelDeployment.clusterRole.annotations</a></td>
+            <td id="otelDeployment--clusterRole--annotations"><a href="./values.yaml#L1302">otelDeployment.clusterRole.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -2108,7 +2358,7 @@ tls: []</pre>
             <td>Annotations for the ClusterRole.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--name"><a href="./values.yaml#L1285">otelDeployment.clusterRole.name</a></td>
+            <td id="otelDeployment--clusterRole--name"><a href="./values.yaml#L1305">otelDeployment.clusterRole.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -2117,7 +2367,7 @@ tls: []</pre>
             <td>The name of the ClusterRole to use. A name is generated if not set.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--rules"><a href="./values.yaml#L1289">otelDeployment.clusterRole.rules</a></td>
+            <td id="otelDeployment--clusterRole--rules"><a href="./values.yaml#L1309">otelDeployment.clusterRole.rules</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please checkout the values.yml for default values</pre>
@@ -2126,7 +2376,7 @@ tls: []</pre>
             <td>RBAC rules for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--clusterRoleBinding"><a href="./values.yaml#L1319">otelDeployment.clusterRole.clusterRoleBinding</a></td>
+            <td id="otelDeployment--clusterRole--clusterRoleBinding"><a href="./values.yaml#L1339">otelDeployment.clusterRole.clusterRoleBinding</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -2136,7 +2386,7 @@ name: ""</pre>
             <td>ClusterRoleBinding configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--config"><a href="./values.yaml#L1330">otelDeployment.config</a></td>
+            <td id="otelDeployment--config"><a href="./values.yaml#L1350">otelDeployment.config</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please Checkout the values.yml for default values</pre>
@@ -2145,7 +2395,7 @@ name: ""</pre>
             <td>Base configuration for the OtelDeployment Collector.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--config--processors--batch"><a href="./values.yaml#L1337">otelDeployment.config.processors.batch</a></td>
+            <td id="otelDeployment--config--processors--batch"><a href="./values.yaml#L1357">otelDeployment.config.processors.batch</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">send_batch_size: 10000
@@ -2155,7 +2405,7 @@ timeout: 1s</pre>
             <td>Batch processor config.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--extraVolumes"><a href="./values.yaml#L1377">otelDeployment.extraVolumes</a></td>
+            <td id="otelDeployment--extraVolumes"><a href="./values.yaml#L1397">otelDeployment.extraVolumes</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -2164,7 +2414,7 @@ timeout: 1s</pre>
             <td>Additional volumes for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--extraVolumeMounts"><a href="./values.yaml#L1387">otelDeployment.extraVolumeMounts</a></td>
+            <td id="otelDeployment--extraVolumeMounts"><a href="./values.yaml#L1407">otelDeployment.extraVolumeMounts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>

--- a/charts/k8s-infra/README.md
+++ b/charts/k8s-infra/README.md
@@ -1351,16 +1351,16 @@ name: ""</pre>
             <td>Enable service port for pprof.</td>
         </tr>
         <tr>
-            <td id="otelAgent--hostNetwork"><a href="./values.yaml#L795">otelAgent.hostNetwork</a></td>
+            <td id="otelAgent--hostNetwork"><a href="./values.yaml#L796">otelAgent.hostNetwork</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
 </div>
             </td>
-            <td>Host networking requested for this pod. Use the host's network namespace.</td>
+            <td>Host networking requested for this pod. Use the host's network namespace. Please make sure while enabling hostNetwork that the host ports are available as it can lead to port conflicts.</td>
         </tr>
         <tr>
-            <td id="otelAgent--livenessProbe"><a href="./values.yaml#L799">otelAgent.livenessProbe</a></td>
+            <td id="otelAgent--livenessProbe"><a href="./values.yaml#L800">otelAgent.livenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
@@ -1376,7 +1376,7 @@ timeoutSeconds: 5</pre>
             <td>Configure liveness probe. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command</td>
         </tr>
         <tr>
-            <td id="otelAgent--readinessProbe"><a href="./values.yaml#L820">otelAgent.readinessProbe</a></td>
+            <td id="otelAgent--readinessProbe"><a href="./values.yaml#L821">otelAgent.readinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
@@ -1392,7 +1392,7 @@ timeoutSeconds: 5</pre>
             <td>Configure readiness probe. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes</td>
         </tr>
         <tr>
-            <td id="otelAgent--customLivenessProbe"><a href="./values.yaml#L840">otelAgent.customLivenessProbe</a></td>
+            <td id="otelAgent--customLivenessProbe"><a href="./values.yaml#L841">otelAgent.customLivenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1401,7 +1401,7 @@ timeoutSeconds: 5</pre>
             <td>Custom liveness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--customReadinessProbe"><a href="./values.yaml#L843">otelAgent.customReadinessProbe</a></td>
+            <td id="otelAgent--customReadinessProbe"><a href="./values.yaml#L844">otelAgent.customReadinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1410,7 +1410,7 @@ timeoutSeconds: 5</pre>
             <td>Custom readiness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress"><a href="./values.yaml#L847">otelAgent.ingress</a></td>
+            <td id="otelAgent--ingress"><a href="./values.yaml#L848">otelAgent.ingress</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1428,7 +1428,7 @@ tls: []</pre>
             <td>Ingress configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--enabled"><a href="./values.yaml#L850">otelAgent.ingress.enabled</a></td>
+            <td id="otelAgent--ingress--enabled"><a href="./values.yaml#L851">otelAgent.ingress.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1437,7 +1437,7 @@ tls: []</pre>
             <td>Enable Ingress for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--className"><a href="./values.yaml#L853">otelAgent.ingress.className</a></td>
+            <td id="otelAgent--ingress--className"><a href="./values.yaml#L854">otelAgent.ingress.className</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -1446,7 +1446,7 @@ tls: []</pre>
             <td>Ingress Class Name to be used.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--annotations"><a href="./values.yaml#L856">otelAgent.ingress.annotations</a></td>
+            <td id="otelAgent--ingress--annotations"><a href="./values.yaml#L857">otelAgent.ingress.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1455,7 +1455,7 @@ tls: []</pre>
             <td>Annotations for the OtelAgent Ingress.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--hosts"><a href="./values.yaml#L864">otelAgent.ingress.hosts</a></td>
+            <td id="otelAgent--ingress--hosts"><a href="./values.yaml#L865">otelAgent.ingress.hosts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- host: otel-agent.domain.com
@@ -1468,7 +1468,7 @@ tls: []</pre>
             <td>OtelAgent Ingress hostnames with their path details.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--tls"><a href="./values.yaml#L872">otelAgent.ingress.tls</a></td>
+            <td id="otelAgent--ingress--tls"><a href="./values.yaml#L873">otelAgent.ingress.tls</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1477,7 +1477,7 @@ tls: []</pre>
             <td>OtelAgent Ingress TLS configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--resources"><a href="./values.yaml#L880">otelAgent.resources</a></td>
+            <td id="otelAgent--resources"><a href="./values.yaml#L881">otelAgent.resources</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">requests:
@@ -1488,7 +1488,7 @@ tls: []</pre>
             <td>Configure resource requests and limits for the OtelAgent. ref: http://kubernetes.io/docs/user-guide/compute-resources/</td>
         </tr>
         <tr>
-            <td id="otelAgent--priorityClassName"><a href="./values.yaml#L891">otelAgent.priorityClassName</a></td>
+            <td id="otelAgent--priorityClassName"><a href="./values.yaml#L892">otelAgent.priorityClassName</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -1497,7 +1497,7 @@ tls: []</pre>
             <td>OtelAgent Priority Class name.</td>
         </tr>
         <tr>
-            <td id="otelAgent--nodeSelector"><a href="./values.yaml#L895">otelAgent.nodeSelector</a></td>
+            <td id="otelAgent--nodeSelector"><a href="./values.yaml#L896">otelAgent.nodeSelector</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1506,7 +1506,7 @@ tls: []</pre>
             <td>Node selector for OtelAgent pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelAgent--tolerations"><a href="./values.yaml#L899">otelAgent.tolerations</a></td>
+            <td id="otelAgent--tolerations"><a href="./values.yaml#L900">otelAgent.tolerations</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- operator: Exists</pre>
@@ -1515,7 +1515,7 @@ tls: []</pre>
             <td>Toleration labels for OtelAgent pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelAgent--affinity"><a href="./values.yaml#L904">otelAgent.affinity</a></td>
+            <td id="otelAgent--affinity"><a href="./values.yaml#L905">otelAgent.affinity</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1524,7 +1524,7 @@ tls: []</pre>
             <td>Affinity settings for the OtelAgent pod.</td>
         </tr>
         <tr>
-            <td id="otelAgent--podSecurityContext"><a href="./values.yaml#L908">otelAgent.podSecurityContext</a></td>
+            <td id="otelAgent--podSecurityContext"><a href="./values.yaml#L909">otelAgent.podSecurityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1533,7 +1533,7 @@ tls: []</pre>
             <td>Pod-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--securityContext"><a href="./values.yaml#L913">otelAgent.securityContext</a></td>
+            <td id="otelAgent--securityContext"><a href="./values.yaml#L914">otelAgent.securityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1542,7 +1542,7 @@ tls: []</pre>
             <td>Container-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--config"><a href="./values.yaml#L924">otelAgent.config</a></td>
+            <td id="otelAgent--config"><a href="./values.yaml#L925">otelAgent.config</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please Checkout the values.yml for default values</pre>
@@ -1551,7 +1551,7 @@ tls: []</pre>
             <td>Base configuration for the OtelAgent Collector.</td>
         </tr>
         <tr>
-            <td id="otelAgent--config--processors--batch"><a href="./values.yaml#L939">otelAgent.config.processors.batch</a></td>
+            <td id="otelAgent--config--processors--batch"><a href="./values.yaml#L940">otelAgent.config.processors.batch</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">send_batch_size: 10000
@@ -1561,7 +1561,7 @@ timeout: 200ms</pre>
             <td>Batch processor config. ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md</td>
         </tr>
         <tr>
-            <td id="otelAgent--extraVolumes"><a href="./values.yaml#L981">otelAgent.extraVolumes</a></td>
+            <td id="otelAgent--extraVolumes"><a href="./values.yaml#L982">otelAgent.extraVolumes</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1570,7 +1570,7 @@ timeout: 200ms</pre>
             <td>Additional volumes for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--extraVolumeMounts"><a href="./values.yaml#L991">otelAgent.extraVolumeMounts</a></td>
+            <td id="otelAgent--extraVolumeMounts"><a href="./values.yaml#L992">otelAgent.extraVolumeMounts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1590,7 +1590,7 @@ timeout: 200ms</pre>
     </thead>
     <tbody>
         <tr>
-            <td id="otelDeployment--enabled"><a href="./values.yaml#L1003">otelDeployment.enabled</a></td>
+            <td id="otelDeployment--enabled"><a href="./values.yaml#L1004">otelDeployment.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1599,7 +1599,7 @@ timeout: 200ms</pre>
             <td>Enable the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--name"><a href="./values.yaml#L1006">otelDeployment.name</a></td>
+            <td id="otelDeployment--name"><a href="./values.yaml#L1007">otelDeployment.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">otel-deployment</pre>
@@ -1608,7 +1608,7 @@ timeout: 200ms</pre>
             <td>Name of the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image"><a href="./values.yaml#L1009">otelDeployment.image</a></td>
+            <td id="otelDeployment--image"><a href="./values.yaml#L1010">otelDeployment.image</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">pullPolicy: IfNotPresent
@@ -1620,7 +1620,7 @@ tag: 0.109.0</pre>
             <td>Image configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--registry"><a href="./values.yaml#L1012">otelDeployment.image.registry</a></td>
+            <td id="otelDeployment--image--registry"><a href="./values.yaml#L1013">otelDeployment.image.registry</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">docker.io</pre>
@@ -1629,7 +1629,7 @@ tag: 0.109.0</pre>
             <td>Docker registry for the OtelDeployment image.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--repository"><a href="./values.yaml#L1015">otelDeployment.image.repository</a></td>
+            <td id="otelDeployment--image--repository"><a href="./values.yaml#L1016">otelDeployment.image.repository</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">otel/opentelemetry-collector-contrib</pre>
@@ -1638,7 +1638,7 @@ tag: 0.109.0</pre>
             <td>Repository for the OtelDeployment image.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--tag"><a href="./values.yaml#L1018">otelDeployment.image.tag</a></td>
+            <td id="otelDeployment--image--tag"><a href="./values.yaml#L1019">otelDeployment.image.tag</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">0.109.0</pre>
@@ -1647,7 +1647,7 @@ tag: 0.109.0</pre>
             <td>Tag for the OtelDeployment image.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--pullPolicy"><a href="./values.yaml#L1021">otelDeployment.image.pullPolicy</a></td>
+            <td id="otelDeployment--image--pullPolicy"><a href="./values.yaml#L1022">otelDeployment.image.pullPolicy</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">IfNotPresent</pre>
@@ -1656,7 +1656,7 @@ tag: 0.109.0</pre>
             <td>Image pull policy for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--imagePullSecrets"><a href="./values.yaml#L1025">otelDeployment.imagePullSecrets</a></td>
+            <td id="otelDeployment--imagePullSecrets"><a href="./values.yaml#L1026">otelDeployment.imagePullSecrets</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1665,7 +1665,7 @@ tag: 0.109.0</pre>
             <td>Image Pull Secrets for the OtelDeployment. Merged with `global.imagePullSecrets`.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--command"><a href="./values.yaml#L1030">otelDeployment.command</a></td>
+            <td id="otelDeployment--command"><a href="./values.yaml#L1031">otelDeployment.command</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">extraArgs: []
@@ -1675,7 +1675,7 @@ name: /otelcol-contrib</pre>
             <td>Command and arguments for the OtelDeployment container.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--command--name"><a href="./values.yaml#L1033">otelDeployment.command.name</a></td>
+            <td id="otelDeployment--command--name"><a href="./values.yaml#L1034">otelDeployment.command.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">/otelcol-contrib</pre>
@@ -1684,7 +1684,7 @@ name: /otelcol-contrib</pre>
             <td>OtelDeployment command name.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--command--extraArgs"><a href="./values.yaml#L1036">otelDeployment.command.extraArgs</a></td>
+            <td id="otelDeployment--command--extraArgs"><a href="./values.yaml#L1037">otelDeployment.command.extraArgs</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -1693,7 +1693,7 @@ name: /otelcol-contrib</pre>
             <td>Extra arguments for the OtelDeployment command.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--configMap"><a href="./values.yaml#L1040">otelDeployment.configMap</a></td>
+            <td id="otelDeployment--configMap"><a href="./values.yaml#L1041">otelDeployment.configMap</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">create: true</pre>
@@ -1702,7 +1702,7 @@ name: /otelcol-contrib</pre>
             <td>ConfigMap configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--configMap--create"><a href="./values.yaml#L1043">otelDeployment.configMap.create</a></td>
+            <td id="otelDeployment--configMap--create"><a href="./values.yaml#L1044">otelDeployment.configMap.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1711,7 +1711,7 @@ name: /otelcol-contrib</pre>
             <td>Specifies whether a ConfigMap should be created.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--service"><a href="./values.yaml#L1047">otelDeployment.service</a></td>
+            <td id="otelDeployment--service"><a href="./values.yaml#L1048">otelDeployment.service</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1721,7 +1721,7 @@ type: ClusterIP</pre>
             <td>Service configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--service--annotations"><a href="./values.yaml#L1050">otelDeployment.service.annotations</a></td>
+            <td id="otelDeployment--service--annotations"><a href="./values.yaml#L1051">otelDeployment.service.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1730,7 +1730,7 @@ type: ClusterIP</pre>
             <td>Annotations for the OtelDeployment service.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--service--type"><a href="./values.yaml#L1053">otelDeployment.service.type</a></td>
+            <td id="otelDeployment--service--type"><a href="./values.yaml#L1054">otelDeployment.service.type</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">ClusterIP</pre>
@@ -1739,7 +1739,7 @@ type: ClusterIP</pre>
             <td>Service type.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount"><a href="./values.yaml#L1057">otelDeployment.serviceAccount</a></td>
+            <td id="otelDeployment--serviceAccount"><a href="./values.yaml#L1058">otelDeployment.serviceAccount</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1750,7 +1750,7 @@ name: null</pre>
             <td>ServiceAccount configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount--create"><a href="./values.yaml#L1060">otelDeployment.serviceAccount.create</a></td>
+            <td id="otelDeployment--serviceAccount--create"><a href="./values.yaml#L1061">otelDeployment.serviceAccount.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1759,7 +1759,7 @@ name: null</pre>
             <td>Specifies whether a ServiceAccount should be created.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount--annotations"><a href="./values.yaml#L1063">otelDeployment.serviceAccount.annotations</a></td>
+            <td id="otelDeployment--serviceAccount--annotations"><a href="./values.yaml#L1064">otelDeployment.serviceAccount.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1768,7 +1768,7 @@ name: null</pre>
             <td>Annotations for the ServiceAccount.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount--name"><a href="./values.yaml#L1066">otelDeployment.serviceAccount.name</a></td>
+            <td id="otelDeployment--serviceAccount--name"><a href="./values.yaml#L1067">otelDeployment.serviceAccount.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">null</pre>
@@ -1777,7 +1777,7 @@ name: null</pre>
             <td>The name of the ServiceAccount to use. A name is generated if not set.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--annotations"><a href="./values.yaml#L1070">otelDeployment.annotations</a></td>
+            <td id="otelDeployment--annotations"><a href="./values.yaml#L1071">otelDeployment.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1786,7 +1786,7 @@ name: null</pre>
             <td>Annotations for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--podAnnotations"><a href="./values.yaml#L1073">otelDeployment.podAnnotations</a></td>
+            <td id="otelDeployment--podAnnotations"><a href="./values.yaml#L1074">otelDeployment.podAnnotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1795,7 +1795,7 @@ name: null</pre>
             <td>Annotations for the OtelDeployment pods.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--additionalEnvs"><a href="./values.yaml#L1080">otelDeployment.additionalEnvs</a></td>
+            <td id="otelDeployment--additionalEnvs"><a href="./values.yaml#L1081">otelDeployment.additionalEnvs</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1804,7 +1804,7 @@ name: null</pre>
             <td>Additional environment variables for the OtelDeployment container.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--podSecurityContext"><a href="./values.yaml#L1084">otelDeployment.podSecurityContext</a></td>
+            <td id="otelDeployment--podSecurityContext"><a href="./values.yaml#L1085">otelDeployment.podSecurityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1813,7 +1813,7 @@ name: null</pre>
             <td>Pod-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--securityContext"><a href="./values.yaml#L1089">otelDeployment.securityContext</a></td>
+            <td id="otelDeployment--securityContext"><a href="./values.yaml#L1090">otelDeployment.securityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1822,7 +1822,7 @@ name: null</pre>
             <td>Container-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--minReadySeconds"><a href="./values.yaml#L1099">otelDeployment.minReadySeconds</a></td>
+            <td id="otelDeployment--minReadySeconds"><a href="./values.yaml#L1100">otelDeployment.minReadySeconds</a></td>
             <td>int</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">5</pre>
@@ -1831,7 +1831,7 @@ name: null</pre>
             <td>Minimum number of seconds for which a newly created Pod should be ready.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--progressDeadlineSeconds"><a href="./values.yaml#L1103">otelDeployment.progressDeadlineSeconds</a></td>
+            <td id="otelDeployment--progressDeadlineSeconds"><a href="./values.yaml#L1104">otelDeployment.progressDeadlineSeconds</a></td>
             <td>int</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">120</pre>
@@ -1840,7 +1840,7 @@ name: null</pre>
             <td>Seconds to wait for the Deployment to progress before it's considered failed.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports"><a href="./values.yaml#L1107">otelDeployment.ports</a></td>
+            <td id="otelDeployment--ports"><a href="./values.yaml#L1108">otelDeployment.ports</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">health-check:
@@ -1872,7 +1872,7 @@ zpages:
             <td>Port configurations for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--metrics--enabled"><a href="./values.yaml#L1112">otelDeployment.ports.metrics.enabled</a></td>
+            <td id="otelDeployment--ports--metrics--enabled"><a href="./values.yaml#L1113">otelDeployment.ports.metrics.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1881,7 +1881,7 @@ zpages:
             <td>Enable service port for internal metrics.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--zpages--enabled"><a href="./values.yaml#L1125">otelDeployment.ports.zpages.enabled</a></td>
+            <td id="otelDeployment--ports--zpages--enabled"><a href="./values.yaml#L1126">otelDeployment.ports.zpages.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1890,7 +1890,7 @@ zpages:
             <td>Enable service port for ZPages.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--health-check--enabled"><a href="./values.yaml#L1138">otelDeployment.ports.health-check.enabled</a></td>
+            <td id="otelDeployment--ports--health-check--enabled"><a href="./values.yaml#L1139">otelDeployment.ports.health-check.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -1899,7 +1899,7 @@ zpages:
             <td>Enable service port for health checks.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--pprof--enabled"><a href="./values.yaml#L1151">otelDeployment.ports.pprof.enabled</a></td>
+            <td id="otelDeployment--ports--pprof--enabled"><a href="./values.yaml#L1152">otelDeployment.ports.pprof.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1908,7 +1908,7 @@ zpages:
             <td>Enable service port for pprof.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--livenessProbe"><a href="./values.yaml#L1163">otelDeployment.livenessProbe</a></td>
+            <td id="otelDeployment--livenessProbe"><a href="./values.yaml#L1164">otelDeployment.livenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
@@ -1924,7 +1924,7 @@ timeoutSeconds: 5</pre>
             <td>Configure liveness probe.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--readinessProbe"><a href="./values.yaml#L1183">otelDeployment.readinessProbe</a></td>
+            <td id="otelDeployment--readinessProbe"><a href="./values.yaml#L1184">otelDeployment.readinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">enabled: true
@@ -1940,7 +1940,7 @@ timeoutSeconds: 5</pre>
             <td>Configure readiness probe.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--customLivenessProbe"><a href="./values.yaml#L1203">otelDeployment.customLivenessProbe</a></td>
+            <td id="otelDeployment--customLivenessProbe"><a href="./values.yaml#L1204">otelDeployment.customLivenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1949,7 +1949,7 @@ timeoutSeconds: 5</pre>
             <td>Custom liveness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--customReadinessProbe"><a href="./values.yaml#L1207">otelDeployment.customReadinessProbe</a></td>
+            <td id="otelDeployment--customReadinessProbe"><a href="./values.yaml#L1208">otelDeployment.customReadinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -1958,7 +1958,7 @@ timeoutSeconds: 5</pre>
             <td>Custom readiness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress"><a href="./values.yaml#L1211">otelDeployment.ingress</a></td>
+            <td id="otelDeployment--ingress"><a href="./values.yaml#L1212">otelDeployment.ingress</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -1976,7 +1976,7 @@ tls: []</pre>
             <td>Ingress configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--enabled"><a href="./values.yaml#L1214">otelDeployment.ingress.enabled</a></td>
+            <td id="otelDeployment--ingress--enabled"><a href="./values.yaml#L1215">otelDeployment.ingress.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">false</pre>
@@ -1985,7 +1985,7 @@ tls: []</pre>
             <td>Enable Ingress for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--className"><a href="./values.yaml#L1217">otelDeployment.ingress.className</a></td>
+            <td id="otelDeployment--ingress--className"><a href="./values.yaml#L1218">otelDeployment.ingress.className</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -1994,7 +1994,7 @@ tls: []</pre>
             <td>Ingress Class Name to be used.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--annotations"><a href="./values.yaml#L1220">otelDeployment.ingress.annotations</a></td>
+            <td id="otelDeployment--ingress--annotations"><a href="./values.yaml#L1221">otelDeployment.ingress.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -2003,7 +2003,7 @@ tls: []</pre>
             <td>Annotations for the OtelDeployment Ingress.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--hosts"><a href="./values.yaml#L1223">otelDeployment.ingress.hosts</a></td>
+            <td id="otelDeployment--ingress--hosts"><a href="./values.yaml#L1224">otelDeployment.ingress.hosts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">- host: otel-deployment.domain.com
@@ -2016,7 +2016,7 @@ tls: []</pre>
             <td>OtelDeployment Ingress hostnames.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--tls"><a href="./values.yaml#L1231">otelDeployment.ingress.tls</a></td>
+            <td id="otelDeployment--ingress--tls"><a href="./values.yaml#L1232">otelDeployment.ingress.tls</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -2025,7 +2025,7 @@ tls: []</pre>
             <td>OtelDeployment Ingress TLS configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--resources"><a href="./values.yaml#L1238">otelDeployment.resources</a></td>
+            <td id="otelDeployment--resources"><a href="./values.yaml#L1239">otelDeployment.resources</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">requests:
@@ -2036,7 +2036,7 @@ tls: []</pre>
             <td>Configure resource requests and limits for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--priorityClassName"><a href="./values.yaml#L1249">otelDeployment.priorityClassName</a></td>
+            <td id="otelDeployment--priorityClassName"><a href="./values.yaml#L1250">otelDeployment.priorityClassName</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -2045,7 +2045,7 @@ tls: []</pre>
             <td>OtelDeployment Priority Class name.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--nodeSelector"><a href="./values.yaml#L1253">otelDeployment.nodeSelector</a></td>
+            <td id="otelDeployment--nodeSelector"><a href="./values.yaml#L1254">otelDeployment.nodeSelector</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -2054,7 +2054,7 @@ tls: []</pre>
             <td>Node selector for OtelDeployment pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--tolerations"><a href="./values.yaml#L1257">otelDeployment.tolerations</a></td>
+            <td id="otelDeployment--tolerations"><a href="./values.yaml#L1258">otelDeployment.tolerations</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -2063,7 +2063,7 @@ tls: []</pre>
             <td>Toleration labels for OtelDeployment pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--affinity"><a href="./values.yaml#L1261">otelDeployment.affinity</a></td>
+            <td id="otelDeployment--affinity"><a href="./values.yaml#L1262">otelDeployment.affinity</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -2072,7 +2072,7 @@ tls: []</pre>
             <td>Affinity settings for the OtelDeployment pod.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--topologySpreadConstraints"><a href="./values.yaml#L1265">otelDeployment.topologySpreadConstraints</a></td>
+            <td id="otelDeployment--topologySpreadConstraints"><a href="./values.yaml#L1266">otelDeployment.topologySpreadConstraints</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -2081,7 +2081,7 @@ tls: []</pre>
             <td>Describes how OtelDeployment pods ought to spread.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole"><a href="./values.yaml#L1270">otelDeployment.clusterRole</a></td>
+            <td id="otelDeployment--clusterRole"><a href="./values.yaml#L1271">otelDeployment.clusterRole</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please Checkout the values.yml for default values</pre>
@@ -2090,7 +2090,7 @@ tls: []</pre>
             <td>ClusterRole configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--create"><a href="./values.yaml#L1273">otelDeployment.clusterRole.create</a></td>
+            <td id="otelDeployment--clusterRole--create"><a href="./values.yaml#L1274">otelDeployment.clusterRole.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">true</pre>
@@ -2099,7 +2099,7 @@ tls: []</pre>
             <td>Specifies whether a ClusterRole should be created.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--annotations"><a href="./values.yaml#L1276">otelDeployment.clusterRole.annotations</a></td>
+            <td id="otelDeployment--clusterRole--annotations"><a href="./values.yaml#L1277">otelDeployment.clusterRole.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">{}</pre>
@@ -2108,7 +2108,7 @@ tls: []</pre>
             <td>Annotations for the ClusterRole.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--name"><a href="./values.yaml#L1279">otelDeployment.clusterRole.name</a></td>
+            <td id="otelDeployment--clusterRole--name"><a href="./values.yaml#L1280">otelDeployment.clusterRole.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">""</pre>
@@ -2117,7 +2117,7 @@ tls: []</pre>
             <td>The name of the ClusterRole to use. A name is generated if not set.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--rules"><a href="./values.yaml#L1283">otelDeployment.clusterRole.rules</a></td>
+            <td id="otelDeployment--clusterRole--rules"><a href="./values.yaml#L1284">otelDeployment.clusterRole.rules</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please checkout the values.yml for default values</pre>
@@ -2126,7 +2126,7 @@ tls: []</pre>
             <td>RBAC rules for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--clusterRoleBinding"><a href="./values.yaml#L1313">otelDeployment.clusterRole.clusterRoleBinding</a></td>
+            <td id="otelDeployment--clusterRole--clusterRoleBinding"><a href="./values.yaml#L1314">otelDeployment.clusterRole.clusterRoleBinding</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">annotations: {}
@@ -2136,7 +2136,7 @@ name: ""</pre>
             <td>ClusterRoleBinding configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--config"><a href="./values.yaml#L1324">otelDeployment.config</a></td>
+            <td id="otelDeployment--config"><a href="./values.yaml#L1325">otelDeployment.config</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">Please Checkout the values.yml for default values</pre>
@@ -2145,7 +2145,7 @@ name: ""</pre>
             <td>Base configuration for the OtelDeployment Collector.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--config--processors--batch"><a href="./values.yaml#L1331">otelDeployment.config.processors.batch</a></td>
+            <td id="otelDeployment--config--processors--batch"><a href="./values.yaml#L1332">otelDeployment.config.processors.batch</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">send_batch_size: 10000
@@ -2155,7 +2155,7 @@ timeout: 1s</pre>
             <td>Batch processor config.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--extraVolumes"><a href="./values.yaml#L1371">otelDeployment.extraVolumes</a></td>
+            <td id="otelDeployment--extraVolumes"><a href="./values.yaml#L1372">otelDeployment.extraVolumes</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>
@@ -2164,7 +2164,7 @@ timeout: 1s</pre>
             <td>Additional volumes for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--extraVolumeMounts"><a href="./values.yaml#L1381">otelDeployment.extraVolumeMounts</a></td>
+            <td id="otelDeployment--extraVolumeMounts"><a href="./values.yaml#L1382">otelDeployment.extraVolumeMounts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="tpl/array">[]</pre>

--- a/charts/k8s-infra/README.md
+++ b/charts/k8s-infra/README.md
@@ -342,7 +342,7 @@ storageClass: null</pre>
         </tr>
     </tbody>
 </table><h3>Presets Configuration</h3>
-  <p>Presets to easily set up OtelCollector configurations. For more details, see the [documentation](https://signoz.io/docs/collection-agents/k8s/k8s-infra/configure-k8s-infra/).</p>
+  <p>Presets to easily set up OtelCollector configurations. For more details, see the <a href="https://signoz.io/docs/collection-agents/k8s/k8s-infra/configure-k8s-infra/">documentation</a>.</p>
 <h3>Logging Exporter Presets</h3>
 <table>
     <thead>

--- a/charts/k8s-infra/README.md.gotmpl
+++ b/charts/k8s-infra/README.md.gotmpl
@@ -75,6 +75,11 @@ kubectl delete namespace platform
 
 {{/* Handle explicitly defined sections */}}
 {{- range .Sections.Sections }}
+{{- if and (eq .SectionName "Presets Configuration")}}
+  {{- $item := index .SectionItems 0 -}}
+  <h3>{{- .SectionName }}</h3>
+  <p>{{ if $item.Description }}{{ $item.Description }}{{ else }}{{ $item.AutoDescription }}{{ end }}.</p>
+{{- else }}
 <h3>{{- .SectionName }}</h3>
 <table>
     <thead>
@@ -96,6 +101,7 @@ kubectl delete namespace platform
     {{- end }}
     </tbody>
 </table>
+{{- end}}
 {{- end }}
 
 {{/* Handle the default section for any un-annotated values */}}
@@ -122,7 +128,6 @@ kubectl delete namespace platform
 	</tbody>
 </table>
 {{ end }}
-
 {{ end }}
 
 {{ define "chart.valuesSectionHtml" }}

--- a/charts/k8s-infra/README.md.gotmpl
+++ b/charts/k8s-infra/README.md.gotmpl
@@ -18,7 +18,7 @@ The `k8s-infra` chart provides Kubernetes infrastructure observability by deploy
 
 It enables collection of metrics, logs, and events from your Kubernetes cluster, making it easier to monitor and troubleshoot your infrastructure with SigNoz.
 
-Refer to the documentation for a more detailed explanation of [k8s-infra](https://signoz.io/docs/infrastructure-monitoring/k8s-infra-architecture).
+Refer to the documentation for a more detailed explanation of [k8s-infra](https://signoz.io/docs/collection-agents/k8s/k8s-infra/overview/)
 ### Prerequisites
 
 - Kubernetes 1.16+

--- a/charts/k8s-infra/README.md.gotmpl
+++ b/charts/k8s-infra/README.md.gotmpl
@@ -80,7 +80,11 @@ kubectl delete namespace platform
   <h3>{{- .SectionName }}</h3>
   <p>{{ if $item.Description }}{{ $item.Description }}{{ else }}{{ $item.AutoDescription }}{{ end }}.</p>
 {{- else}}
+{{- if contains "Presets" .SectionName}}
+<h4>{{- .SectionName}}</h4>
+{{- else}}
 <h3>{{- .SectionName }}</h3>
+{{- end}}
 <table>
     <thead>
         <th>Key</th>

--- a/charts/k8s-infra/README.md.gotmpl
+++ b/charts/k8s-infra/README.md.gotmpl
@@ -68,7 +68,7 @@ kubectl delete namespace platform
 {{- if (and (hasPrefix "" $defaultValue) (hasSuffix "" $defaultValue) ) -}}
 {{- $defaultValue = (toYaml (fromJson (trimAll "`" $defaultValue) ) ) -}}
 {{- end -}}
-<pre lang="tpl/array">{{ $defaultValue }}</pre>
+<pre lang="yaml">{{ $defaultValue }}</pre>
 {{ end }}
 
 {{ define "chart.valuesTableHtml" }}

--- a/charts/k8s-infra/README.md.gotmpl
+++ b/charts/k8s-infra/README.md.gotmpl
@@ -75,11 +75,11 @@ kubectl delete namespace platform
 
 {{/* Handle explicitly defined sections */}}
 {{- range .Sections.Sections }}
-{{- if and (eq .SectionName "Presets Configuration")}}
+{{- if (eq .SectionName "Presets Configuration")}}
   {{- $item := index .SectionItems 0 -}}
   <h3>{{- .SectionName }}</h3>
   <p>{{ if $item.Description }}{{ $item.Description }}{{ else }}{{ $item.AutoDescription }}{{ end }}.</p>
-{{- else }}
+{{- else}}
 <h3>{{- .SectionName }}</h3>
 <table>
     <thead>

--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -168,7 +168,7 @@ Build config file for deployment OpenTelemetry Collector: OtelDeployment
 
 {{- define "opentelemetry-collector.loggingExporterConfig" -}}
 exporters:
-  logging:
+  debug:
     {{- with .Values.presets.loggingExporter }}
     verbosity: {{ .verbosity }}
     sampling_initial: {{ .samplingInitial }}

--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -83,7 +83,7 @@ spec:
             - name: {{ $key }}
               containerPort: {{ $port.containerPort }}
               protocol: {{ $port.protocol }}
-              {{- if and $port.hostPort (ne $.Values.global.cloud "gcp/autogke") }}
+              {{- if and $port.hostPort (ne $.Values.global.cloud "gcp/autogke") (not $.Values.otelAgent.hostNetwork) }}
               hostPort: {{ $port.hostPort }}
               {{- end }}
             {{- end }}

--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -72,6 +72,7 @@ spec:
         {{- with .Values.otelAgent.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      hostNetwork: {{ .Values.otelAgent.hostNetwork | default false }}
       containers:
         - name: {{ include "otelAgent.fullname" . }}
           image: {{ include "otelAgent.image" . }}

--- a/charts/k8s-infra/tests/otel-agent_debug_exporter_test.yaml
+++ b/charts/k8s-infra/tests/otel-agent_debug_exporter_test.yaml
@@ -36,7 +36,7 @@ tests:
   - it: should have debug enabled is enabled with default settings
     set:
       presets:
-        debugExporter: 
+        debugExporter:
           enabled: true
     asserts:
       - equal:
@@ -103,7 +103,7 @@ tests:
   - it: should have debug enabled is enabled with custom settings
     set:
       presets:
-        debugExporter: 
+        debugExporter:
           enabled: true
           samplingInitial: 5
           samplingThereafter: 600
@@ -169,11 +169,11 @@ tests:
                 metrics:
                   address: 0.0.0.0:8888
 
-  # Test case 2: Verify debug exporter is enabled when set to true with custom settings
+  # Test case 3: Verify debug exporter is enabled when set to true with custom settings
   - it: should have logging exporter enabled is enabled with custom settings
     set:
       presets:
-        loggingExporter: 
+        loggingExporter:
           enabled: true
           samplingInitial: 5
           samplingThereafter: 600

--- a/charts/k8s-infra/tests/otel-agent_debug_exporter_test.yaml
+++ b/charts/k8s-infra/tests/otel-agent_debug_exporter_test.yaml
@@ -1,4 +1,4 @@
-suite: Test otlp exporter setting
+suite: Test debug exporter setting
 templates:
   - otel-agent/configmap.yaml
 set:
@@ -6,10 +6,10 @@ set:
     # Disable other presets to focus on otlp exporter
     prometheus:
       enabled: false
-    debugExporter:
-      enabled: false
     otlpExporter:
-      enabled: true
+      enabled: false
+    otlphttpExporter:
+      enabled: false
     logsCollection:
       enabled: false
     hostMetrics:
@@ -31,21 +31,22 @@ set:
         enabled: false
       logs:
         enabled: false
-# Test case 1: Verify otlp (grpc) is enabled by default and otlp (http) is disabled
+# Test case 1: Verify when debug exporter is enabled it should be configured correctly with default settings
 tests:
-  - it: should have otlp (grpc) enabled by default and otlp (http) disabled
+  - it: should have debug enabled is enabled with default settings
+    set:
+      presets:
+        debugExporter: 
+          enabled: true
     asserts:
       - equal:
           path: data["otel-agent-config.yaml"]
           value: |-
             exporters:
-              otlp:
-                endpoint: ${env:OTEL_EXPORTER_OTLP_ENDPOINT}
-                headers:
-                  signoz-access-token: ${env:SIGNOZ_API_KEY}
-                tls:
-                  insecure: ${env:OTEL_EXPORTER_OTLP_INSECURE}
-                  insecure_skip_verify: ${env:OTEL_EXPORTER_OTLP_INSECURE_SKIP_VERIFY}
+              debug:
+                sampling_initial: 2
+                sampling_thereafter: 500
+                verbosity: basic
             extensions:
               health_check:
                 endpoint: 0.0.0.0:13133
@@ -73,21 +74,21 @@ tests:
               pipelines:
                 logs:
                   exporters:
-                  - otlp
+                  - debug
                   processors:
                   - batch
                   receivers:
                   - otlp
                 metrics:
                   exporters:
-                  - otlp
+                  - debug
                   processors:
                   - batch
                   receivers:
                   - otlp
                 traces:
                   exporters:
-                  - otlp
+                  - debug
                   processors:
                   - batch
                   receivers:
@@ -98,24 +99,24 @@ tests:
                 metrics:
                   address: 0.0.0.0:8888
 
-  # Test case 2: Verify otlp/http is enabled when the value is set to true
-  - it: should enable otlp/http when otlphttpExporter set to true
+  # Test case 2: Verify debug exporter is enabled when set to true with custom settings
+  - it: should have debug enabled is enabled with custom settings
     set:
       presets:
-        otlphttpExporter: 
+        debugExporter: 
           enabled: true
+          samplingInitial: 5
+          samplingThereafter: 600
+          verbosity: normal
     asserts:
       - equal:
           path: data["otel-agent-config.yaml"]
           value: |-
             exporters:
-              otlphttp:
-                endpoint: ${env:OTEL_EXPORTER_OTLP_ENDPOINT}
-                headers:
-                  signoz-access-token: ${env:SIGNOZ_API_KEY}
-                tls:
-                  insecure: ${env:OTEL_EXPORTER_OTLP_INSECURE}
-                  insecure_skip_verify: ${env:OTEL_EXPORTER_OTLP_INSECURE_SKIP_VERIFY}
+              debug:
+                sampling_initial: 5
+                sampling_thereafter: 600
+                verbosity: normal
             extensions:
               health_check:
                 endpoint: 0.0.0.0:13133
@@ -143,21 +144,91 @@ tests:
               pipelines:
                 logs:
                   exporters:
-                  - otlphttp
+                  - debug
                   processors:
                   - batch
                   receivers:
                   - otlp
                 metrics:
                   exporters:
-                  - otlphttp
+                  - debug
                   processors:
                   - batch
                   receivers:
                   - otlp
                 traces:
                   exporters:
-                  - otlphttp
+                  - debug
+                  processors:
+                  - batch
+                  receivers:
+                  - otlp
+              telemetry:
+                logs:
+                  encoding: json
+                metrics:
+                  address: 0.0.0.0:8888
+
+  # Test case 2: Verify debug exporter is enabled when set to true with custom settings
+  - it: should have logging exporter enabled is enabled with custom settings
+    set:
+      presets:
+        loggingExporter: 
+          enabled: true
+          samplingInitial: 5
+          samplingThereafter: 600
+          verbosity: normal
+    asserts:
+      - equal:
+          path: data["otel-agent-config.yaml"]
+          value: |-
+            exporters:
+              debug:
+                sampling_initial: 5
+                sampling_thereafter: 600
+                verbosity: normal
+            extensions:
+              health_check:
+                endpoint: 0.0.0.0:13133
+              pprof:
+                endpoint: localhost:1777
+              zpages:
+                endpoint: localhost:55679
+            processors:
+              batch:
+                send_batch_size: 10000
+                timeout: 200ms
+            receivers:
+              otlp:
+                protocols:
+                  grpc:
+                    endpoint: 0.0.0.0:4317
+                    max_recv_msg_size_mib: 4
+                  http:
+                    endpoint: 0.0.0.0:4318
+            service:
+              extensions:
+              - health_check
+              - zpages
+              - pprof
+              pipelines:
+                logs:
+                  exporters:
+                  - debug
+                  processors:
+                  - batch
+                  receivers:
+                  - otlp
+                metrics:
+                  exporters:
+                  - debug
+                  processors:
+                  - batch
+                  receivers:
+                  - otlp
+                traces:
+                  exporters:
+                  - debug
                   processors:
                   - batch
                   receivers:

--- a/charts/k8s-infra/tests/otel-agent_host_network_test.yaml
+++ b/charts/k8s-infra/tests/otel-agent_host_network_test.yaml
@@ -1,0 +1,24 @@
+suite: Test hostNetwork setting
+templates:
+  - otel-agent/daemonset.yaml
+  - otel-agent/configmap.yaml
+
+# Test case 1: Verify hostNetwork is present but disabled by default
+tests:
+  - it: should have hostNetwork present but disabled by default
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+        template: otel-agent/daemonset.yaml
+
+  # Test case 2: Verify hostNetwork is enabled when the value is set to true
+  - it: should enable hostNetwork when set to true
+    set:
+      otelAgent:
+        hostNetwork: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+        template: otel-agent/daemonset.yaml

--- a/charts/k8s-infra/tests/otel-agent_log_collection_test.yaml
+++ b/charts/k8s-infra/tests/otel-agent_log_collection_test.yaml
@@ -9,7 +9,7 @@ set:
   presets:
     prometheus:
       enabled: false
-    loggingExporter:
+    debugExporter:
       enabled: false
     otlpExporter:
       enabled: false

--- a/charts/k8s-infra/tests/otel-agent_otlp_exporter_test.yaml
+++ b/charts/k8s-infra/tests/otel-agent_otlp_exporter_test.yaml
@@ -102,7 +102,7 @@ tests:
   - it: should enable otlp/http when otlphttpExporter set to true
     set:
       presets:
-        otlphttpExporter: 
+        otlphttpExporter:
           enabled: true
     asserts:
       - equal:

--- a/charts/k8s-infra/tests/otel-agent_otlp_exporter_test.yaml
+++ b/charts/k8s-infra/tests/otel-agent_otlp_exporter_test.yaml
@@ -1,0 +1,169 @@
+suite: Test otlp exporter setting
+templates:
+  - otel-agent/configmap.yaml
+set:
+  presets:
+    # Disable other presets to focus on otlp exporter
+    prometheus:
+      enabled: false
+    loggingExporter:
+      enabled: false
+    otlpExporter:
+      enabled: true
+    logsCollection:
+      enabled: false
+    hostMetrics:
+      enabled: false
+    kubeletMetrics:
+      enabled: false
+    kubernetesAttributes:
+      enabled: false
+    clusterMetrics:
+      enabled: false
+    resourceDetection:
+      enabled: false
+    k8sEvents:
+      enabled: false
+    selfTelemetry:
+      traces:
+        enabled: false
+      metrics:
+        enabled: false
+      logs:
+        enabled: false
+# Test case 1: Verify otlp (grpc) is enabled by default and otlp (http) is disabled
+tests:
+  - it: should have otlp (grpc) enabled by default and otlp (http) disabled
+    asserts:
+      - equal:
+          path: data["otel-agent-config.yaml"]
+          value: |-
+            exporters:
+              otlphttp:
+                endpoint: ${env:OTEL_EXPORTER_OTLP_ENDPOINT}
+                headers:
+                  signoz-access-token: ${env:SIGNOZ_API_KEY}
+                tls:
+                  insecure: ${env:OTEL_EXPORTER_OTLP_INSECURE}
+                  insecure_skip_verify: ${env:OTEL_EXPORTER_OTLP_INSECURE_SKIP_VERIFY}
+            extensions:
+              health_check:
+                endpoint: 0.0.0.0:13133
+              pprof:
+                endpoint: localhost:1777
+              zpages:
+                endpoint: localhost:55679
+            processors:
+              batch:
+                send_batch_size: 10000
+                timeout: 200ms
+            receivers:
+              otlp:
+                protocols:
+                  grpc:
+                    endpoint: 0.0.0.0:4317
+                    max_recv_msg_size_mib: 4
+                  http:
+                    endpoint: 0.0.0.0:4318
+            service:
+              extensions:
+              - health_check
+              - zpages
+              - pprof
+              pipelines:
+                logs:
+                  exporters:
+                  - otlp
+                  processors:
+                  - batch
+                  receivers:
+                  - otlp
+                metrics:
+                  exporters:
+                  - otlp
+                  processors:
+                  - batch
+                  receivers:
+                  - otlp
+                traces:
+                  exporters:
+                  - otlp
+                  processors:
+                  - batch
+                  receivers:
+                  - otlp
+              telemetry:
+                logs:
+                  encoding: json
+                metrics:
+                  address: 0.0.0.0:8888
+
+  # Test case 2: Verify otlp/http is enabled when the value is set to true
+  - it: should enable otlp/http when otlphttpExporter set to true
+    set:
+      presets:
+        otlphttpExporter: 
+          enabled: true
+    asserts:
+      - equal:
+          path: data["otel-agent-config.yaml"]
+          value: |-
+            exporters:
+              otlphttp:
+                endpoint: ${env:OTEL_EXPORTER_OTLP_ENDPOINT}
+                headers:
+                  signoz-access-token: ${env:SIGNOZ_API_KEY}
+                tls:
+                  insecure: ${env:OTEL_EXPORTER_OTLP_INSECURE}
+                  insecure_skip_verify: ${env:OTEL_EXPORTER_OTLP_INSECURE_SKIP_VERIFY}
+            extensions:
+              health_check:
+                endpoint: 0.0.0.0:13133
+              pprof:
+                endpoint: localhost:1777
+              zpages:
+                endpoint: localhost:55679
+            processors:
+              batch:
+                send_batch_size: 10000
+                timeout: 200ms
+            receivers:
+              otlp:
+                protocols:
+                  grpc:
+                    endpoint: 0.0.0.0:4317
+                    max_recv_msg_size_mib: 4
+                  http:
+                    endpoint: 0.0.0.0:4318
+            service:
+              extensions:
+              - health_check
+              - zpages
+              - pprof
+              pipelines:
+                logs:
+                  exporters:
+                  - otlp/http
+                  processors:
+                  - batch
+                  receivers:
+                  - otlp
+                metrics:
+                  exporters:
+                  - otlp/http
+                  processors:
+                  - batch
+                  receivers:
+                  - otlp
+                traces:
+                  exporters:
+                  - otlp/http
+                  processors:
+                  - batch
+                  receivers:
+                  - otlp
+              telemetry:
+                logs:
+                  encoding: json
+                metrics:
+                  address: 0.0.0.0:8888

--- a/charts/k8s-infra/tests/otel-agent_self_telemetry_enable_otlp_test.yaml
+++ b/charts/k8s-infra/tests/otel-agent_self_telemetry_enable_otlp_test.yaml
@@ -21,7 +21,7 @@ set:
     # Disable other presets to focus on selfTelemetry
     prometheus:
       enabled: false
-    loggingExporter:
+    debugExporter:
       enabled: false
     otlpExporter:
       enabled: true

--- a/charts/k8s-infra/tests/otel-agent_self_telemetry_test.yaml
+++ b/charts/k8s-infra/tests/otel-agent_self_telemetry_test.yaml
@@ -19,7 +19,7 @@ set:
     # Disable other presets to focus on selfTelemetry
     prometheus:
       enabled: false
-    loggingExporter:
+    debugExporter:
       enabled: false
     otlpExporter:
       enabled: false

--- a/charts/k8s-infra/tests/otel-deployment_debug_exporter_test.yaml
+++ b/charts/k8s-infra/tests/otel-deployment_debug_exporter_test.yaml
@@ -1,0 +1,371 @@
+suite: Test debug exporter setting
+templates:
+  - otel-deployment/configmap.yaml
+set:
+  presets:
+    # Disable other presets to focus on debug exporter with prometheus enabled
+    prometheus:
+      enabled: true
+      annotationsPrefix: "signoz.io"
+      scrapeInterval: 60s
+    otlpExporter:
+      enabled: false
+    logsCollection:
+      enabled: false
+    hostMetrics:
+      enabled: false
+    kubeletMetrics:
+      enabled: false
+    kubernetesAttributes:
+      enabled: false
+    clusterMetrics:
+      enabled: false
+    resourceDetection:
+      enabled: true
+    k8sEvents:
+      enabled: false
+# Test case 1: Verify when debug exporter is enabled it should be configured correctly with default settings
+tests:
+  - it: should have debug enabled when set to true with default settings
+    set:
+      presets:
+        debugExporter: 
+          enabled: true
+    asserts:
+      - equal:
+          path: data["otel-deployment-config.yaml"]
+          value: |-
+            exporters:
+              debug:
+                sampling_initial: 2
+                sampling_thereafter: 500
+                verbosity: basic
+            extensions:
+              health_check:
+                endpoint: 0.0.0.0:13133
+              pprof:
+                endpoint: localhost:1777
+              zpages:
+                endpoint: localhost:55679
+            processors:
+              batch:
+                send_batch_size: 10000
+                timeout: 1s
+              resourcedetection:
+                detectors:
+                - env
+                override: false
+                timeout: 2s
+            receivers:
+              prometheus/scraper:
+                config:
+                  scrape_configs:
+                  - job_name: signoz-scraper
+                    kubernetes_sd_configs:
+                    - role: pod
+                    relabel_configs:
+                    - action: keep
+                      regex: true
+                      source_labels:
+                      - __meta_kubernetes_pod_annotation_signoz_io_scrape
+                    - action: replace
+                      regex: (.+)
+                      source_labels:
+                      - __meta_kubernetes_pod_annotation_signoz_io_path
+                      target_label: __metrics_path__
+                    - action: replace
+                      separator: ':'
+                      source_labels:
+                      - __meta_kubernetes_pod_ip
+                      - __meta_kubernetes_pod_annotation_signoz_io_port
+                      target_label: __address__
+                    - replacement: signoz-scraper
+                      target_label: job_name
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_label_app_kubernetes_io_name
+                      target_label: signoz_k8s_name
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_label_app_kubernetes_io_instance
+                      target_label: signoz_k8s_instance
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_label_app_kubernetes_io_component
+                      target_label: signoz_k8s_component
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_namespace
+                      target_label: k8s_namespace_name
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_name
+                      target_label: k8s_pod_name
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_uid
+                      target_label: k8s_pod_uid
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_node_name
+                      target_label: k8s_node_name
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_ready
+                      target_label: k8s_pod_ready
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_phase
+                      target_label: k8s_pod_phase
+                    scrape_interval: 60s
+            service:
+              extensions:
+              - health_check
+              - zpages
+              - pprof
+              pipelines:
+                metrics/scraper:
+                  exporters:
+                  - debug
+                  processors:
+                  - resourcedetection
+                  - batch
+                  receivers:
+                  - prometheus/scraper
+              telemetry:
+                logs:
+                  encoding: json
+                metrics:
+                  address: 0.0.0.0:8888
+
+  # Test case 2: Verify debug exporter is enabled when set to true with custom settings
+  - it: should have debug enabled is enabled with custom settings
+    set:
+      presets:
+        debugExporter: 
+          enabled: true
+          samplingInitial: 6
+          samplingThereafter: 600
+          verbosity: normal
+    asserts:
+      - equal:
+          path: data["otel-deployment-config.yaml"]
+          value: |-
+            exporters:
+              debug:
+                sampling_initial: 6
+                sampling_thereafter: 600
+                verbosity: normal
+            extensions:
+              health_check:
+                endpoint: 0.0.0.0:13133
+              pprof:
+                endpoint: localhost:1777
+              zpages:
+                endpoint: localhost:55679
+            processors:
+              batch:
+                send_batch_size: 10000
+                timeout: 1s
+              resourcedetection:
+                detectors:
+                - env
+                override: false
+                timeout: 2s
+            receivers:
+              prometheus/scraper:
+                config:
+                  scrape_configs:
+                  - job_name: signoz-scraper
+                    kubernetes_sd_configs:
+                    - role: pod
+                    relabel_configs:
+                    - action: keep
+                      regex: true
+                      source_labels:
+                      - __meta_kubernetes_pod_annotation_signoz_io_scrape
+                    - action: replace
+                      regex: (.+)
+                      source_labels:
+                      - __meta_kubernetes_pod_annotation_signoz_io_path
+                      target_label: __metrics_path__
+                    - action: replace
+                      separator: ':'
+                      source_labels:
+                      - __meta_kubernetes_pod_ip
+                      - __meta_kubernetes_pod_annotation_signoz_io_port
+                      target_label: __address__
+                    - replacement: signoz-scraper
+                      target_label: job_name
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_label_app_kubernetes_io_name
+                      target_label: signoz_k8s_name
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_label_app_kubernetes_io_instance
+                      target_label: signoz_k8s_instance
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_label_app_kubernetes_io_component
+                      target_label: signoz_k8s_component
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_namespace
+                      target_label: k8s_namespace_name
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_name
+                      target_label: k8s_pod_name
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_uid
+                      target_label: k8s_pod_uid
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_node_name
+                      target_label: k8s_node_name
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_ready
+                      target_label: k8s_pod_ready
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_phase
+                      target_label: k8s_pod_phase
+                    scrape_interval: 60s
+            service:
+              extensions:
+              - health_check
+              - zpages
+              - pprof
+              pipelines:
+                metrics/scraper:
+                  exporters:
+                  - debug
+                  processors:
+                  - resourcedetection
+                  - batch
+                  receivers:
+                  - prometheus/scraper
+              telemetry:
+                logs:
+                  encoding: json
+                metrics:
+                  address: 0.0.0.0:8888
+
+  # Test case 2: Verify debug exporter is enabled when set to true with custom settings
+  - it: should have logging exporter enabled is enabled with custom settings
+    set:
+      presets:
+        loggingExporter: 
+          enabled: true
+          samplingInitial: 5
+          samplingThereafter: 600
+          verbosity: normal
+    asserts:
+      - equal:
+          path: data["otel-deployment-config.yaml"]
+          value: |-
+            exporters:
+              debug:
+                sampling_initial: 5
+                sampling_thereafter: 600
+                verbosity: normal
+            extensions:
+              health_check:
+                endpoint: 0.0.0.0:13133
+              pprof:
+                endpoint: localhost:1777
+              zpages:
+                endpoint: localhost:55679
+            processors:
+              batch:
+                send_batch_size: 10000
+                timeout: 1s
+              resourcedetection:
+                detectors:
+                - env
+                override: false
+                timeout: 2s
+            receivers:
+              prometheus/scraper:
+                config:
+                  scrape_configs:
+                  - job_name: signoz-scraper
+                    kubernetes_sd_configs:
+                    - role: pod
+                    relabel_configs:
+                    - action: keep
+                      regex: true
+                      source_labels:
+                      - __meta_kubernetes_pod_annotation_signoz_io_scrape
+                    - action: replace
+                      regex: (.+)
+                      source_labels:
+                      - __meta_kubernetes_pod_annotation_signoz_io_path
+                      target_label: __metrics_path__
+                    - action: replace
+                      separator: ':'
+                      source_labels:
+                      - __meta_kubernetes_pod_ip
+                      - __meta_kubernetes_pod_annotation_signoz_io_port
+                      target_label: __address__
+                    - replacement: signoz-scraper
+                      target_label: job_name
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_label_app_kubernetes_io_name
+                      target_label: signoz_k8s_name
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_label_app_kubernetes_io_instance
+                      target_label: signoz_k8s_instance
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_label_app_kubernetes_io_component
+                      target_label: signoz_k8s_component
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_namespace
+                      target_label: k8s_namespace_name
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_name
+                      target_label: k8s_pod_name
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_uid
+                      target_label: k8s_pod_uid
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_node_name
+                      target_label: k8s_node_name
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_ready
+                      target_label: k8s_pod_ready
+                    - action: replace
+                      source_labels:
+                      - __meta_kubernetes_pod_phase
+                      target_label: k8s_pod_phase
+                    scrape_interval: 60s
+            service:
+              extensions:
+              - health_check
+              - zpages
+              - pprof
+              pipelines:
+                metrics/scraper:
+                  exporters:
+                  - debug
+                  processors:
+                  - resourcedetection
+                  - batch
+                  receivers:
+                  - prometheus/scraper
+              telemetry:
+                logs:
+                  encoding: json
+                metrics:
+                  address: 0.0.0.0:8888

--- a/charts/k8s-infra/tests/otel-deployment_debug_exporter_test.yaml
+++ b/charts/k8s-infra/tests/otel-deployment_debug_exporter_test.yaml
@@ -29,7 +29,7 @@ tests:
   - it: should have debug enabled when set to true with default settings
     set:
       presets:
-        debugExporter: 
+        debugExporter:
           enabled: true
     asserts:
       - equal:
@@ -142,7 +142,7 @@ tests:
   - it: should have debug enabled is enabled with custom settings
     set:
       presets:
-        debugExporter: 
+        debugExporter:
           enabled: true
           samplingInitial: 6
           samplingThereafter: 600
@@ -254,11 +254,11 @@ tests:
                 metrics:
                   address: 0.0.0.0:8888
 
-  # Test case 2: Verify debug exporter is enabled when set to true with custom settings
+  # Test case 3: Verify debug exporter is enabled when set to true with custom settings
   - it: should have logging exporter enabled is enabled with custom settings
     set:
       presets:
-        loggingExporter: 
+        loggingExporter:
           enabled: true
           samplingInitial: 5
           samplingThereafter: 600

--- a/charts/k8s-infra/tests/otel-deployment_prometheus_test.yaml
+++ b/charts/k8s-infra/tests/otel-deployment_prometheus_test.yaml
@@ -11,7 +11,7 @@ set:
       enabled: true
       annotationsPrefix: "signoz.io"
       scrapeInterval: 60s
-    loggingExporter:
+    debugExporter:
       enabled: true
     otlpExporter:
       enabled: false
@@ -130,7 +130,7 @@ tests:
               pipelines:
                 metrics/scraper:
                   exporters:
-                  - logging
+                  - debug
                   processors:
                   - resourcedetection
                   - batch

--- a/charts/k8s-infra/tests/otel-deployment_prometheus_test.yaml
+++ b/charts/k8s-infra/tests/otel-deployment_prometheus_test.yaml
@@ -40,7 +40,7 @@ tests:
           path: data["otel-deployment-config.yaml"]
           value: |-
             exporters:
-              logging:
+              debug:
                 sampling_initial: 2
                 sampling_thereafter: 500
                 verbosity: basic

--- a/charts/k8s-infra/tests/otel-deployment_self_telemetry_test.yaml
+++ b/charts/k8s-infra/tests/otel-deployment_self_telemetry_test.yaml
@@ -17,7 +17,7 @@ set:
     # Disable other presets to focus on selfTelemetry
     prometheus:
       enabled: false
-    loggingExporter:
+    debugExporter:
       enabled: false
     otlpExporter:
       enabled: false

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -791,6 +791,7 @@ otelAgent:
       # @section -- OpenTelemetry Agent (DaemonSet)
       protocol: TCP
   # otelAgent.hostNetwork -- Host networking requested for this pod. Use the host's network namespace.
+  # Please make sure while enabling hostNetwork that the host ports are available as it can lead to port conflicts.
   # @section -- OpenTelemetry Agent (DaemonSet)
   hostNetwork: false
   # otelAgent.livenessProbe -- Configure liveness probe.

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -101,9 +101,9 @@ namespace: ""
 
 
 # presets -- Presets to easily set up OtelCollector configurations.
-# @section -- Configuration Presets
+# @section -- Presets Configuration
 # @default -- "Please check out the values.yml for default values"
-# For more details, see the documentation: https://signoz.io/docs/metrics-management/k8s-infra-otel-config
+# For more details, see the [documentation](https://signoz.io/docs/collection-agents/k8s/k8s-infra/configure-k8s-infra/)
 presets:
   # presets.loggingExporter -- Configuration for the logging exporter, used for debugging telemetry data.
   # @section -- Logging Exporter Presets

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -790,7 +790,9 @@ otelAgent:
       hostPort: 1777
       # @section -- OpenTelemetry Agent (DaemonSet)
       protocol: TCP
-
+  # otelAgent.hostNetwork -- Host networking requested for this pod. Use the host's network namespace.
+  # @section -- OpenTelemetry Agent (DaemonSet)
+  hostNetwork: false
   # otelAgent.livenessProbe -- Configure liveness probe.
   # @section -- OpenTelemetry Agent (DaemonSet)
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -106,154 +106,167 @@ namespace: ""
 # For more details, see the documentation: https://signoz.io/docs/metrics-management/k8s-infra-otel-config
 presets:
   # presets.loggingExporter -- Configuration for the logging exporter, used for debugging telemetry data.
-  # @section -- Configuration Presets
+  # @section -- Logging Exporter Presets
   loggingExporter:
     # presets.loggingExporter.enabled - Enable the logging exporter.
-    # @section -- Configuration Presets
+    # @section -- Logging Exporter Presets
     enabled: false
     # presets.loggingExporter.verbosity - Verbosity of the logging export: `basic`, `normal`, or `detailed`.
-    # @section -- Configuration Presets
+    # @section -- Logging Exporter Presets
     verbosity: basic
     # presets.loggingExporter.samplingInitial - Number of messages initially logged each second.
-    # @section -- Configuration Presets
+    # @section -- Logging Exporter Presets
     samplingInitial: 2
     # presets.loggingExporter.samplingThereafter - Sampling rate after the initial messages are logged.
-    # @section -- Configuration Presets
+    # @section -- Logging Exporter Presets
     samplingThereafter: 500
-  # presets.otlpExporter -- Configuration for the OTLP exporter.
-  # @section -- Configuration Presets
+  # presets.otlpExporter -- OTLP Exporter for the OTLP exporter.
+  # @section -- OTLP Exporter Presets
   otlpExporter:
     # presets.otlpExporter.enabled - Enable the OTLP exporter to send data to the backend.
-    # @section -- Configuration Presets
+    # @section -- OTLP Exporter Presets
     enabled: true
-  # presets.otlphttpExporter.endpoint -- The OTLP HTTP endpoint to which data will be sent.
-  # Set this to true to enable the OTLP HTTP exporter, which uses the HTTP endpoint instead of the gRPC endpoint. Ensure that the OTEL_EXPORTER_OTLP_ENDPOINT environment variable points to the correct endpoint.
-  # @section -- Configuration Presets
+  # presets.otlphttpExporter --  OTLP HTTP Exporter to which data will be sent.
+  # Set this to true to enable the OTLP HTTP exporter, which uses the HTTP endpoint instead of the gRPC endpoint.
+  # @section -- OTLP Exporter Presets
   otlphttpExporter:
+    # presets.otlphttpExporter.enabled - Enable the OTLP HTTP exporter.
+    # @section -- OTLP Exporter Presets
     enabled: false
   # presets.selfTelemetry -- Configuration for sending the collector's own telemetry data.
-  # @section -- Configuration Presets
+  # @section -- Self Telemetry Presets
   selfTelemetry:
     # presets.selfTelemetry.endpoint -- OTLP HTTP endpoint to send own telemetry data to.
-    # @section -- Configuration Presets
+    # @section -- Self Telemetry Presets
     endpoint: ""
     # presets.selfTelemetry.insecure - Whether to use insecure mode for self-telemetry.
-    # @section -- Configuration Presets
+    # @section -- Self Telemetry Presets
     insecure: true
     # presets.selfTelemetry.insecureSkipVerify - Whether to skip verifying the certificate for self-telemetry.
-    # @section -- Configuration Presets
+    # @section -- Self Telemetry Presets
     insecureSkipVerify: true
     # presets.selfTelemetry.signozApiKey - API key for SigNoz Cloud for self-telemetry.
-    # @section -- Configuration Presets
+    # @section -- Self Telemetry Presets
     signozApiKey: ""
     # presets.selfTelemetry.apiKeyExistingSecretName - Existing secret name for the self-telemetry API key.
-    # @section -- Configuration Presets
+    # @section -- Self Telemetry Presets
     apiKeyExistingSecretName: ""
     # presets.selfTelemetry.apiKeyExistingSecretKey - Existing secret key for the self-telemetry API key.
-    # @section -- Configuration Presets
+    # @section -- Self Telemetry Presets
     apiKeyExistingSecretKey: ""
     # presets.selfTelemetry.traces - Configuration for self-telemetry traces.
-    # @section -- Configuration Presets
+    # @section -- Self Telemetry Presets
     traces:
       # presets.selfTelemetry.traces.enabled -- Enable self-telemetry for traces.
-      # @section -- Configuration Presets
+      # @section -- Self Telemetry Presets
       enabled: false
     # presets.selfTelemetry.metrics - Configuration for self-telemetry metrics.
-    # @section -- Configuration Presets
+    # @section -- Self Telemetry Presets
     metrics:
       # presets.selfTelemetry.metrics.enabled -- Enable self-telemetry for metrics.
-      # @section -- Configuration Presets
+      # @section -- Self Telemetry Presets
       enabled: false
     # presets.selfTelemetry.logs -- Configuration for self-telemetry logs.
-    # @section -- Configuration Presets
+    # @section -- Self Telemetry Presets
     logs:
       # presets.selfTelemetry.logs.enabled -- Enable self-telemetry for logs.
-      # @section -- Configuration Presets
+      # @section -- Self Telemetry Presets
       enabled: false
   # presets.logsCollection -- Configuration for collecting logs from pods.
-  # @section -- Configuration Presets
+  # @section -- Logs Collection Presets
+  # @default -- "Please check out the values.yml for default values"
   logsCollection:
     # presets.logsCollection.enabled -- Enable log collection.
-    # @section -- Configuration Presets
+    # @section -- Logs Collection Presets
     enabled: true
     # presets.logsCollection.startAt -- Where to start reading logs from: `end` or `beginning`.
-    # @section -- Configuration Presets
+    # @section -- Logs Collection Presets
     startAt: end
-    # presets.logsCollection.includeFilePath - Include the log file path as an attribute.
-    # @section -- Configuration Presets
+    # presets.logsCollection.includeFilePath -- Include the log file path as an attribute.
+    # @section -- Logs Collection Presets
     includeFilePath: true
-    # presets.logsCollection.includeFileName - Include the log file name as an attribute.
-    # @section -- Configuration Presets
+    # presets.logsCollection.includeFileName -- Include the log file name as an attribute.
+    # @section -- Logs Collection Presets
     includeFileName: false
-    # presets.logsCollection.include - Include path patterns for log files to be collected. By default, all container logs are collected.
-    # @section -- Configuration Presets
+    # presets.logsCollection.include -- Include path patterns for log files to be collected. By default, all container logs are collected.
+    # @section -- Logs Collection Presets
     include:
       - /var/log/pods/*/*/*.log
-    # presets.logsCollection.blacklist - Exclude certain log files from being collected.
-    # @section -- Configuration Presets
+    # presets.logsCollection.blacklist -- Exclude certain log files from being collected.
+    # @section -- Logs Collection Presets
     blacklist:
       # presets.logsCollection.blacklist.enabled - Enable the blacklist.
-      # @section -- Configuration Presets
+      # @section -- Logs Collection Presets
       enabled: true
       # presets.logsCollection.blacklist.signozLogs - Exclude SigNoz's own logs.
-      # @section -- Configuration Presets
+      # @section -- Logs Collection Presets
       signozLogs: true
       # presets.logsCollection.blacklist.namespaces - List of namespaces to exclude from log collection.
-      # @section -- Configuration Presets
+      # @section -- Logs Collection Presets
       namespaces:
         - kube-system
       # presets.logsCollection.blacklist.pods - List of pod names to exclude.
-      # @section -- Configuration Presets
+      # @section -- Logs Collection Presets
       pods:
         - hotrod
         - locust
       # presets.logsCollection.blacklist.containers - List of container names to exclude.
-      # @section -- Configuration Presets
+      # @section -- Logs Collection Presets
       containers: []
       # presets.logsCollection.blacklist.additionalExclude - List of additional file path patterns to exclude.
-      # @section -- Configuration Presets
+      # @section -- Logs Collection Presets
       additionalExclude: []
     # presets.logsCollection.whitelist -- Whitelist certain log files to be collected. If enabled, `include` is ignored.
-    # @section -- Configuration Presets
+    # @section -- Logs Collection Presets
     whitelist:
-      # presets.logsCollection.whitelist.enabled -- Enable the whitelist.
-      # @section -- Configuration Presets
+      # presets.logsCollection.whitelist.enabled - Enable the whitelist.
+      # @section -- Logs Collection Presets
       enabled: false
-      # presets.logsCollection.whitelist.signozLogs -- Include SigNoz's own logs.
-      # @section -- Configuration Presets
+      # presets.logsCollection.whitelist.signozLogs - Include SigNoz's own logs.
+      # @section -- Logs Collection Presets
       signozLogs: true
-      # presets.logsCollection.whitelist.namespaces -- List of namespaces to include in log collection.
-      # @section -- Configuration Presets
+      # presets.logsCollection.whitelist.namespaces - List of namespaces to include in log collection.
+      # @section -- Logs Collection Presets
       namespaces: []
-      # presets.logsCollection.whitelist.pods -- List of pod names to include.
-      # @section -- Configuration Presets
+      # presets.logsCollection.whitelist.pods - List of pod names to include.
+      # @section -- Logs Collection Presets
       pods: []
-      # presets.logsCollection.whitelist.containers -- List of container names to include.
-      # @section -- Configuration Presets
+      # presets.logsCollection.whitelist.containers - List of container names to include.
+      # @section -- Logs Collection Presets
       containers: []
-      # presets.logsCollection.whitelist.additionalInclude -- List of additional file path patterns to include.
-      # @section -- Configuration Presets
+      # presets.logsCollection.whitelist.additionalInclude - List of additional file path patterns to include.
+      # @section -- Logs Collection Presets
       additionalInclude: []
     # presets.logsCollection.operators -- A list of log processing operators.
-    # @section -- Configuration Presets
+    # @section -- Logs Collection Presets
     operators:
       - id: container-parser
         type: container
   # presets.hostMetrics -- Configuration for collecting host-level metrics from nodes.
-  # @section -- Configuration Presets
+  # @section -- Host Metrics Presets
+  # @default -- "Please check out the values.yml for default values"
   hostMetrics:
     # presets.hostMetrics.enabled -- Enable host metrics collection.
-    # @section -- Configuration Presets
+    # @section -- Host Metrics Presets
     enabled: true
-    # presets.hostMetrics.collectionInterval - Frequency at which to scrape host metrics.
-    # @section -- Configuration Presets
+    # presets.hostMetrics.collectionInterval -- Frequency at which to scrape host metrics.
+    # @section -- Host Metrics Presets
     collectionInterval: 30s
-    # presets.hostMetrics.scrapers - Fine-grained control over which host metric scrapers are enabled.
-    # @section -- Configuration Presets
+    # presets.hostMetrics.scrapers -- Fine-grained control over which host metric scrapers are enabled.
+    # @section -- Host Metrics Presets
+    # @default -- "Please check out the values.yml for default values"
     scrapers:
+      # presets.hostMetrics.scrapers.cpu -- Enable CPU metrics collection.
+      # @section -- Host Metrics Presets
       cpu: {}
+      # presets.hostMetrics.scrapers.load -- Enable load metrics collection.
+      # @section -- Host Metrics Presets
       load: {}
+      # presets.hostMetrics.scrapers.memory -- Enable memory metrics collection.
+      # @section -- Host Metrics Presets
       memory: {}
+      # presets.hostMetrics.scrapers.disk -- Enable disk metrics collection.
+      # @section -- Host Metrics Presets
       disk:
         exclude:
           devices:
@@ -267,6 +280,8 @@ presets:
             - ^xvd[a-z]\d+$
             - ^nvme\d+n\d+p\d+$
           match_type: regexp
+      # presets.hostmetrics.scrapers.filesystem -- Enable filesystem metrics collection.
+      # @section -- Host Metrics Presets
       filesystem:
         exclude_fs_types:
           fs_types:
@@ -306,6 +321,8 @@ presets:
             - /var/lib/kubelet/*
             - /snap/*
           match_type: regexp
+      # presets.hostMetrics.scrapers.network -- Enable network metrics collection.
+      # @section -- Host Metrics Presets
       network:
         exclude:
           interfaces:
@@ -321,37 +338,38 @@ presets:
             - ^lo$
           match_type: regexp
   # presets.kubeletMetrics -- Configuration for collecting metrics from Kubelet.
-  # @section -- Configuration Presets
+  # @section -- Kubelet Metrics Presets
+  # @default -- "Please check out the values.yml for default values"
   kubeletMetrics:
     # presets.kubeletMetrics.enabled -- Enable Kubelet metrics collection.
-    # @section -- Configuration Presets
+    # @section -- Kubelet Metrics Presets
     enabled: true
-    # presets.kubeletMetrics.collectionInterval - Frequency at which to scrape Kubelet metrics.
-    # @section -- Configuration Presets
+    # presets.kubeletMetrics.collectionInterval -- Frequency at which to scrape Kubelet metrics.
+    # @section -- Kubelet Metrics Presets
     collectionInterval: 30s
-    # presets.kubeletMetrics.authType - Authentication type to use with Kubelet: `serviceAccount` or `tls`.
-    # @section -- Configuration Presets
+    # presets.kubeletMetrics.authType -- Authentication type to use with Kubelet: `serviceAccount` or `tls`.
+    # @section -- Kubelet Metrics Presets
     authType: serviceAccount
     # presets.kubeletMetrics.endpoint -- Kubelet endpoint.
-    # @section -- Configuration Presets
+    # @section -- Kubelet Metrics Presets
     endpoint: ${env:K8S_HOST_IP}:10250
     # presets.kubeletMetrics.insecureSkipVerify -- Skip verifying Kubelet's certificate.
-    # @section -- Configuration Presets
+    # @section -- Kubelet Metrics Presets
     insecureSkipVerify: true
     # presets.kubeletMetrics.extraMetadataLabels -- List of extra metadata labels to collect.
-    # @section -- Configuration Presets
+    # @section -- Kubelet Metrics Presets
     extraMetadataLabels:
       - container.id
       - k8s.volume.type
     # presets.kubeletMetrics.metricGroups -- Groups of metrics to collect from Kubelet.
-    # @section -- Configuration Presets
+    # @section -- Kubelet Metrics Presets
     metricGroups:
       - container
       - pod
       - node
       - volume
-    # presets.kubeletMetrics.metrics - Fine-grained control over which Kubelet metrics are enabled.
-    # @section -- Configuration Presets
+    # presets.kubeletMetrics.metrics -- Fine-grained control over which Kubelet metrics are enabled.
+    # @section -- Kubelet Metrics Presets
     metrics:
       k8s.node.cpu.usage:
         enabled: true
@@ -382,22 +400,23 @@ presets:
       container.uptime:
         enabled: true
   # presets.kubernetesAttributes -- Processor for adding Kubernetes attributes to telemetry data.
-  # @section -- Configuration Presets
+  # @section -- Kubernetes Attributes Processor Presets
+  # @default -- "Please check out the values.yml for default values"
   kubernetesAttributes:
     # presets.kubernetesAttributes.enabled -- Enable the Kubernetes attributes processor.
-    # @section -- Configuration Presets
+    # @section -- Kubernetes Attributes Processor Presets
     enabled: true
-    # presets.kubernetesAttributes.passthrough - If true, agents will not make k8s API calls, do discovery, or extract metadata.
-    # @section -- Configuration Presets
+    # presets.kubernetesAttributes.passthrough -- If true, agents will not make k8s API calls, do discovery, or extract metadata.
+    # @section -- Kubernetes Attributes Processor Presets
     passthrough: false
-    # presets.kubernetesAttributes.filter - Limit agents to query pods based on specific selectors to reduce resource usage.
-    # @section -- Configuration Presets
+    # presets.kubernetesAttributes.filter -- Limit agents to query pods based on specific selectors to reduce resource usage.
+    # @section -- Kubernetes Attributes Processor Presets
     filter:
-      # presets.kubernetesAttributes.filter.node_from_env_var - Restrict each agent to query pods on the same node.
-      # @section -- Configuration Presets
+      # presets.kubernetesAttributes.filter.node_from_env_var -- Restrict each agent to query pods on the same node.
+      # @section -- Kubernetes Attributes Processor Presets
       node_from_env_var: K8S_NODE_NAME
-    # presets.kubernetesAttributes.podAssociation - Rules for tagging telemetry with pod metadata.
-    # @section -- Configuration Presets
+    # presets.kubernetesAttributes.podAssociation -- Rules for tagging telemetry with pod metadata.
+    # @section -- Kubernetes Attributes Processor Presets
     podAssociation:
       - sources:
         - from: resource_attribute
@@ -407,8 +426,8 @@ presets:
           name: k8s.pod.uid
       - sources:
         - from: connection
-    # presets.kubernetesAttributes.extractMetadatas - Pod/namespace metadata to extract from a list of default metadata fields.
-    # @section -- Configuration Presets
+    # presets.kubernetesAttributes.extractMetadatas -- Pod/namespace metadata to extract from a list of default metadata fields.
+    # @section -- Kubernetes Attributes Processor Presets
     extractMetadatas:
       - k8s.namespace.name
       - k8s.deployment.name
@@ -421,23 +440,24 @@ presets:
       - k8s.pod.name
       - k8s.pod.uid
       - k8s.pod.start_time
-    # presets.kubernetesAttributes.extractLabels - Pod labels to extract as attributes.
-    # @section -- Configuration Presets
+    # presets.kubernetesAttributes.extractLabels -- Pod labels to extract as attributes.
+    # @section -- Kubernetes Attributes Processor Presets
     extractLabels: []
-    # presets.kubernetesAttributes.extractAnnotations - Pod annotations to extract as attributes.
-    # @section -- Configuration Presets
+    # presets.kubernetesAttributes.extractAnnotations -- Pod annotations to extract as attributes.
+    # @section -- Kubernetes Attributes Processor Presets
     extractAnnotations: []
   # presets.clusterMetrics -- Configuration for collecting cluster-level metrics.
-  # @section -- Configuration Presets
+  # @section -- Cluster Metrics Presets
+  # @default -- "Please check out the values.yml for default values"
   clusterMetrics:
     # presets.clusterMetrics.enabled -- Enable cluster metrics collection.
-    # @section -- Configuration Presets
+    # @section -- Cluster Metrics Presets
     enabled: true
-    # presets.clusterMetrics.collectionInterval - Frequency at which to scrape cluster metrics.
-    # @section -- Configuration Presets
+    # presets.clusterMetrics.collectionInterval -- Frequency at which to scrape cluster metrics.
+    # @section -- Cluster Metrics Presets
     collectionInterval: 30s
     # presets.clusterMetrics.resourceAttributes -- Resource attributes to report.
-    # @section -- Configuration Presets
+    # @section -- Cluster Metrics Presets
     resourceAttributes:
       k8s.pod.qos_class:
         enabled: true
@@ -450,7 +470,7 @@ presets:
       k8s.container.status.last_terminated_reason:
         enabled: true
     # presets.clusterMetrics.nodeConditionsToReport -- Node conditions to report as metrics.
-    # @section -- Configuration Presets
+    # @section -- Cluster Metrics Presets
     nodeConditionsToReport:
       - Ready
       - MemoryPressure
@@ -458,69 +478,69 @@ presets:
       - PIDPressure
       - NetworkUnavailable
     # presets.clusterMetrics.allocatableTypesToReport -- Allocatable resource types to report.
-    # @section -- Configuration Presets
+    # @section -- Cluster Metrics Presets
     allocatableTypesToReport:
       - cpu
       - memory
       # - ephemeral-storage
       # - storage
     # presets.clusterMetrics.metrics -- Fine-grained control over which cluster metrics are enabled.
-    # @section -- Configuration Presets
+    # @section -- Cluster Metrics Presets
     metrics:
       k8s.node.condition:
         enabled: true
       k8s.pod.status_reason:
         enabled: true
   # presets.prometheus -- Configuration for scraping Prometheus metrics from pod annotations.
-  # @section -- Configuration Presets
+  # @section -- Prometheus Metrics Presets
   prometheus:
     # presets.prometheus.enabled -- Enable Prometheus metrics scraping.
-    # @section -- Configuration Presets
+    # @section -- Prometheus Metrics Presets
     enabled: false
-    # presets.prometheus.annotationsPrefix - Prefix for the pod annotations used for metrics scraping (e.g., `signoz.io`).
-    # @section -- Configuration Presets
+    # presets.prometheus.annotationsPrefix -- Prefix for the pod annotations used for metrics scraping (e.g., `signoz.io`).
+    # @section -- Prometheus Metrics Presets
     annotationsPrefix: signoz.io
-    # presets.prometheus.scrapeInterval - How often to scrape metrics.
-    # @section -- Configuration Presets
+    # presets.prometheus.scrapeInterval -- How often to scrape metrics.
+    # @section -- Prometheus Metrics Presets
     scrapeInterval: 60s
-    # presets.prometheus.namespaceScoped - Only scrape metrics from pods in the same namespace.
-    # @section -- Configuration Presets
+    # presets.prometheus.namespaceScoped -- Only scrape metrics from pods in the same namespace.
+    # @section -- Prometheus Metrics Presets
     namespaceScoped: false
-    # presets.prometheus.namespaces - If set, only scrape metrics from pods in the specified namespaces.
-    # @section -- Configuration Presets
+    # presets.prometheus.namespaces -- If set, only scrape metrics from pods in the specified namespaces.
+    # @section -- Prometheus Metrics Presets
     namespaces: []
-    # presets.prometheus.includePodLabel - Include all pod labels in the metrics (can cause high cardinality).
-    # @section -- Configuration Presets
+    # presets.prometheus.includePodLabel -- Include all pod labels in the metrics (can cause high cardinality).
+    # @section -- Prometheus Metrics Presets
     includePodLabel: false
-    # presets.prometheus.includeContainerName - Include container name in metrics (not recommended for multi-container pods).
-    # @section -- Configuration Presets
+    # presets.prometheus.includeContainerName -- Include container name in metrics (not recommended for multi-container pods).
+    # @section -- Prometheus Metrics Presets
     includeContainerName: false
   # presets.resourceDetection -- Processor for detecting resource information from the environment (e.g., cloud provider, k8s).
-  # @section -- Configuration Presets
+  # @section -- Resource Detection Processor Presets
   resourceDetection:
-    # presets.resourceDetection.enabled - Enable the resource detection processor.
-    # @section -- Configuration Presets
+    # presets.resourceDetection.enabled -- Enable the resource detection processor.
+    # @section -- Resource Detection Processor Presets
     enabled: true
-    # presets.resourceDetection.timeout - Timeout for resource detection.
-    # @section -- Configuration Presets
+    # presets.resourceDetection.timeout -- Timeout for resource detection.
+    # @section -- Resource Detection Processor Presets
     timeout: 2s
-    # presets.resourceDetection.override - Whether to override existing resource attributes.
-    # @section -- Configuration Presets
+    # presets.resourceDetection.override -- Whether to override existing resource attributes.
+    # @section -- Resource Detection Processor Presets
     override: false
-    # presets.resourceDetection.envResourceAttributes - Additional resource attributes from environment variables.
-    # @section -- Configuration Presets
+    # presets.resourceDetection.envResourceAttributes -- Additional resource attributes from environment variables.
+    # @section -- Resource Detection Processor Presets
     envResourceAttributes: ""
   # presets.k8sEvents -- Configuration for collecting Kubernetes events as logs.
-  # @section -- Configuration Presets
+  # @section -- Kubernetes Events Collection Presets
   k8sEvents:
     # presets.k8sEvents.enabled -- Enable Kubernetes events collection.
-    # @section -- Configuration Presets
+    # @section -- Kubernetes Events Collection Presets
     enabled: true
     # presets.k8sEvents.authType -- Authentication type: `serviceAccount` or `kubeconfig`.
-    # @section -- Configuration Presets
+    # @section -- Kubernetes Events Collection Presets
     authType: serviceAccount
     # presets.k8sEvents.namespaces -- List of namespaces to watch for events. Empty list means all namespaces.
-    # @section -- Configuration Presets
+    # @section -- Kubernetes Events Collection Presets
     namespaces: []
 
 # @section -- OpenTelemetry Agent (DaemonSet)

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -105,20 +105,20 @@ namespace: ""
 # @default -- "Please check out the values.yml for default values"
 # For more details, see the <a href="https://signoz.io/docs/collection-agents/k8s/k8s-infra/configure-k8s-infra/">documentation</a>
 presets:
-  # presets.loggingExporter -- Configuration for the logging exporter, used for debugging telemetry data.
-  # @section -- Logging Exporter Presets
-  loggingExporter:
-    # presets.loggingExporter.enabled - Enable the logging exporter.
-    # @section -- Logging Exporter Presets
+  # presets.debugExporter -- Configuration for the debug exporter, used for debugging telemetry data.
+  # @section -- Debug Exporter Presets
+  debugExporter:
+    # presets.debugExporter.enabled -- Enable the debug exporter.
+    # @section -- Debug Exporter Presets
     enabled: false
-    # presets.loggingExporter.verbosity - Verbosity of the logging export: `basic`, `normal`, or `detailed`.
-    # @section -- Logging Exporter Presets
+    # presets.debugExporter.verbosity -- Verbosity of the debug exporter: `basic`, `normal`, or `detailed`.
+    # @section -- Debug Exporter Presets
     verbosity: basic
-    # presets.loggingExporter.samplingInitial - Number of messages initially logged each second.
-    # @section -- Logging Exporter Presets
+    # presets.debugExporter.samplingInitial -- Number of messages initially logged each second.
+    # @section -- Debug Exporter Presets
     samplingInitial: 2
-    # presets.loggingExporter.samplingThereafter - Sampling rate after the initial messages are logged.
-    # @section -- Logging Exporter Presets
+    # presets.debugExporter.samplingThereafter -- Sampling rate after the initial messages are logged.
+    # @section -- Debug Exporter Presets
     samplingThereafter: 500
   # presets.otlpExporter -- OTLP Exporter for the OTLP exporter.
   # @section -- OTLP Exporter Presets

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -126,6 +126,11 @@ presets:
     # presets.otlpExporter.enabled - Enable the OTLP exporter to send data to the backend.
     # @section -- Configuration Presets
     enabled: true
+  # presets.otlphttpExporter.endpoint -- The OTLP HTTP endpoint to which data will be sent.
+  # Set this to true to enable the OTLP HTTP exporter, which uses the HTTP endpoint instead of the gRPC endpoint. Ensure that the OTEL_EXPORTER_OTLP_ENDPOINT environment variable points to the correct endpoint.
+  # @section -- Configuration Presets
+  otlphttpExporter:
+    enabled: false
   # presets.selfTelemetry -- Configuration for sending the collector's own telemetry data.
   # @section -- Configuration Presets
   selfTelemetry:

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -103,7 +103,7 @@ namespace: ""
 # presets -- Presets to easily set up OtelCollector configurations.
 # @section -- Presets Configuration
 # @default -- "Please check out the values.yml for default values"
-# For more details, see the [documentation](https://signoz.io/docs/collection-agents/k8s/k8s-infra/configure-k8s-infra/)
+# For more details, see the <a href="https://signoz.io/docs/collection-agents/k8s/k8s-infra/configure-k8s-infra/">documentation</a>
 presets:
   # presets.loggingExporter -- Configuration for the logging exporter, used for debugging telemetry data.
   # @section -- Logging Exporter Presets


### PR DESCRIPTION
Related: https://github.com/SigNoz/platform-pod/issues/271
Related: https://github.com/SigNoz/platform-pod/issues/697
Related: https://github.com/SigNoz/charts/pull/653
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable host networking for the OpenTelemetry Agent DaemonSet, allowing agent pods to use the host's network namespace.
  * Introduced a new preset to enable an OTLP HTTP exporter alongside the existing gRPC exporter.
* **Documentation**
  * Updated documentation to describe the new host networking option and the OTLP HTTP exporter preset.
  * Updated documentation links for improved accuracy.
* **Tests**
  * Added tests to validate the host networking configuration behavior.
  * Added tests to verify OTLP exporter protocol configurations, including the new HTTP exporter.
  * Added tests for the new debug exporter configuration and renamed exporter keys.
* **Bug Fixes**
  * Renamed the OpenTelemetry Collector exporter key from "logging" to "debug" for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->