### PR TITLE
chore(k8s-infra): adds support for running k8s-infra on windows

### DIFF
--- a/charts/k8s-infra/README.md
+++ b/charts/k8s-infra/README.md
@@ -1975,16 +1975,16 @@ tag: 0.109.0</pre>
             <td>Repository for the OtelDeployment image.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--tag"><a href="./values.yaml#L1049">otelDeployment.image.tag</a></td>
+            <td id="otelDeployment--image--tag"><a href="./values.yaml#L1050">otelDeployment.image.tag</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">0.109.0</pre>
 </div>
             </td>
-            <td>Tag for the OtelDeployment image.</td>
+            <td>Tag for the OtelDeployment image. In case of your Host OS is windows, use the `0.123.0-windows-2022-amd64` tag.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--pullPolicy"><a href="./values.yaml#L1052">otelDeployment.image.pullPolicy</a></td>
+            <td id="otelDeployment--image--pullPolicy"><a href="./values.yaml#L1053">otelDeployment.image.pullPolicy</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">IfNotPresent</pre>
@@ -1993,7 +1993,7 @@ tag: 0.109.0</pre>
             <td>Image pull policy for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--imagePullSecrets"><a href="./values.yaml#L1056">otelDeployment.imagePullSecrets</a></td>
+            <td id="otelDeployment--imagePullSecrets"><a href="./values.yaml#L1057">otelDeployment.imagePullSecrets</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -2002,7 +2002,7 @@ tag: 0.109.0</pre>
             <td>Image Pull Secrets for the OtelDeployment. Merged with `global.imagePullSecrets`.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--command"><a href="./values.yaml#L1061">otelDeployment.command</a></td>
+            <td id="otelDeployment--command"><a href="./values.yaml#L1062">otelDeployment.command</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">extraArgs: []
@@ -2012,7 +2012,7 @@ name: /otelcol-contrib</pre>
             <td>Command and arguments for the OtelDeployment container.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--command--name"><a href="./values.yaml#L1064">otelDeployment.command.name</a></td>
+            <td id="otelDeployment--command--name"><a href="./values.yaml#L1065">otelDeployment.command.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">/otelcol-contrib</pre>
@@ -2021,7 +2021,7 @@ name: /otelcol-contrib</pre>
             <td>OtelDeployment command name.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--command--extraArgs"><a href="./values.yaml#L1067">otelDeployment.command.extraArgs</a></td>
+            <td id="otelDeployment--command--extraArgs"><a href="./values.yaml#L1068">otelDeployment.command.extraArgs</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -2030,7 +2030,7 @@ name: /otelcol-contrib</pre>
             <td>Extra arguments for the OtelDeployment command.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--configMap"><a href="./values.yaml#L1071">otelDeployment.configMap</a></td>
+            <td id="otelDeployment--configMap"><a href="./values.yaml#L1072">otelDeployment.configMap</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">create: true</pre>
@@ -2039,7 +2039,7 @@ name: /otelcol-contrib</pre>
             <td>ConfigMap configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--configMap--create"><a href="./values.yaml#L1074">otelDeployment.configMap.create</a></td>
+            <td id="otelDeployment--configMap--create"><a href="./values.yaml#L1075">otelDeployment.configMap.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -2048,7 +2048,7 @@ name: /otelcol-contrib</pre>
             <td>Specifies whether a ConfigMap should be created.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--service"><a href="./values.yaml#L1078">otelDeployment.service</a></td>
+            <td id="otelDeployment--service"><a href="./values.yaml#L1079">otelDeployment.service</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
@@ -2058,7 +2058,7 @@ type: ClusterIP</pre>
             <td>Service configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--service--annotations"><a href="./values.yaml#L1081">otelDeployment.service.annotations</a></td>
+            <td id="otelDeployment--service--annotations"><a href="./values.yaml#L1082">otelDeployment.service.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2067,7 +2067,7 @@ type: ClusterIP</pre>
             <td>Annotations for the OtelDeployment service.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--service--type"><a href="./values.yaml#L1084">otelDeployment.service.type</a></td>
+            <td id="otelDeployment--service--type"><a href="./values.yaml#L1085">otelDeployment.service.type</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">ClusterIP</pre>
@@ -2076,7 +2076,7 @@ type: ClusterIP</pre>
             <td>Service type.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount"><a href="./values.yaml#L1088">otelDeployment.serviceAccount</a></td>
+            <td id="otelDeployment--serviceAccount"><a href="./values.yaml#L1089">otelDeployment.serviceAccount</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
@@ -2087,7 +2087,7 @@ name: null</pre>
             <td>ServiceAccount configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount--create"><a href="./values.yaml#L1091">otelDeployment.serviceAccount.create</a></td>
+            <td id="otelDeployment--serviceAccount--create"><a href="./values.yaml#L1092">otelDeployment.serviceAccount.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -2096,7 +2096,7 @@ name: null</pre>
             <td>Specifies whether a ServiceAccount should be created.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount--annotations"><a href="./values.yaml#L1094">otelDeployment.serviceAccount.annotations</a></td>
+            <td id="otelDeployment--serviceAccount--annotations"><a href="./values.yaml#L1095">otelDeployment.serviceAccount.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2105,7 +2105,7 @@ name: null</pre>
             <td>Annotations for the ServiceAccount.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount--name"><a href="./values.yaml#L1097">otelDeployment.serviceAccount.name</a></td>
+            <td id="otelDeployment--serviceAccount--name"><a href="./values.yaml#L1098">otelDeployment.serviceAccount.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">null</pre>
@@ -2114,7 +2114,7 @@ name: null</pre>
             <td>The name of the ServiceAccount to use. A name is generated if not set.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--annotations"><a href="./values.yaml#L1101">otelDeployment.annotations</a></td>
+            <td id="otelDeployment--annotations"><a href="./values.yaml#L1102">otelDeployment.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2123,7 +2123,7 @@ name: null</pre>
             <td>Annotations for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--podAnnotations"><a href="./values.yaml#L1104">otelDeployment.podAnnotations</a></td>
+            <td id="otelDeployment--podAnnotations"><a href="./values.yaml#L1105">otelDeployment.podAnnotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2132,7 +2132,7 @@ name: null</pre>
             <td>Annotations for the OtelDeployment pods.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--additionalEnvs"><a href="./values.yaml#L1111">otelDeployment.additionalEnvs</a></td>
+            <td id="otelDeployment--additionalEnvs"><a href="./values.yaml#L1112">otelDeployment.additionalEnvs</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2141,7 +2141,7 @@ name: null</pre>
             <td>Additional environment variables for the OtelDeployment container.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--podSecurityContext"><a href="./values.yaml#L1115">otelDeployment.podSecurityContext</a></td>
+            <td id="otelDeployment--podSecurityContext"><a href="./values.yaml#L1116">otelDeployment.podSecurityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2150,7 +2150,7 @@ name: null</pre>
             <td>Pod-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--securityContext"><a href="./values.yaml#L1120">otelDeployment.securityContext</a></td>
+            <td id="otelDeployment--securityContext"><a href="./values.yaml#L1121">otelDeployment.securityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2159,7 +2159,7 @@ name: null</pre>
             <td>Container-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--minReadySeconds"><a href="./values.yaml#L1130">otelDeployment.minReadySeconds</a></td>
+            <td id="otelDeployment--minReadySeconds"><a href="./values.yaml#L1131">otelDeployment.minReadySeconds</a></td>
             <td>int</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">5</pre>
@@ -2168,7 +2168,7 @@ name: null</pre>
             <td>Minimum number of seconds for which a newly created Pod should be ready.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--progressDeadlineSeconds"><a href="./values.yaml#L1134">otelDeployment.progressDeadlineSeconds</a></td>
+            <td id="otelDeployment--progressDeadlineSeconds"><a href="./values.yaml#L1135">otelDeployment.progressDeadlineSeconds</a></td>
             <td>int</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">120</pre>
@@ -2177,7 +2177,7 @@ name: null</pre>
             <td>Seconds to wait for the Deployment to progress before it's considered failed.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports"><a href="./values.yaml#L1138">otelDeployment.ports</a></td>
+            <td id="otelDeployment--ports"><a href="./values.yaml#L1139">otelDeployment.ports</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">health-check:
@@ -2209,7 +2209,7 @@ zpages:
             <td>Port configurations for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--metrics--enabled"><a href="./values.yaml#L1143">otelDeployment.ports.metrics.enabled</a></td>
+            <td id="otelDeployment--ports--metrics--enabled"><a href="./values.yaml#L1144">otelDeployment.ports.metrics.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">false</pre>
@@ -2218,7 +2218,7 @@ zpages:
             <td>Enable service port for internal metrics.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--zpages--enabled"><a href="./values.yaml#L1156">otelDeployment.ports.zpages.enabled</a></td>
+            <td id="otelDeployment--ports--zpages--enabled"><a href="./values.yaml#L1157">otelDeployment.ports.zpages.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">false</pre>
@@ -2227,7 +2227,7 @@ zpages:
             <td>Enable service port for ZPages.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--health-check--enabled"><a href="./values.yaml#L1169">otelDeployment.ports.health-check.enabled</a></td>
+            <td id="otelDeployment--ports--health-check--enabled"><a href="./values.yaml#L1170">otelDeployment.ports.health-check.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -2236,7 +2236,7 @@ zpages:
             <td>Enable service port for health checks.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--pprof--enabled"><a href="./values.yaml#L1182">otelDeployment.ports.pprof.enabled</a></td>
+            <td id="otelDeployment--ports--pprof--enabled"><a href="./values.yaml#L1183">otelDeployment.ports.pprof.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">false</pre>
@@ -2245,7 +2245,7 @@ zpages:
             <td>Enable service port for pprof.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--livenessProbe"><a href="./values.yaml#L1194">otelDeployment.livenessProbe</a></td>
+            <td id="otelDeployment--livenessProbe"><a href="./values.yaml#L1195">otelDeployment.livenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">enabled: true
@@ -2261,7 +2261,7 @@ timeoutSeconds: 5</pre>
             <td>Configure liveness probe.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--readinessProbe"><a href="./values.yaml#L1214">otelDeployment.readinessProbe</a></td>
+            <td id="otelDeployment--readinessProbe"><a href="./values.yaml#L1215">otelDeployment.readinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">enabled: true
@@ -2277,7 +2277,7 @@ timeoutSeconds: 5</pre>
             <td>Configure readiness probe.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--customLivenessProbe"><a href="./values.yaml#L1234">otelDeployment.customLivenessProbe</a></td>
+            <td id="otelDeployment--customLivenessProbe"><a href="./values.yaml#L1235">otelDeployment.customLivenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2286,7 +2286,7 @@ timeoutSeconds: 5</pre>
             <td>Custom liveness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--customReadinessProbe"><a href="./values.yaml#L1238">otelDeployment.customReadinessProbe</a></td>
+            <td id="otelDeployment--customReadinessProbe"><a href="./values.yaml#L1239">otelDeployment.customReadinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2295,7 +2295,7 @@ timeoutSeconds: 5</pre>
             <td>Custom readiness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress"><a href="./values.yaml#L1242">otelDeployment.ingress</a></td>
+            <td id="otelDeployment--ingress"><a href="./values.yaml#L1243">otelDeployment.ingress</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
@@ -2313,7 +2313,7 @@ tls: []</pre>
             <td>Ingress configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--enabled"><a href="./values.yaml#L1245">otelDeployment.ingress.enabled</a></td>
+            <td id="otelDeployment--ingress--enabled"><a href="./values.yaml#L1246">otelDeployment.ingress.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">false</pre>
@@ -2322,7 +2322,7 @@ tls: []</pre>
             <td>Enable Ingress for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--className"><a href="./values.yaml#L1248">otelDeployment.ingress.className</a></td>
+            <td id="otelDeployment--ingress--className"><a href="./values.yaml#L1249">otelDeployment.ingress.className</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">""</pre>
@@ -2331,7 +2331,7 @@ tls: []</pre>
             <td>Ingress Class Name to be used.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--annotations"><a href="./values.yaml#L1251">otelDeployment.ingress.annotations</a></td>
+            <td id="otelDeployment--ingress--annotations"><a href="./values.yaml#L1252">otelDeployment.ingress.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2340,7 +2340,7 @@ tls: []</pre>
             <td>Annotations for the OtelDeployment Ingress.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--hosts"><a href="./values.yaml#L1254">otelDeployment.ingress.hosts</a></td>
+            <td id="otelDeployment--ingress--hosts"><a href="./values.yaml#L1255">otelDeployment.ingress.hosts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">- host: otel-deployment.domain.com
@@ -2353,7 +2353,7 @@ tls: []</pre>
             <td>OtelDeployment Ingress hostnames.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--tls"><a href="./values.yaml#L1262">otelDeployment.ingress.tls</a></td>
+            <td id="otelDeployment--ingress--tls"><a href="./values.yaml#L1263">otelDeployment.ingress.tls</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -2362,7 +2362,7 @@ tls: []</pre>
             <td>OtelDeployment Ingress TLS configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--resources"><a href="./values.yaml#L1269">otelDeployment.resources</a></td>
+            <td id="otelDeployment--resources"><a href="./values.yaml#L1270">otelDeployment.resources</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">requests:
@@ -2373,7 +2373,7 @@ tls: []</pre>
             <td>Configure resource requests and limits for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--priorityClassName"><a href="./values.yaml#L1280">otelDeployment.priorityClassName</a></td>
+            <td id="otelDeployment--priorityClassName"><a href="./values.yaml#L1281">otelDeployment.priorityClassName</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">""</pre>
@@ -2382,7 +2382,7 @@ tls: []</pre>
             <td>OtelDeployment Priority Class name.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--nodeSelector"><a href="./values.yaml#L1284">otelDeployment.nodeSelector</a></td>
+            <td id="otelDeployment--nodeSelector"><a href="./values.yaml#L1285">otelDeployment.nodeSelector</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2391,7 +2391,7 @@ tls: []</pre>
             <td>Node selector for OtelDeployment pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--tolerations"><a href="./values.yaml#L1288">otelDeployment.tolerations</a></td>
+            <td id="otelDeployment--tolerations"><a href="./values.yaml#L1289">otelDeployment.tolerations</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -2400,7 +2400,7 @@ tls: []</pre>
             <td>Toleration labels for OtelDeployment pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--affinity"><a href="./values.yaml#L1292">otelDeployment.affinity</a></td>
+            <td id="otelDeployment--affinity"><a href="./values.yaml#L1293">otelDeployment.affinity</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2409,7 +2409,7 @@ tls: []</pre>
             <td>Affinity settings for the OtelDeployment pod.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--topologySpreadConstraints"><a href="./values.yaml#L1296">otelDeployment.topologySpreadConstraints</a></td>
+            <td id="otelDeployment--topologySpreadConstraints"><a href="./values.yaml#L1297">otelDeployment.topologySpreadConstraints</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -2418,7 +2418,7 @@ tls: []</pre>
             <td>Describes how OtelDeployment pods ought to spread.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole"><a href="./values.yaml#L1301">otelDeployment.clusterRole</a></td>
+            <td id="otelDeployment--clusterRole"><a href="./values.yaml#L1302">otelDeployment.clusterRole</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">Please Checkout the values.yml for default values</pre>
@@ -2427,7 +2427,7 @@ tls: []</pre>
             <td>ClusterRole configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--create"><a href="./values.yaml#L1304">otelDeployment.clusterRole.create</a></td>
+            <td id="otelDeployment--clusterRole--create"><a href="./values.yaml#L1305">otelDeployment.clusterRole.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -2436,7 +2436,7 @@ tls: []</pre>
             <td>Specifies whether a ClusterRole should be created.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--annotations"><a href="./values.yaml#L1307">otelDeployment.clusterRole.annotations</a></td>
+            <td id="otelDeployment--clusterRole--annotations"><a href="./values.yaml#L1308">otelDeployment.clusterRole.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2445,7 +2445,7 @@ tls: []</pre>
             <td>Annotations for the ClusterRole.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--name"><a href="./values.yaml#L1310">otelDeployment.clusterRole.name</a></td>
+            <td id="otelDeployment--clusterRole--name"><a href="./values.yaml#L1311">otelDeployment.clusterRole.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">""</pre>
@@ -2454,7 +2454,7 @@ tls: []</pre>
             <td>The name of the ClusterRole to use. A name is generated if not set.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--rules"><a href="./values.yaml#L1314">otelDeployment.clusterRole.rules</a></td>
+            <td id="otelDeployment--clusterRole--rules"><a href="./values.yaml#L1315">otelDeployment.clusterRole.rules</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">Please checkout the values.yml for default values</pre>
@@ -2463,7 +2463,7 @@ tls: []</pre>
             <td>RBAC rules for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--clusterRoleBinding"><a href="./values.yaml#L1344">otelDeployment.clusterRole.clusterRoleBinding</a></td>
+            <td id="otelDeployment--clusterRole--clusterRoleBinding"><a href="./values.yaml#L1345">otelDeployment.clusterRole.clusterRoleBinding</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
@@ -2473,7 +2473,7 @@ name: ""</pre>
             <td>ClusterRoleBinding configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--config"><a href="./values.yaml#L1355">otelDeployment.config</a></td>
+            <td id="otelDeployment--config"><a href="./values.yaml#L1356">otelDeployment.config</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">Please Checkout the values.yml for default values</pre>
@@ -2482,7 +2482,7 @@ name: ""</pre>
             <td>Base configuration for the OtelDeployment Collector.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--config--processors--batch"><a href="./values.yaml#L1362">otelDeployment.config.processors.batch</a></td>
+            <td id="otelDeployment--config--processors--batch"><a href="./values.yaml#L1363">otelDeployment.config.processors.batch</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">send_batch_size: 10000
@@ -2492,7 +2492,7 @@ timeout: 1s</pre>
             <td>Batch processor config.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--extraVolumes"><a href="./values.yaml#L1402">otelDeployment.extraVolumes</a></td>
+            <td id="otelDeployment--extraVolumes"><a href="./values.yaml#L1403">otelDeployment.extraVolumes</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -2501,7 +2501,7 @@ timeout: 1s</pre>
             <td>Additional volumes for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--extraVolumeMounts"><a href="./values.yaml#L1412">otelDeployment.extraVolumeMounts</a></td>
+            <td id="otelDeployment--extraVolumeMounts"><a href="./values.yaml#L1413">otelDeployment.extraVolumeMounts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>

--- a/charts/k8s-infra/README.md
+++ b/charts/k8s-infra/README.md
@@ -36,7 +36,37 @@ helm -n platform --create-namespace install "my-release" signoz/k8s-infra
 These commands deploy K8s-infra on the Kubernetes cluster in the default configuration.
 The [Configuration](#configuration) section lists the parameters that can be configured during installation:
 
-> **Tip**: List all releases using `helm list`
+>[!NOTE]
+> ### Installing K8s-Infra on Windows
+> Follow these steps to configure k8s-infra for Windows environments.
+>
+> #### Use OpenTelemetry Collector Contrib for Windows
+>
+> OpenTelemetry provides Windows-compatible [opentelemetry-collector-contrib](https://hub.docker.com/r/otel/opentelemetry-collector-contrib/tags?name=windows) container images which can be used for k8s-infra. You must specify the Windows image tags in your Helm values configuration.
+>
+> Add the following configuration to your Helm values file:
+>
+> ```yaml
+> otelAgent:
+>   image:
+>     tag: 0.123.0-windows-2022-amd64
+>
+> otelDeployment:
+>   image:
+>     tag: 0.123.0-windows-2022-amd64
+> ```
+>
+> #### Remove Root Path for Host Metrics
+>
+> The host metrics receiver requires configuring the `root_path` when using the host receiver for Linux in containers. However, Windows deployments do not require this configuration and the k8s-infra installation may fail if included. Remove the path from the `root_path` key under `presets.hostMetrics` in your Helm values:
+>
+> ```yaml
+> presets:
+>   hostMetrics:
+>     root_path: ""
+> ```
+>
+> After completing these steps, you can proceed with the [standard k8s-infra installation](https://github.com/SigNoz/charts/tree/main/charts/k8s-infra#installing-the-chart).
 
 ### Uninstalling the chart
 
@@ -62,6 +92,37 @@ Sometimes everything doesn't get properly removed. If that happens try deleting 
 ```bash
 kubectl delete namespace platform
 ```
+> [!WARNING] 
+> ### Breaking Changes
+>
+> #### Version 0.14.1
+>
+> **Configuration Migration Required:**
+> - `presets.loggingExporter` has been deprecated and must be migrated to `presets.debugExporter`.
+>
+> This change aligns with OpenTelemetry's deprecation of the [logging exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.110.0/exporter/loggingexporter) in favor of the [debug exporter](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.110.0/exporter/debugexporter/README.md).
+>
+> **Migration Example:**
+>
+> Replace this configuration:
+> ```yaml
+> presets:
+>   loggingExporter: 
+>     enabled: true
+>     verbosity: basic
+>     samplingInitial: 2
+>     samplingThereafter: 500
+> ```
+>
+> With this configuration:
+> ```yaml
+> presets:
+>   debugExporter: 
+>     enabled: true
+>     verbosity: basic
+>     samplingInitial: 2
+>     samplingThereafter: 500
+> ```
 
 ## Values
 
@@ -641,7 +702,16 @@ signozLogs: true</pre>
             <td>Enable host metrics collection.</td>
         </tr>
         <tr>
-            <td id="presets--hostMetrics--collectionInterval"><a href="./values.yaml#L254">presets.hostMetrics.collectionInterval</a></td>
+            <td id="presets--hostMetrics--rootPath"><a href="./values.yaml#L255">presets.hostMetrics.rootPath</a></td>
+            <td>string</td>
+            <td>
+                <div style="max-width: 300px;"><pre lang="yaml">/hostfs</pre>
+</div>
+            </td>
+            <td>Root path for host metrics collection (Linux only).</td>
+        </tr>
+        <tr>
+            <td id="presets--hostMetrics--collectionInterval"><a href="./values.yaml#L258">presets.hostMetrics.collectionInterval</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">30s</pre>
@@ -650,7 +720,7 @@ signozLogs: true</pre>
             <td>Frequency at which to scrape host metrics.</td>
         </tr>
         <tr>
-            <td id="presets--hostMetrics--scrapers"><a href="./values.yaml#L258">presets.hostMetrics.scrapers</a></td>
+            <td id="presets--hostMetrics--scrapers"><a href="./values.yaml#L262">presets.hostMetrics.scrapers</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">Please check out the values.yml for default values</pre>
@@ -659,7 +729,7 @@ signozLogs: true</pre>
             <td>Fine-grained control over which host metric scrapers are enabled.</td>
         </tr>
         <tr>
-            <td id="presets--hostMetrics--scrapers--cpu"><a href="./values.yaml#L261">presets.hostMetrics.scrapers.cpu</a></td>
+            <td id="presets--hostMetrics--scrapers--cpu"><a href="./values.yaml#L265">presets.hostMetrics.scrapers.cpu</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -668,7 +738,7 @@ signozLogs: true</pre>
             <td>Enable CPU metrics collection.</td>
         </tr>
         <tr>
-            <td id="presets--hostMetrics--scrapers--load"><a href="./values.yaml#L264">presets.hostMetrics.scrapers.load</a></td>
+            <td id="presets--hostMetrics--scrapers--load"><a href="./values.yaml#L268">presets.hostMetrics.scrapers.load</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -677,7 +747,7 @@ signozLogs: true</pre>
             <td>Enable load metrics collection.</td>
         </tr>
         <tr>
-            <td id="presets--hostMetrics--scrapers--memory"><a href="./values.yaml#L267">presets.hostMetrics.scrapers.memory</a></td>
+            <td id="presets--hostMetrics--scrapers--memory"><a href="./values.yaml#L271">presets.hostMetrics.scrapers.memory</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -686,7 +756,7 @@ signozLogs: true</pre>
             <td>Enable memory metrics collection.</td>
         </tr>
         <tr>
-            <td id="presets--hostMetrics--scrapers--disk"><a href="./values.yaml#L270">presets.hostMetrics.scrapers.disk</a></td>
+            <td id="presets--hostMetrics--scrapers--disk"><a href="./values.yaml#L274">presets.hostMetrics.scrapers.disk</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">exclude:
@@ -706,7 +776,7 @@ signozLogs: true</pre>
             <td>Enable disk metrics collection.</td>
         </tr>
         <tr>
-            <td id="presets--hostMetrics--scrapers--network"><a href="./values.yaml#L326">presets.hostMetrics.scrapers.network</a></td>
+            <td id="presets--hostMetrics--scrapers--network"><a href="./values.yaml#L330">presets.hostMetrics.scrapers.network</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">exclude:
@@ -738,7 +808,7 @@ signozLogs: true</pre>
     </thead>
     <tbody>
         <tr>
-            <td id="presets--kubeletMetrics"><a href="./values.yaml#L343">presets.kubeletMetrics</a></td>
+            <td id="presets--kubeletMetrics"><a href="./values.yaml#L347">presets.kubeletMetrics</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">Please check out the values.yml for default values</pre>
@@ -747,7 +817,7 @@ signozLogs: true</pre>
             <td>Configuration for collecting metrics from Kubelet.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics--enabled"><a href="./values.yaml#L346">presets.kubeletMetrics.enabled</a></td>
+            <td id="presets--kubeletMetrics--enabled"><a href="./values.yaml#L350">presets.kubeletMetrics.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -756,7 +826,7 @@ signozLogs: true</pre>
             <td>Enable Kubelet metrics collection.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics--collectionInterval"><a href="./values.yaml#L349">presets.kubeletMetrics.collectionInterval</a></td>
+            <td id="presets--kubeletMetrics--collectionInterval"><a href="./values.yaml#L353">presets.kubeletMetrics.collectionInterval</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">30s</pre>
@@ -765,7 +835,7 @@ signozLogs: true</pre>
             <td>Frequency at which to scrape Kubelet metrics.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics--authType"><a href="./values.yaml#L352">presets.kubeletMetrics.authType</a></td>
+            <td id="presets--kubeletMetrics--authType"><a href="./values.yaml#L356">presets.kubeletMetrics.authType</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">serviceAccount</pre>
@@ -774,7 +844,7 @@ signozLogs: true</pre>
             <td>Authentication type to use with Kubelet: `serviceAccount` or `tls`.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics--endpoint"><a href="./values.yaml#L355">presets.kubeletMetrics.endpoint</a></td>
+            <td id="presets--kubeletMetrics--endpoint"><a href="./values.yaml#L359">presets.kubeletMetrics.endpoint</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">${env:K8S_HOST_IP}:10250</pre>
@@ -783,7 +853,7 @@ signozLogs: true</pre>
             <td>Kubelet endpoint.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics--insecureSkipVerify"><a href="./values.yaml#L358">presets.kubeletMetrics.insecureSkipVerify</a></td>
+            <td id="presets--kubeletMetrics--insecureSkipVerify"><a href="./values.yaml#L362">presets.kubeletMetrics.insecureSkipVerify</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -792,7 +862,7 @@ signozLogs: true</pre>
             <td>Skip verifying Kubelet's certificate.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics--extraMetadataLabels"><a href="./values.yaml#L361">presets.kubeletMetrics.extraMetadataLabels</a></td>
+            <td id="presets--kubeletMetrics--extraMetadataLabels"><a href="./values.yaml#L365">presets.kubeletMetrics.extraMetadataLabels</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">- container.id
@@ -802,7 +872,7 @@ signozLogs: true</pre>
             <td>List of extra metadata labels to collect.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics--metricGroups"><a href="./values.yaml#L366">presets.kubeletMetrics.metricGroups</a></td>
+            <td id="presets--kubeletMetrics--metricGroups"><a href="./values.yaml#L370">presets.kubeletMetrics.metricGroups</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">- container
@@ -814,7 +884,7 @@ signozLogs: true</pre>
             <td>Groups of metrics to collect from Kubelet.</td>
         </tr>
         <tr>
-            <td id="presets--kubeletMetrics--metrics"><a href="./values.yaml#L373">presets.kubeletMetrics.metrics</a></td>
+            <td id="presets--kubeletMetrics--metrics"><a href="./values.yaml#L377">presets.kubeletMetrics.metrics</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">container.cpu.usage:
@@ -861,7 +931,7 @@ k8s.pod.uptime:
     </thead>
     <tbody>
         <tr>
-            <td id="presets--kubernetesAttributes"><a href="./values.yaml#L405">presets.kubernetesAttributes</a></td>
+            <td id="presets--kubernetesAttributes"><a href="./values.yaml#L409">presets.kubernetesAttributes</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">Please check out the values.yml for default values</pre>
@@ -870,7 +940,7 @@ k8s.pod.uptime:
             <td>Processor for adding Kubernetes attributes to telemetry data.</td>
         </tr>
         <tr>
-            <td id="presets--kubernetesAttributes--enabled"><a href="./values.yaml#L408">presets.kubernetesAttributes.enabled</a></td>
+            <td id="presets--kubernetesAttributes--enabled"><a href="./values.yaml#L412">presets.kubernetesAttributes.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -879,7 +949,7 @@ k8s.pod.uptime:
             <td>Enable the Kubernetes attributes processor.</td>
         </tr>
         <tr>
-            <td id="presets--kubernetesAttributes--passthrough"><a href="./values.yaml#L411">presets.kubernetesAttributes.passthrough</a></td>
+            <td id="presets--kubernetesAttributes--passthrough"><a href="./values.yaml#L415">presets.kubernetesAttributes.passthrough</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">false</pre>
@@ -888,7 +958,7 @@ k8s.pod.uptime:
             <td>If true, agents will not make k8s API calls, do discovery, or extract metadata.</td>
         </tr>
         <tr>
-            <td id="presets--kubernetesAttributes--filter"><a href="./values.yaml#L414">presets.kubernetesAttributes.filter</a></td>
+            <td id="presets--kubernetesAttributes--filter"><a href="./values.yaml#L418">presets.kubernetesAttributes.filter</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">node_from_env_var: K8S_NODE_NAME</pre>
@@ -897,7 +967,7 @@ k8s.pod.uptime:
             <td>Limit agents to query pods based on specific selectors to reduce resource usage.</td>
         </tr>
         <tr>
-            <td id="presets--kubernetesAttributes--filter--node_from_env_var"><a href="./values.yaml#L417">presets.kubernetesAttributes.filter.node_from_env_var</a></td>
+            <td id="presets--kubernetesAttributes--filter--node_from_env_var"><a href="./values.yaml#L421">presets.kubernetesAttributes.filter.node_from_env_var</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">K8S_NODE_NAME</pre>
@@ -906,7 +976,7 @@ k8s.pod.uptime:
             <td>Restrict each agent to query pods on the same node.</td>
         </tr>
         <tr>
-            <td id="presets--kubernetesAttributes--podAssociation"><a href="./values.yaml#L420">presets.kubernetesAttributes.podAssociation</a></td>
+            <td id="presets--kubernetesAttributes--podAssociation"><a href="./values.yaml#L424">presets.kubernetesAttributes.podAssociation</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">- sources:
@@ -922,7 +992,7 @@ k8s.pod.uptime:
             <td>Rules for tagging telemetry with pod metadata.</td>
         </tr>
         <tr>
-            <td id="presets--kubernetesAttributes--extractMetadatas"><a href="./values.yaml#L431">presets.kubernetesAttributes.extractMetadatas</a></td>
+            <td id="presets--kubernetesAttributes--extractMetadatas"><a href="./values.yaml#L435">presets.kubernetesAttributes.extractMetadatas</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">- k8s.namespace.name
@@ -941,7 +1011,7 @@ k8s.pod.uptime:
             <td>Pod/namespace metadata to extract from a list of default metadata fields.</td>
         </tr>
         <tr>
-            <td id="presets--kubernetesAttributes--extractLabels"><a href="./values.yaml#L445">presets.kubernetesAttributes.extractLabels</a></td>
+            <td id="presets--kubernetesAttributes--extractLabels"><a href="./values.yaml#L449">presets.kubernetesAttributes.extractLabels</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -950,7 +1020,7 @@ k8s.pod.uptime:
             <td>Pod labels to extract as attributes.</td>
         </tr>
         <tr>
-            <td id="presets--kubernetesAttributes--extractAnnotations"><a href="./values.yaml#L448">presets.kubernetesAttributes.extractAnnotations</a></td>
+            <td id="presets--kubernetesAttributes--extractAnnotations"><a href="./values.yaml#L452">presets.kubernetesAttributes.extractAnnotations</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -970,7 +1040,7 @@ k8s.pod.uptime:
     </thead>
     <tbody>
         <tr>
-            <td id="presets--clusterMetrics"><a href="./values.yaml#L452">presets.clusterMetrics</a></td>
+            <td id="presets--clusterMetrics"><a href="./values.yaml#L456">presets.clusterMetrics</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">Please check out the values.yml for default values</pre>
@@ -979,7 +1049,7 @@ k8s.pod.uptime:
             <td>Configuration for collecting cluster-level metrics.</td>
         </tr>
         <tr>
-            <td id="presets--clusterMetrics--enabled"><a href="./values.yaml#L455">presets.clusterMetrics.enabled</a></td>
+            <td id="presets--clusterMetrics--enabled"><a href="./values.yaml#L459">presets.clusterMetrics.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -988,7 +1058,7 @@ k8s.pod.uptime:
             <td>Enable cluster metrics collection.</td>
         </tr>
         <tr>
-            <td id="presets--clusterMetrics--collectionInterval"><a href="./values.yaml#L458">presets.clusterMetrics.collectionInterval</a></td>
+            <td id="presets--clusterMetrics--collectionInterval"><a href="./values.yaml#L462">presets.clusterMetrics.collectionInterval</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">30s</pre>
@@ -997,7 +1067,7 @@ k8s.pod.uptime:
             <td>Frequency at which to scrape cluster metrics.</td>
         </tr>
         <tr>
-            <td id="presets--clusterMetrics--resourceAttributes"><a href="./values.yaml#L461">presets.clusterMetrics.resourceAttributes</a></td>
+            <td id="presets--clusterMetrics--resourceAttributes"><a href="./values.yaml#L465">presets.clusterMetrics.resourceAttributes</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">container.runtime:
@@ -1015,7 +1085,7 @@ k8s.pod.qos_class:
             <td>Resource attributes to report.</td>
         </tr>
         <tr>
-            <td id="presets--clusterMetrics--nodeConditionsToReport"><a href="./values.yaml#L474">presets.clusterMetrics.nodeConditionsToReport</a></td>
+            <td id="presets--clusterMetrics--nodeConditionsToReport"><a href="./values.yaml#L478">presets.clusterMetrics.nodeConditionsToReport</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">- Ready
@@ -1028,7 +1098,7 @@ k8s.pod.qos_class:
             <td>Node conditions to report as metrics.</td>
         </tr>
         <tr>
-            <td id="presets--clusterMetrics--allocatableTypesToReport"><a href="./values.yaml#L482">presets.clusterMetrics.allocatableTypesToReport</a></td>
+            <td id="presets--clusterMetrics--allocatableTypesToReport"><a href="./values.yaml#L486">presets.clusterMetrics.allocatableTypesToReport</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">- cpu
@@ -1038,7 +1108,7 @@ k8s.pod.qos_class:
             <td>Allocatable resource types to report.</td>
         </tr>
         <tr>
-            <td id="presets--clusterMetrics--metrics"><a href="./values.yaml#L489">presets.clusterMetrics.metrics</a></td>
+            <td id="presets--clusterMetrics--metrics"><a href="./values.yaml#L493">presets.clusterMetrics.metrics</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">k8s.node.condition:
@@ -1061,7 +1131,7 @@ k8s.pod.status_reason:
     </thead>
     <tbody>
         <tr>
-            <td id="presets--prometheus"><a href="./values.yaml#L496">presets.prometheus</a></td>
+            <td id="presets--prometheus"><a href="./values.yaml#L500">presets.prometheus</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">annotationsPrefix: signoz.io
@@ -1076,7 +1146,7 @@ scrapeInterval: 60s</pre>
             <td>Configuration for scraping Prometheus metrics from pod annotations.</td>
         </tr>
         <tr>
-            <td id="presets--prometheus--enabled"><a href="./values.yaml#L499">presets.prometheus.enabled</a></td>
+            <td id="presets--prometheus--enabled"><a href="./values.yaml#L503">presets.prometheus.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">false</pre>
@@ -1085,7 +1155,7 @@ scrapeInterval: 60s</pre>
             <td>Enable Prometheus metrics scraping.</td>
         </tr>
         <tr>
-            <td id="presets--prometheus--annotationsPrefix"><a href="./values.yaml#L502">presets.prometheus.annotationsPrefix</a></td>
+            <td id="presets--prometheus--annotationsPrefix"><a href="./values.yaml#L506">presets.prometheus.annotationsPrefix</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">signoz.io</pre>
@@ -1094,7 +1164,7 @@ scrapeInterval: 60s</pre>
             <td>Prefix for the pod annotations used for metrics scraping (e.g., `signoz.io`).</td>
         </tr>
         <tr>
-            <td id="presets--prometheus--scrapeInterval"><a href="./values.yaml#L505">presets.prometheus.scrapeInterval</a></td>
+            <td id="presets--prometheus--scrapeInterval"><a href="./values.yaml#L509">presets.prometheus.scrapeInterval</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">60s</pre>
@@ -1103,7 +1173,7 @@ scrapeInterval: 60s</pre>
             <td>How often to scrape metrics.</td>
         </tr>
         <tr>
-            <td id="presets--prometheus--namespaceScoped"><a href="./values.yaml#L508">presets.prometheus.namespaceScoped</a></td>
+            <td id="presets--prometheus--namespaceScoped"><a href="./values.yaml#L512">presets.prometheus.namespaceScoped</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">false</pre>
@@ -1112,7 +1182,7 @@ scrapeInterval: 60s</pre>
             <td>Only scrape metrics from pods in the same namespace.</td>
         </tr>
         <tr>
-            <td id="presets--prometheus--namespaces"><a href="./values.yaml#L511">presets.prometheus.namespaces</a></td>
+            <td id="presets--prometheus--namespaces"><a href="./values.yaml#L515">presets.prometheus.namespaces</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -1121,7 +1191,7 @@ scrapeInterval: 60s</pre>
             <td>If set, only scrape metrics from pods in the specified namespaces.</td>
         </tr>
         <tr>
-            <td id="presets--prometheus--includePodLabel"><a href="./values.yaml#L514">presets.prometheus.includePodLabel</a></td>
+            <td id="presets--prometheus--includePodLabel"><a href="./values.yaml#L518">presets.prometheus.includePodLabel</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">false</pre>
@@ -1130,7 +1200,7 @@ scrapeInterval: 60s</pre>
             <td>Include all pod labels in the metrics (can cause high cardinality).</td>
         </tr>
         <tr>
-            <td id="presets--prometheus--includeContainerName"><a href="./values.yaml#L517">presets.prometheus.includeContainerName</a></td>
+            <td id="presets--prometheus--includeContainerName"><a href="./values.yaml#L521">presets.prometheus.includeContainerName</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">false</pre>
@@ -1150,7 +1220,7 @@ scrapeInterval: 60s</pre>
     </thead>
     <tbody>
         <tr>
-            <td id="presets--resourceDetection"><a href="./values.yaml#L520">presets.resourceDetection</a></td>
+            <td id="presets--resourceDetection"><a href="./values.yaml#L524">presets.resourceDetection</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">enabled: true
@@ -1162,7 +1232,7 @@ timeout: 2s</pre>
             <td>Processor for detecting resource information from the environment (e.g., cloud provider, k8s).</td>
         </tr>
         <tr>
-            <td id="presets--resourceDetection--enabled"><a href="./values.yaml#L523">presets.resourceDetection.enabled</a></td>
+            <td id="presets--resourceDetection--enabled"><a href="./values.yaml#L527">presets.resourceDetection.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -1171,7 +1241,7 @@ timeout: 2s</pre>
             <td>Enable the resource detection processor.</td>
         </tr>
         <tr>
-            <td id="presets--resourceDetection--timeout"><a href="./values.yaml#L526">presets.resourceDetection.timeout</a></td>
+            <td id="presets--resourceDetection--timeout"><a href="./values.yaml#L530">presets.resourceDetection.timeout</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">2s</pre>
@@ -1180,7 +1250,7 @@ timeout: 2s</pre>
             <td>Timeout for resource detection.</td>
         </tr>
         <tr>
-            <td id="presets--resourceDetection--override"><a href="./values.yaml#L529">presets.resourceDetection.override</a></td>
+            <td id="presets--resourceDetection--override"><a href="./values.yaml#L533">presets.resourceDetection.override</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">false</pre>
@@ -1189,7 +1259,7 @@ timeout: 2s</pre>
             <td>Whether to override existing resource attributes.</td>
         </tr>
         <tr>
-            <td id="presets--resourceDetection--envResourceAttributes"><a href="./values.yaml#L532">presets.resourceDetection.envResourceAttributes</a></td>
+            <td id="presets--resourceDetection--envResourceAttributes"><a href="./values.yaml#L536">presets.resourceDetection.envResourceAttributes</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">""</pre>
@@ -1209,7 +1279,7 @@ timeout: 2s</pre>
     </thead>
     <tbody>
         <tr>
-            <td id="presets--k8sEvents"><a href="./values.yaml#L535">presets.k8sEvents</a></td>
+            <td id="presets--k8sEvents"><a href="./values.yaml#L539">presets.k8sEvents</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">authType: serviceAccount
@@ -1220,7 +1290,7 @@ namespaces: []</pre>
             <td>Configuration for collecting Kubernetes events as logs.</td>
         </tr>
         <tr>
-            <td id="presets--k8sEvents--enabled"><a href="./values.yaml#L538">presets.k8sEvents.enabled</a></td>
+            <td id="presets--k8sEvents--enabled"><a href="./values.yaml#L542">presets.k8sEvents.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -1229,7 +1299,7 @@ namespaces: []</pre>
             <td>Enable Kubernetes events collection.</td>
         </tr>
         <tr>
-            <td id="presets--k8sEvents--authType"><a href="./values.yaml#L541">presets.k8sEvents.authType</a></td>
+            <td id="presets--k8sEvents--authType"><a href="./values.yaml#L545">presets.k8sEvents.authType</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">serviceAccount</pre>
@@ -1238,7 +1308,7 @@ namespaces: []</pre>
             <td>Authentication type: `serviceAccount` or `kubeconfig`.</td>
         </tr>
         <tr>
-            <td id="presets--k8sEvents--namespaces"><a href="./values.yaml#L544">presets.k8sEvents.namespaces</a></td>
+            <td id="presets--k8sEvents--namespaces"><a href="./values.yaml#L548">presets.k8sEvents.namespaces</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -1258,7 +1328,7 @@ namespaces: []</pre>
     </thead>
     <tbody>
         <tr>
-            <td id="otelAgent--enabled"><a href="./values.yaml#L551">otelAgent.enabled</a></td>
+            <td id="otelAgent--enabled"><a href="./values.yaml#L555">otelAgent.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -1267,7 +1337,7 @@ namespaces: []</pre>
             <td>Enable the OtelAgent DaemonSet.</td>
         </tr>
         <tr>
-            <td id="otelAgent--name"><a href="./values.yaml#L554">otelAgent.name</a></td>
+            <td id="otelAgent--name"><a href="./values.yaml#L558">otelAgent.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">otel-agent</pre>
@@ -1276,7 +1346,7 @@ namespaces: []</pre>
             <td>Name of the OtelAgent DaemonSet.</td>
         </tr>
         <tr>
-            <td id="otelAgent--image"><a href="./values.yaml#L557">otelAgent.image</a></td>
+            <td id="otelAgent--image"><a href="./values.yaml#L561">otelAgent.image</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">pullPolicy: IfNotPresent
@@ -1288,7 +1358,7 @@ tag: 0.109.0</pre>
             <td>Image configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--image--registry"><a href="./values.yaml#L560">otelAgent.image.registry</a></td>
+            <td id="otelAgent--image--registry"><a href="./values.yaml#L564">otelAgent.image.registry</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">docker.io</pre>
@@ -1297,7 +1367,7 @@ tag: 0.109.0</pre>
             <td>Docker registry for the OtelAgent image.</td>
         </tr>
         <tr>
-            <td id="otelAgent--image--repository"><a href="./values.yaml#L563">otelAgent.image.repository</a></td>
+            <td id="otelAgent--image--repository"><a href="./values.yaml#L567">otelAgent.image.repository</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">otel/opentelemetry-collector-contrib</pre>
@@ -1306,16 +1376,16 @@ tag: 0.109.0</pre>
             <td>Repository for the OtelAgent image.</td>
         </tr>
         <tr>
-            <td id="otelAgent--image--tag"><a href="./values.yaml#L566">otelAgent.image.tag</a></td>
+            <td id="otelAgent--image--tag"><a href="./values.yaml#L571">otelAgent.image.tag</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">0.109.0</pre>
 </div>
             </td>
-            <td>Tag for the OtelAgent image.</td>
+            <td>Tag for the OtelAgent image. In case of your Host OS is windows, use the `0.123.0-windows-2022-amd64` tag.</td>
         </tr>
         <tr>
-            <td id="otelAgent--image--pullPolicy"><a href="./values.yaml#L569">otelAgent.image.pullPolicy</a></td>
+            <td id="otelAgent--image--pullPolicy"><a href="./values.yaml#L574">otelAgent.image.pullPolicy</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">IfNotPresent</pre>
@@ -1324,7 +1394,7 @@ tag: 0.109.0</pre>
             <td>Image pull policy for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--imagePullSecrets"><a href="./values.yaml#L573">otelAgent.imagePullSecrets</a></td>
+            <td id="otelAgent--imagePullSecrets"><a href="./values.yaml#L578">otelAgent.imagePullSecrets</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -1333,7 +1403,7 @@ tag: 0.109.0</pre>
             <td>Image Pull Secrets for the OtelAgent. Merged with `global.imagePullSecrets`.</td>
         </tr>
         <tr>
-            <td id="otelAgent--command"><a href="./values.yaml#L578">otelAgent.command</a></td>
+            <td id="otelAgent--command"><a href="./values.yaml#L583">otelAgent.command</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">extraArgs: []
@@ -1343,7 +1413,7 @@ name: /otelcol-contrib</pre>
             <td>Command and arguments for the OtelAgent container.</td>
         </tr>
         <tr>
-            <td id="otelAgent--command--name"><a href="./values.yaml#L581">otelAgent.command.name</a></td>
+            <td id="otelAgent--command--name"><a href="./values.yaml#L586">otelAgent.command.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">/otelcol-contrib</pre>
@@ -1352,7 +1422,7 @@ name: /otelcol-contrib</pre>
             <td>OtelAgent command name.</td>
         </tr>
         <tr>
-            <td id="otelAgent--command--extraArgs"><a href="./values.yaml#L584">otelAgent.command.extraArgs</a></td>
+            <td id="otelAgent--command--extraArgs"><a href="./values.yaml#L589">otelAgent.command.extraArgs</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -1361,7 +1431,7 @@ name: /otelcol-contrib</pre>
             <td>Extra arguments for the OtelAgent command.</td>
         </tr>
         <tr>
-            <td id="otelAgent--configMap"><a href="./values.yaml#L588">otelAgent.configMap</a></td>
+            <td id="otelAgent--configMap"><a href="./values.yaml#L593">otelAgent.configMap</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">create: true</pre>
@@ -1370,7 +1440,7 @@ name: /otelcol-contrib</pre>
             <td>ConfigMap configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--configMap--create"><a href="./values.yaml#L591">otelAgent.configMap.create</a></td>
+            <td id="otelAgent--configMap--create"><a href="./values.yaml#L596">otelAgent.configMap.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -1379,7 +1449,7 @@ name: /otelcol-contrib</pre>
             <td>Specifies whether a ConfigMap should be created.</td>
         </tr>
         <tr>
-            <td id="otelAgent--service"><a href="./values.yaml#L595">otelAgent.service</a></td>
+            <td id="otelAgent--service"><a href="./values.yaml#L600">otelAgent.service</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
@@ -1390,7 +1460,7 @@ type: ClusterIP</pre>
             <td>Service configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--service--annotations"><a href="./values.yaml#L598">otelAgent.service.annotations</a></td>
+            <td id="otelAgent--service--annotations"><a href="./values.yaml#L603">otelAgent.service.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -1399,7 +1469,7 @@ type: ClusterIP</pre>
             <td>Annotations for the OtelAgent service.</td>
         </tr>
         <tr>
-            <td id="otelAgent--service--type"><a href="./values.yaml#L601">otelAgent.service.type</a></td>
+            <td id="otelAgent--service--type"><a href="./values.yaml#L606">otelAgent.service.type</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">ClusterIP</pre>
@@ -1408,7 +1478,7 @@ type: ClusterIP</pre>
             <td>Service type: `ClusterIP`, `NodePort`, or `LoadBalancer`.</td>
         </tr>
         <tr>
-            <td id="otelAgent--service--internalTrafficPolicy"><a href="./values.yaml#L605">otelAgent.service.internalTrafficPolicy</a></td>
+            <td id="otelAgent--service--internalTrafficPolicy"><a href="./values.yaml#L610">otelAgent.service.internalTrafficPolicy</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">Local</pre>
@@ -1417,7 +1487,7 @@ type: ClusterIP</pre>
             <td>Internal traffic policy: `Local` or `Cluster`. ref: https://kubernetes.io/docs/reference/networking/virtual-ips/#internal-traffic-policy</td>
         </tr>
         <tr>
-            <td id="otelAgent--serviceAccount"><a href="./values.yaml#L609">otelAgent.serviceAccount</a></td>
+            <td id="otelAgent--serviceAccount"><a href="./values.yaml#L614">otelAgent.serviceAccount</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
@@ -1428,7 +1498,7 @@ name: null</pre>
             <td>ServiceAccount configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--serviceAccount--create"><a href="./values.yaml#L612">otelAgent.serviceAccount.create</a></td>
+            <td id="otelAgent--serviceAccount--create"><a href="./values.yaml#L617">otelAgent.serviceAccount.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -1437,7 +1507,7 @@ name: null</pre>
             <td>Specifies whether a ServiceAccount should be created.</td>
         </tr>
         <tr>
-            <td id="otelAgent--serviceAccount--annotations"><a href="./values.yaml#L615">otelAgent.serviceAccount.annotations</a></td>
+            <td id="otelAgent--serviceAccount--annotations"><a href="./values.yaml#L620">otelAgent.serviceAccount.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -1446,7 +1516,7 @@ name: null</pre>
             <td>Annotations for the ServiceAccount.</td>
         </tr>
         <tr>
-            <td id="otelAgent--serviceAccount--name"><a href="./values.yaml#L618">otelAgent.serviceAccount.name</a></td>
+            <td id="otelAgent--serviceAccount--name"><a href="./values.yaml#L623">otelAgent.serviceAccount.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">null</pre>
@@ -1455,7 +1525,7 @@ name: null</pre>
             <td>The name of the ServiceAccount to use. A name is generated if not set.</td>
         </tr>
         <tr>
-            <td id="otelAgent--annotations"><a href="./values.yaml#L622">otelAgent.annotations</a></td>
+            <td id="otelAgent--annotations"><a href="./values.yaml#L627">otelAgent.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -1464,7 +1534,7 @@ name: null</pre>
             <td>Annotations for the OtelAgent DaemonSet.</td>
         </tr>
         <tr>
-            <td id="otelAgent--podAnnotations"><a href="./values.yaml#L625">otelAgent.podAnnotations</a></td>
+            <td id="otelAgent--podAnnotations"><a href="./values.yaml#L630">otelAgent.podAnnotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -1473,7 +1543,7 @@ name: null</pre>
             <td>Annotations for the OtelAgent pods.</td>
         </tr>
         <tr>
-            <td id="otelAgent--additionalEnvs"><a href="./values.yaml#L647">otelAgent.additionalEnvs</a></td>
+            <td id="otelAgent--additionalEnvs"><a href="./values.yaml#L652">otelAgent.additionalEnvs</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -1482,7 +1552,7 @@ name: null</pre>
             <td>Additional environment variables for the OtelAgent container. You can specify variables in two ways: 1. Flexible structure for advanced configurations (recommended):    Example:      additionalEnvs:        MY_KEY:          value: my-value        SECRET_KEY:          valueFrom:            secretKeyRef:              name: my-secret              key: my-key 2. Simple key-value pairs (backward-compatible):    Example:      additionalEnvs:        MY_KEY: my-value</td>
         </tr>
         <tr>
-            <td id="otelAgent--minReadySeconds"><a href="./values.yaml#L651">otelAgent.minReadySeconds</a></td>
+            <td id="otelAgent--minReadySeconds"><a href="./values.yaml#L656">otelAgent.minReadySeconds</a></td>
             <td>int</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">5</pre>
@@ -1491,7 +1561,7 @@ name: null</pre>
             <td>Minimum number of seconds for which a newly created Pod should be ready.</td>
         </tr>
         <tr>
-            <td id="otelAgent--clusterRole"><a href="./values.yaml#L656">otelAgent.clusterRole</a></td>
+            <td id="otelAgent--clusterRole"><a href="./values.yaml#L661">otelAgent.clusterRole</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">Please checkout the values.yml for default values</pre>
@@ -1500,7 +1570,7 @@ name: null</pre>
             <td>ClusterRole configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--clusterRole--create"><a href="./values.yaml#L659">otelAgent.clusterRole.create</a></td>
+            <td id="otelAgent--clusterRole--create"><a href="./values.yaml#L664">otelAgent.clusterRole.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -1509,7 +1579,7 @@ name: null</pre>
             <td>Specifies whether a ClusterRole should be created.</td>
         </tr>
         <tr>
-            <td id="otelAgent--clusterRole--annotations"><a href="./values.yaml#L662">otelAgent.clusterRole.annotations</a></td>
+            <td id="otelAgent--clusterRole--annotations"><a href="./values.yaml#L667">otelAgent.clusterRole.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -1518,7 +1588,7 @@ name: null</pre>
             <td>Annotations for the ClusterRole.</td>
         </tr>
         <tr>
-            <td id="otelAgent--clusterRole--name"><a href="./values.yaml#L665">otelAgent.clusterRole.name</a></td>
+            <td id="otelAgent--clusterRole--name"><a href="./values.yaml#L670">otelAgent.clusterRole.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">""</pre>
@@ -1527,7 +1597,7 @@ name: null</pre>
             <td>The name of the ClusterRole to use. A name is generated if not set.</td>
         </tr>
         <tr>
-            <td id="otelAgent--clusterRole--rules"><a href="./values.yaml#L670">otelAgent.clusterRole.rules</a></td>
+            <td id="otelAgent--clusterRole--rules"><a href="./values.yaml#L675">otelAgent.clusterRole.rules</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">Please checkout the values.yml for default values</pre>
@@ -1536,7 +1606,7 @@ name: null</pre>
             <td>RBAC rules for the OtelAgent. ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/</td>
         </tr>
         <tr>
-            <td id="otelAgent--clusterRole--clusterRoleBinding"><a href="./values.yaml#L701">otelAgent.clusterRole.clusterRoleBinding</a></td>
+            <td id="otelAgent--clusterRole--clusterRoleBinding"><a href="./values.yaml#L706">otelAgent.clusterRole.clusterRoleBinding</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
@@ -1546,7 +1616,7 @@ name: ""</pre>
             <td>ClusterRoleBinding configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports"><a href="./values.yaml#L712">otelAgent.ports</a></td>
+            <td id="otelAgent--ports"><a href="./values.yaml#L717">otelAgent.ports</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">Please checkout the values.yml for default values</pre>
@@ -1555,7 +1625,7 @@ name: ""</pre>
             <td>Port configurations for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--otlp--enabled"><a href="./values.yaml#L717">otelAgent.ports.otlp.enabled</a></td>
+            <td id="otelAgent--ports--otlp--enabled"><a href="./values.yaml#L722">otelAgent.ports.otlp.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -1564,7 +1634,7 @@ name: ""</pre>
             <td>Enable service port for OTLP gRPC.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--otlp-http--enabled"><a href="./values.yaml#L732">otelAgent.ports.otlp-http.enabled</a></td>
+            <td id="otelAgent--ports--otlp-http--enabled"><a href="./values.yaml#L737">otelAgent.ports.otlp-http.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -1573,7 +1643,7 @@ name: ""</pre>
             <td>Enable service port for OTLP HTTP.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--zipkin--enabled"><a href="./values.yaml#L747">otelAgent.ports.zipkin.enabled</a></td>
+            <td id="otelAgent--ports--zipkin--enabled"><a href="./values.yaml#L752">otelAgent.ports.zipkin.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">false</pre>
@@ -1582,7 +1652,7 @@ name: ""</pre>
             <td>Enable service port for Zipkin.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--metrics--enabled"><a href="./values.yaml#L762">otelAgent.ports.metrics.enabled</a></td>
+            <td id="otelAgent--ports--metrics--enabled"><a href="./values.yaml#L767">otelAgent.ports.metrics.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -1591,7 +1661,7 @@ name: ""</pre>
             <td>Enable service port for internal metrics.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--zpages--enabled"><a href="./values.yaml#L777">otelAgent.ports.zpages.enabled</a></td>
+            <td id="otelAgent--ports--zpages--enabled"><a href="./values.yaml#L782">otelAgent.ports.zpages.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">false</pre>
@@ -1600,7 +1670,7 @@ name: ""</pre>
             <td>Enable service port for ZPages.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--health-check--enabled"><a href="./values.yaml#L792">otelAgent.ports.health-check.enabled</a></td>
+            <td id="otelAgent--ports--health-check--enabled"><a href="./values.yaml#L797">otelAgent.ports.health-check.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -1609,7 +1679,7 @@ name: ""</pre>
             <td>Enable service port for health checks.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ports--pprof--enabled"><a href="./values.yaml#L807">otelAgent.ports.pprof.enabled</a></td>
+            <td id="otelAgent--ports--pprof--enabled"><a href="./values.yaml#L812">otelAgent.ports.pprof.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">false</pre>
@@ -1618,7 +1688,7 @@ name: ""</pre>
             <td>Enable service port for pprof.</td>
         </tr>
         <tr>
-            <td id="otelAgent--hostNetwork"><a href="./values.yaml#L821">otelAgent.hostNetwork</a></td>
+            <td id="otelAgent--hostNetwork"><a href="./values.yaml#L826">otelAgent.hostNetwork</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">false</pre>
@@ -1627,7 +1697,7 @@ name: ""</pre>
             <td>Host networking requested for this pod. Use the host's network namespace. Please make sure while enabling hostNetwork that the host ports are available as it can lead to port conflicts.</td>
         </tr>
         <tr>
-            <td id="otelAgent--livenessProbe"><a href="./values.yaml#L825">otelAgent.livenessProbe</a></td>
+            <td id="otelAgent--livenessProbe"><a href="./values.yaml#L830">otelAgent.livenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">enabled: true
@@ -1643,7 +1713,7 @@ timeoutSeconds: 5</pre>
             <td>Configure liveness probe. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command</td>
         </tr>
         <tr>
-            <td id="otelAgent--readinessProbe"><a href="./values.yaml#L846">otelAgent.readinessProbe</a></td>
+            <td id="otelAgent--readinessProbe"><a href="./values.yaml#L851">otelAgent.readinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">enabled: true
@@ -1659,7 +1729,7 @@ timeoutSeconds: 5</pre>
             <td>Configure readiness probe. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes</td>
         </tr>
         <tr>
-            <td id="otelAgent--customLivenessProbe"><a href="./values.yaml#L866">otelAgent.customLivenessProbe</a></td>
+            <td id="otelAgent--customLivenessProbe"><a href="./values.yaml#L871">otelAgent.customLivenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -1668,7 +1738,7 @@ timeoutSeconds: 5</pre>
             <td>Custom liveness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--customReadinessProbe"><a href="./values.yaml#L869">otelAgent.customReadinessProbe</a></td>
+            <td id="otelAgent--customReadinessProbe"><a href="./values.yaml#L874">otelAgent.customReadinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -1677,7 +1747,7 @@ timeoutSeconds: 5</pre>
             <td>Custom readiness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress"><a href="./values.yaml#L873">otelAgent.ingress</a></td>
+            <td id="otelAgent--ingress"><a href="./values.yaml#L878">otelAgent.ingress</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
@@ -1695,7 +1765,7 @@ tls: []</pre>
             <td>Ingress configuration for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--enabled"><a href="./values.yaml#L876">otelAgent.ingress.enabled</a></td>
+            <td id="otelAgent--ingress--enabled"><a href="./values.yaml#L881">otelAgent.ingress.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">false</pre>
@@ -1704,7 +1774,7 @@ tls: []</pre>
             <td>Enable Ingress for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--className"><a href="./values.yaml#L879">otelAgent.ingress.className</a></td>
+            <td id="otelAgent--ingress--className"><a href="./values.yaml#L884">otelAgent.ingress.className</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">""</pre>
@@ -1713,7 +1783,7 @@ tls: []</pre>
             <td>Ingress Class Name to be used.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--annotations"><a href="./values.yaml#L882">otelAgent.ingress.annotations</a></td>
+            <td id="otelAgent--ingress--annotations"><a href="./values.yaml#L887">otelAgent.ingress.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -1722,7 +1792,7 @@ tls: []</pre>
             <td>Annotations for the OtelAgent Ingress.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--hosts"><a href="./values.yaml#L890">otelAgent.ingress.hosts</a></td>
+            <td id="otelAgent--ingress--hosts"><a href="./values.yaml#L895">otelAgent.ingress.hosts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">- host: otel-agent.domain.com
@@ -1735,7 +1805,7 @@ tls: []</pre>
             <td>OtelAgent Ingress hostnames with their path details.</td>
         </tr>
         <tr>
-            <td id="otelAgent--ingress--tls"><a href="./values.yaml#L898">otelAgent.ingress.tls</a></td>
+            <td id="otelAgent--ingress--tls"><a href="./values.yaml#L903">otelAgent.ingress.tls</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -1744,7 +1814,7 @@ tls: []</pre>
             <td>OtelAgent Ingress TLS configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--resources"><a href="./values.yaml#L906">otelAgent.resources</a></td>
+            <td id="otelAgent--resources"><a href="./values.yaml#L911">otelAgent.resources</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">requests:
@@ -1755,7 +1825,7 @@ tls: []</pre>
             <td>Configure resource requests and limits for the OtelAgent. ref: http://kubernetes.io/docs/user-guide/compute-resources/</td>
         </tr>
         <tr>
-            <td id="otelAgent--priorityClassName"><a href="./values.yaml#L917">otelAgent.priorityClassName</a></td>
+            <td id="otelAgent--priorityClassName"><a href="./values.yaml#L922">otelAgent.priorityClassName</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">""</pre>
@@ -1764,7 +1834,7 @@ tls: []</pre>
             <td>OtelAgent Priority Class name.</td>
         </tr>
         <tr>
-            <td id="otelAgent--nodeSelector"><a href="./values.yaml#L921">otelAgent.nodeSelector</a></td>
+            <td id="otelAgent--nodeSelector"><a href="./values.yaml#L926">otelAgent.nodeSelector</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -1773,7 +1843,7 @@ tls: []</pre>
             <td>Node selector for OtelAgent pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelAgent--tolerations"><a href="./values.yaml#L925">otelAgent.tolerations</a></td>
+            <td id="otelAgent--tolerations"><a href="./values.yaml#L930">otelAgent.tolerations</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">- operator: Exists</pre>
@@ -1782,7 +1852,7 @@ tls: []</pre>
             <td>Toleration labels for OtelAgent pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelAgent--affinity"><a href="./values.yaml#L930">otelAgent.affinity</a></td>
+            <td id="otelAgent--affinity"><a href="./values.yaml#L935">otelAgent.affinity</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -1791,7 +1861,7 @@ tls: []</pre>
             <td>Affinity settings for the OtelAgent pod.</td>
         </tr>
         <tr>
-            <td id="otelAgent--podSecurityContext"><a href="./values.yaml#L934">otelAgent.podSecurityContext</a></td>
+            <td id="otelAgent--podSecurityContext"><a href="./values.yaml#L939">otelAgent.podSecurityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -1800,7 +1870,7 @@ tls: []</pre>
             <td>Pod-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--securityContext"><a href="./values.yaml#L939">otelAgent.securityContext</a></td>
+            <td id="otelAgent--securityContext"><a href="./values.yaml#L944">otelAgent.securityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -1809,7 +1879,7 @@ tls: []</pre>
             <td>Container-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelAgent--config"><a href="./values.yaml#L950">otelAgent.config</a></td>
+            <td id="otelAgent--config"><a href="./values.yaml#L955">otelAgent.config</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">Please Checkout the values.yml for default values</pre>
@@ -1818,7 +1888,7 @@ tls: []</pre>
             <td>Base configuration for the OtelAgent Collector.</td>
         </tr>
         <tr>
-            <td id="otelAgent--config--processors--batch"><a href="./values.yaml#L965">otelAgent.config.processors.batch</a></td>
+            <td id="otelAgent--config--processors--batch"><a href="./values.yaml#L970">otelAgent.config.processors.batch</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">send_batch_size: 10000
@@ -1828,7 +1898,7 @@ timeout: 200ms</pre>
             <td>Batch processor config. ref: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md</td>
         </tr>
         <tr>
-            <td id="otelAgent--extraVolumes"><a href="./values.yaml#L1007">otelAgent.extraVolumes</a></td>
+            <td id="otelAgent--extraVolumes"><a href="./values.yaml#L1012">otelAgent.extraVolumes</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -1837,7 +1907,7 @@ timeout: 200ms</pre>
             <td>Additional volumes for the OtelAgent.</td>
         </tr>
         <tr>
-            <td id="otelAgent--extraVolumeMounts"><a href="./values.yaml#L1017">otelAgent.extraVolumeMounts</a></td>
+            <td id="otelAgent--extraVolumeMounts"><a href="./values.yaml#L1022">otelAgent.extraVolumeMounts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -1857,7 +1927,7 @@ timeout: 200ms</pre>
     </thead>
     <tbody>
         <tr>
-            <td id="otelDeployment--enabled"><a href="./values.yaml#L1029">otelDeployment.enabled</a></td>
+            <td id="otelDeployment--enabled"><a href="./values.yaml#L1034">otelDeployment.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -1866,7 +1936,7 @@ timeout: 200ms</pre>
             <td>Enable the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--name"><a href="./values.yaml#L1032">otelDeployment.name</a></td>
+            <td id="otelDeployment--name"><a href="./values.yaml#L1037">otelDeployment.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">otel-deployment</pre>
@@ -1875,7 +1945,7 @@ timeout: 200ms</pre>
             <td>Name of the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image"><a href="./values.yaml#L1035">otelDeployment.image</a></td>
+            <td id="otelDeployment--image"><a href="./values.yaml#L1040">otelDeployment.image</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">pullPolicy: IfNotPresent
@@ -1887,7 +1957,7 @@ tag: 0.109.0</pre>
             <td>Image configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--registry"><a href="./values.yaml#L1038">otelDeployment.image.registry</a></td>
+            <td id="otelDeployment--image--registry"><a href="./values.yaml#L1043">otelDeployment.image.registry</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">docker.io</pre>
@@ -1896,7 +1966,7 @@ tag: 0.109.0</pre>
             <td>Docker registry for the OtelDeployment image.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--repository"><a href="./values.yaml#L1041">otelDeployment.image.repository</a></td>
+            <td id="otelDeployment--image--repository"><a href="./values.yaml#L1046">otelDeployment.image.repository</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">otel/opentelemetry-collector-contrib</pre>
@@ -1905,7 +1975,7 @@ tag: 0.109.0</pre>
             <td>Repository for the OtelDeployment image.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--tag"><a href="./values.yaml#L1044">otelDeployment.image.tag</a></td>
+            <td id="otelDeployment--image--tag"><a href="./values.yaml#L1049">otelDeployment.image.tag</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">0.109.0</pre>
@@ -1914,7 +1984,7 @@ tag: 0.109.0</pre>
             <td>Tag for the OtelDeployment image.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--image--pullPolicy"><a href="./values.yaml#L1047">otelDeployment.image.pullPolicy</a></td>
+            <td id="otelDeployment--image--pullPolicy"><a href="./values.yaml#L1052">otelDeployment.image.pullPolicy</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">IfNotPresent</pre>
@@ -1923,7 +1993,7 @@ tag: 0.109.0</pre>
             <td>Image pull policy for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--imagePullSecrets"><a href="./values.yaml#L1051">otelDeployment.imagePullSecrets</a></td>
+            <td id="otelDeployment--imagePullSecrets"><a href="./values.yaml#L1056">otelDeployment.imagePullSecrets</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -1932,7 +2002,7 @@ tag: 0.109.0</pre>
             <td>Image Pull Secrets for the OtelDeployment. Merged with `global.imagePullSecrets`.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--command"><a href="./values.yaml#L1056">otelDeployment.command</a></td>
+            <td id="otelDeployment--command"><a href="./values.yaml#L1061">otelDeployment.command</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">extraArgs: []
@@ -1942,7 +2012,7 @@ name: /otelcol-contrib</pre>
             <td>Command and arguments for the OtelDeployment container.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--command--name"><a href="./values.yaml#L1059">otelDeployment.command.name</a></td>
+            <td id="otelDeployment--command--name"><a href="./values.yaml#L1064">otelDeployment.command.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">/otelcol-contrib</pre>
@@ -1951,7 +2021,7 @@ name: /otelcol-contrib</pre>
             <td>OtelDeployment command name.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--command--extraArgs"><a href="./values.yaml#L1062">otelDeployment.command.extraArgs</a></td>
+            <td id="otelDeployment--command--extraArgs"><a href="./values.yaml#L1067">otelDeployment.command.extraArgs</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -1960,7 +2030,7 @@ name: /otelcol-contrib</pre>
             <td>Extra arguments for the OtelDeployment command.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--configMap"><a href="./values.yaml#L1066">otelDeployment.configMap</a></td>
+            <td id="otelDeployment--configMap"><a href="./values.yaml#L1071">otelDeployment.configMap</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">create: true</pre>
@@ -1969,7 +2039,7 @@ name: /otelcol-contrib</pre>
             <td>ConfigMap configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--configMap--create"><a href="./values.yaml#L1069">otelDeployment.configMap.create</a></td>
+            <td id="otelDeployment--configMap--create"><a href="./values.yaml#L1074">otelDeployment.configMap.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -1978,7 +2048,7 @@ name: /otelcol-contrib</pre>
             <td>Specifies whether a ConfigMap should be created.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--service"><a href="./values.yaml#L1073">otelDeployment.service</a></td>
+            <td id="otelDeployment--service"><a href="./values.yaml#L1078">otelDeployment.service</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
@@ -1988,7 +2058,7 @@ type: ClusterIP</pre>
             <td>Service configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--service--annotations"><a href="./values.yaml#L1076">otelDeployment.service.annotations</a></td>
+            <td id="otelDeployment--service--annotations"><a href="./values.yaml#L1081">otelDeployment.service.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -1997,7 +2067,7 @@ type: ClusterIP</pre>
             <td>Annotations for the OtelDeployment service.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--service--type"><a href="./values.yaml#L1079">otelDeployment.service.type</a></td>
+            <td id="otelDeployment--service--type"><a href="./values.yaml#L1084">otelDeployment.service.type</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">ClusterIP</pre>
@@ -2006,7 +2076,7 @@ type: ClusterIP</pre>
             <td>Service type.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount"><a href="./values.yaml#L1083">otelDeployment.serviceAccount</a></td>
+            <td id="otelDeployment--serviceAccount"><a href="./values.yaml#L1088">otelDeployment.serviceAccount</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
@@ -2017,7 +2087,7 @@ name: null</pre>
             <td>ServiceAccount configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount--create"><a href="./values.yaml#L1086">otelDeployment.serviceAccount.create</a></td>
+            <td id="otelDeployment--serviceAccount--create"><a href="./values.yaml#L1091">otelDeployment.serviceAccount.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -2026,7 +2096,7 @@ name: null</pre>
             <td>Specifies whether a ServiceAccount should be created.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount--annotations"><a href="./values.yaml#L1089">otelDeployment.serviceAccount.annotations</a></td>
+            <td id="otelDeployment--serviceAccount--annotations"><a href="./values.yaml#L1094">otelDeployment.serviceAccount.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2035,7 +2105,7 @@ name: null</pre>
             <td>Annotations for the ServiceAccount.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--serviceAccount--name"><a href="./values.yaml#L1092">otelDeployment.serviceAccount.name</a></td>
+            <td id="otelDeployment--serviceAccount--name"><a href="./values.yaml#L1097">otelDeployment.serviceAccount.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">null</pre>
@@ -2044,7 +2114,7 @@ name: null</pre>
             <td>The name of the ServiceAccount to use. A name is generated if not set.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--annotations"><a href="./values.yaml#L1096">otelDeployment.annotations</a></td>
+            <td id="otelDeployment--annotations"><a href="./values.yaml#L1101">otelDeployment.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2053,7 +2123,7 @@ name: null</pre>
             <td>Annotations for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--podAnnotations"><a href="./values.yaml#L1099">otelDeployment.podAnnotations</a></td>
+            <td id="otelDeployment--podAnnotations"><a href="./values.yaml#L1104">otelDeployment.podAnnotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2062,7 +2132,7 @@ name: null</pre>
             <td>Annotations for the OtelDeployment pods.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--additionalEnvs"><a href="./values.yaml#L1106">otelDeployment.additionalEnvs</a></td>
+            <td id="otelDeployment--additionalEnvs"><a href="./values.yaml#L1111">otelDeployment.additionalEnvs</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2071,7 +2141,7 @@ name: null</pre>
             <td>Additional environment variables for the OtelDeployment container.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--podSecurityContext"><a href="./values.yaml#L1110">otelDeployment.podSecurityContext</a></td>
+            <td id="otelDeployment--podSecurityContext"><a href="./values.yaml#L1115">otelDeployment.podSecurityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2080,7 +2150,7 @@ name: null</pre>
             <td>Pod-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--securityContext"><a href="./values.yaml#L1115">otelDeployment.securityContext</a></td>
+            <td id="otelDeployment--securityContext"><a href="./values.yaml#L1120">otelDeployment.securityContext</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2089,7 +2159,7 @@ name: null</pre>
             <td>Container-level security configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--minReadySeconds"><a href="./values.yaml#L1125">otelDeployment.minReadySeconds</a></td>
+            <td id="otelDeployment--minReadySeconds"><a href="./values.yaml#L1130">otelDeployment.minReadySeconds</a></td>
             <td>int</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">5</pre>
@@ -2098,7 +2168,7 @@ name: null</pre>
             <td>Minimum number of seconds for which a newly created Pod should be ready.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--progressDeadlineSeconds"><a href="./values.yaml#L1129">otelDeployment.progressDeadlineSeconds</a></td>
+            <td id="otelDeployment--progressDeadlineSeconds"><a href="./values.yaml#L1134">otelDeployment.progressDeadlineSeconds</a></td>
             <td>int</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">120</pre>
@@ -2107,7 +2177,7 @@ name: null</pre>
             <td>Seconds to wait for the Deployment to progress before it's considered failed.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports"><a href="./values.yaml#L1133">otelDeployment.ports</a></td>
+            <td id="otelDeployment--ports"><a href="./values.yaml#L1138">otelDeployment.ports</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">health-check:
@@ -2139,7 +2209,7 @@ zpages:
             <td>Port configurations for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--metrics--enabled"><a href="./values.yaml#L1138">otelDeployment.ports.metrics.enabled</a></td>
+            <td id="otelDeployment--ports--metrics--enabled"><a href="./values.yaml#L1143">otelDeployment.ports.metrics.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">false</pre>
@@ -2148,7 +2218,7 @@ zpages:
             <td>Enable service port for internal metrics.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--zpages--enabled"><a href="./values.yaml#L1151">otelDeployment.ports.zpages.enabled</a></td>
+            <td id="otelDeployment--ports--zpages--enabled"><a href="./values.yaml#L1156">otelDeployment.ports.zpages.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">false</pre>
@@ -2157,7 +2227,7 @@ zpages:
             <td>Enable service port for ZPages.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--health-check--enabled"><a href="./values.yaml#L1164">otelDeployment.ports.health-check.enabled</a></td>
+            <td id="otelDeployment--ports--health-check--enabled"><a href="./values.yaml#L1169">otelDeployment.ports.health-check.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -2166,7 +2236,7 @@ zpages:
             <td>Enable service port for health checks.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ports--pprof--enabled"><a href="./values.yaml#L1177">otelDeployment.ports.pprof.enabled</a></td>
+            <td id="otelDeployment--ports--pprof--enabled"><a href="./values.yaml#L1182">otelDeployment.ports.pprof.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">false</pre>
@@ -2175,7 +2245,7 @@ zpages:
             <td>Enable service port for pprof.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--livenessProbe"><a href="./values.yaml#L1189">otelDeployment.livenessProbe</a></td>
+            <td id="otelDeployment--livenessProbe"><a href="./values.yaml#L1194">otelDeployment.livenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">enabled: true
@@ -2191,7 +2261,7 @@ timeoutSeconds: 5</pre>
             <td>Configure liveness probe.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--readinessProbe"><a href="./values.yaml#L1209">otelDeployment.readinessProbe</a></td>
+            <td id="otelDeployment--readinessProbe"><a href="./values.yaml#L1214">otelDeployment.readinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">enabled: true
@@ -2207,7 +2277,7 @@ timeoutSeconds: 5</pre>
             <td>Configure readiness probe.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--customLivenessProbe"><a href="./values.yaml#L1229">otelDeployment.customLivenessProbe</a></td>
+            <td id="otelDeployment--customLivenessProbe"><a href="./values.yaml#L1234">otelDeployment.customLivenessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2216,7 +2286,7 @@ timeoutSeconds: 5</pre>
             <td>Custom liveness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--customReadinessProbe"><a href="./values.yaml#L1233">otelDeployment.customReadinessProbe</a></td>
+            <td id="otelDeployment--customReadinessProbe"><a href="./values.yaml#L1238">otelDeployment.customReadinessProbe</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2225,7 +2295,7 @@ timeoutSeconds: 5</pre>
             <td>Custom readiness probe configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress"><a href="./values.yaml#L1237">otelDeployment.ingress</a></td>
+            <td id="otelDeployment--ingress"><a href="./values.yaml#L1242">otelDeployment.ingress</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
@@ -2243,7 +2313,7 @@ tls: []</pre>
             <td>Ingress configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--enabled"><a href="./values.yaml#L1240">otelDeployment.ingress.enabled</a></td>
+            <td id="otelDeployment--ingress--enabled"><a href="./values.yaml#L1245">otelDeployment.ingress.enabled</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">false</pre>
@@ -2252,7 +2322,7 @@ tls: []</pre>
             <td>Enable Ingress for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--className"><a href="./values.yaml#L1243">otelDeployment.ingress.className</a></td>
+            <td id="otelDeployment--ingress--className"><a href="./values.yaml#L1248">otelDeployment.ingress.className</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">""</pre>
@@ -2261,7 +2331,7 @@ tls: []</pre>
             <td>Ingress Class Name to be used.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--annotations"><a href="./values.yaml#L1246">otelDeployment.ingress.annotations</a></td>
+            <td id="otelDeployment--ingress--annotations"><a href="./values.yaml#L1251">otelDeployment.ingress.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2270,7 +2340,7 @@ tls: []</pre>
             <td>Annotations for the OtelDeployment Ingress.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--hosts"><a href="./values.yaml#L1249">otelDeployment.ingress.hosts</a></td>
+            <td id="otelDeployment--ingress--hosts"><a href="./values.yaml#L1254">otelDeployment.ingress.hosts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">- host: otel-deployment.domain.com
@@ -2283,7 +2353,7 @@ tls: []</pre>
             <td>OtelDeployment Ingress hostnames.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--ingress--tls"><a href="./values.yaml#L1257">otelDeployment.ingress.tls</a></td>
+            <td id="otelDeployment--ingress--tls"><a href="./values.yaml#L1262">otelDeployment.ingress.tls</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -2292,7 +2362,7 @@ tls: []</pre>
             <td>OtelDeployment Ingress TLS configuration.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--resources"><a href="./values.yaml#L1264">otelDeployment.resources</a></td>
+            <td id="otelDeployment--resources"><a href="./values.yaml#L1269">otelDeployment.resources</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">requests:
@@ -2303,7 +2373,7 @@ tls: []</pre>
             <td>Configure resource requests and limits for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--priorityClassName"><a href="./values.yaml#L1275">otelDeployment.priorityClassName</a></td>
+            <td id="otelDeployment--priorityClassName"><a href="./values.yaml#L1280">otelDeployment.priorityClassName</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">""</pre>
@@ -2312,7 +2382,7 @@ tls: []</pre>
             <td>OtelDeployment Priority Class name.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--nodeSelector"><a href="./values.yaml#L1279">otelDeployment.nodeSelector</a></td>
+            <td id="otelDeployment--nodeSelector"><a href="./values.yaml#L1284">otelDeployment.nodeSelector</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2321,7 +2391,7 @@ tls: []</pre>
             <td>Node selector for OtelDeployment pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--tolerations"><a href="./values.yaml#L1283">otelDeployment.tolerations</a></td>
+            <td id="otelDeployment--tolerations"><a href="./values.yaml#L1288">otelDeployment.tolerations</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -2330,7 +2400,7 @@ tls: []</pre>
             <td>Toleration labels for OtelDeployment pod assignment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--affinity"><a href="./values.yaml#L1287">otelDeployment.affinity</a></td>
+            <td id="otelDeployment--affinity"><a href="./values.yaml#L1292">otelDeployment.affinity</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2339,7 +2409,7 @@ tls: []</pre>
             <td>Affinity settings for the OtelDeployment pod.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--topologySpreadConstraints"><a href="./values.yaml#L1291">otelDeployment.topologySpreadConstraints</a></td>
+            <td id="otelDeployment--topologySpreadConstraints"><a href="./values.yaml#L1296">otelDeployment.topologySpreadConstraints</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -2348,7 +2418,7 @@ tls: []</pre>
             <td>Describes how OtelDeployment pods ought to spread.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole"><a href="./values.yaml#L1296">otelDeployment.clusterRole</a></td>
+            <td id="otelDeployment--clusterRole"><a href="./values.yaml#L1301">otelDeployment.clusterRole</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">Please Checkout the values.yml for default values</pre>
@@ -2357,7 +2427,7 @@ tls: []</pre>
             <td>ClusterRole configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--create"><a href="./values.yaml#L1299">otelDeployment.clusterRole.create</a></td>
+            <td id="otelDeployment--clusterRole--create"><a href="./values.yaml#L1304">otelDeployment.clusterRole.create</a></td>
             <td>bool</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">true</pre>
@@ -2366,7 +2436,7 @@ tls: []</pre>
             <td>Specifies whether a ClusterRole should be created.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--annotations"><a href="./values.yaml#L1302">otelDeployment.clusterRole.annotations</a></td>
+            <td id="otelDeployment--clusterRole--annotations"><a href="./values.yaml#L1307">otelDeployment.clusterRole.annotations</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">{}</pre>
@@ -2375,7 +2445,7 @@ tls: []</pre>
             <td>Annotations for the ClusterRole.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--name"><a href="./values.yaml#L1305">otelDeployment.clusterRole.name</a></td>
+            <td id="otelDeployment--clusterRole--name"><a href="./values.yaml#L1310">otelDeployment.clusterRole.name</a></td>
             <td>string</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">""</pre>
@@ -2384,7 +2454,7 @@ tls: []</pre>
             <td>The name of the ClusterRole to use. A name is generated if not set.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--rules"><a href="./values.yaml#L1309">otelDeployment.clusterRole.rules</a></td>
+            <td id="otelDeployment--clusterRole--rules"><a href="./values.yaml#L1314">otelDeployment.clusterRole.rules</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">Please checkout the values.yml for default values</pre>
@@ -2393,7 +2463,7 @@ tls: []</pre>
             <td>RBAC rules for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--clusterRole--clusterRoleBinding"><a href="./values.yaml#L1339">otelDeployment.clusterRole.clusterRoleBinding</a></td>
+            <td id="otelDeployment--clusterRole--clusterRoleBinding"><a href="./values.yaml#L1344">otelDeployment.clusterRole.clusterRoleBinding</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">annotations: {}
@@ -2403,7 +2473,7 @@ name: ""</pre>
             <td>ClusterRoleBinding configuration for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--config"><a href="./values.yaml#L1350">otelDeployment.config</a></td>
+            <td id="otelDeployment--config"><a href="./values.yaml#L1355">otelDeployment.config</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">Please Checkout the values.yml for default values</pre>
@@ -2412,7 +2482,7 @@ name: ""</pre>
             <td>Base configuration for the OtelDeployment Collector.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--config--processors--batch"><a href="./values.yaml#L1357">otelDeployment.config.processors.batch</a></td>
+            <td id="otelDeployment--config--processors--batch"><a href="./values.yaml#L1362">otelDeployment.config.processors.batch</a></td>
             <td>object</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">send_batch_size: 10000
@@ -2422,7 +2492,7 @@ timeout: 1s</pre>
             <td>Batch processor config.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--extraVolumes"><a href="./values.yaml#L1397">otelDeployment.extraVolumes</a></td>
+            <td id="otelDeployment--extraVolumes"><a href="./values.yaml#L1402">otelDeployment.extraVolumes</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>
@@ -2431,7 +2501,7 @@ timeout: 1s</pre>
             <td>Additional volumes for the OtelDeployment.</td>
         </tr>
         <tr>
-            <td id="otelDeployment--extraVolumeMounts"><a href="./values.yaml#L1407">otelDeployment.extraVolumeMounts</a></td>
+            <td id="otelDeployment--extraVolumeMounts"><a href="./values.yaml#L1412">otelDeployment.extraVolumeMounts</a></td>
             <td>list</td>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">[]</pre>

--- a/charts/k8s-infra/README.md.gotmpl
+++ b/charts/k8s-infra/README.md.gotmpl
@@ -36,7 +36,37 @@ helm -n platform --create-namespace install "my-release" signoz/k8s-infra
 These commands deploy K8s-infra on the Kubernetes cluster in the default configuration.
 The [Configuration](#configuration) section lists the parameters that can be configured during installation:
 
-> **Tip**: List all releases using `helm list`
+>[!NOTE]
+> ### Installing K8s-Infra on Windows
+> Follow these steps to configure k8s-infra for Windows environments.
+>
+> #### Use OpenTelemetry Collector Contrib for Windows
+>
+> OpenTelemetry provides Windows-compatible [opentelemetry-collector-contrib](https://hub.docker.com/r/otel/opentelemetry-collector-contrib/tags?name=windows) container images which can be used for k8s-infra. You must specify the Windows image tags in your Helm values configuration.
+>
+> Add the following configuration to your Helm values file:
+>
+> ```yaml
+> otelAgent:
+>   image:
+>     tag: 0.123.0-windows-2022-amd64
+>
+> otelDeployment:
+>   image:
+>     tag: 0.123.0-windows-2022-amd64
+> ```
+>
+> #### Remove Root Path for Host Metrics
+>
+> The host metrics receiver requires configuring the `root_path` when using the host receiver for Linux in containers. However, Windows deployments do not require this configuration and the k8s-infra installation may fail if included. Remove the path from the `root_path` key under `presets.hostMetrics` in your Helm values:
+>
+> ```yaml
+> presets:
+>   hostMetrics:
+>     root_path: ""
+> ```
+>
+> After completing these steps, you can proceed with the [standard k8s-infra installation](https://github.com/SigNoz/charts/tree/main/charts/k8s-infra#installing-the-chart).
 
 ### Uninstalling the chart
 
@@ -62,6 +92,37 @@ Sometimes everything doesn't get properly removed. If that happens try deleting 
 ```bash
 kubectl delete namespace platform
 ```
+> [!WARNING]  
+> ### Breaking Changes
+> 
+> #### Version 0.14.1
+> 
+> **Configuration Migration Required:** 
+> - `presets.loggingExporter` has been deprecated and must be migrated to `presets.debugExporter`.
+> 
+> This change aligns with OpenTelemetry's deprecation of the [logging exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.110.0/exporter/loggingexporter) in favor of the [debug exporter](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.110.0/exporter/debugexporter/README.md).
+> 
+> **Migration Example:**
+> 
+> Replace this configuration:
+> ```yaml
+> presets:
+>   loggingExporter:  
+>     enabled: true
+>     verbosity: basic
+>     samplingInitial: 2
+>     samplingThereafter: 500
+> ```
+> 
+> With this configuration:
+> ```yaml
+> presets:
+>   debugExporter:  
+>     enabled: true
+>     verbosity: basic
+>     samplingInitial: 2
+>     samplingThereafter: 500
+> ```
 
 {{ define "chart.valueDefaultColumnRender" }}
 {{- $defaultValue := (default .Default .AutoDefault) -}}
@@ -72,7 +133,6 @@ kubectl delete namespace platform
 {{ end }}
 
 {{ define "chart.valuesTableHtml" }}
-
 {{/* Handle explicitly defined sections */}}
 {{- range .Sections.Sections }}
 {{- if (eq .SectionName "Presets Configuration")}}

--- a/charts/k8s-infra/templates/_config.tpl
+++ b/charts/k8s-infra/templates/_config.tpl
@@ -494,7 +494,9 @@ receivers:
 receivers:
   hostmetrics:
     collection_interval: {{ .Values.presets.hostMetrics.collectionInterval }}
-    root_path: /hostfs
+    {{- if and .Values.presets.hostMetrics.enabled (ne .Values.presets.hostMetrics.rootPath "") }}
+    root_path: {{.Values.presets.hostMetrics.rootPath | default "/hostfs"}}
+    {{- end}}
     scrapers:
     {{ range $key, $val := .Values.presets.hostMetrics.scrapers }}
       {{ $key }}: {{- $val | toYaml | nindent 8 }}

--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -53,7 +53,7 @@ spec:
         - name: varlibdockercontainers
           hostPath:
             path: /var/lib/docker/containers
-        {{- if eq .Values.presets.hostMetrics.enabled true }}
+        {{- if and .Values.presets.hostMetrics.enabled (ne .Values.presets.hostMetrics.rootPath "") }}
         - name: hostfs
           hostPath:
             path: /
@@ -123,9 +123,9 @@ spec:
             - name: varlibdockercontainers
               mountPath: /var/lib/docker/containers
               readOnly: true
-            {{- if eq .Values.presets.hostMetrics.enabled true }}
+            {{- if and .Values.presets.hostMetrics.enabled (ne .Values.presets.hostMetrics.rootPath "") }}
             - name: hostfs
-              mountPath: /hostfs
+              mountPath: {{ .Values.presets.hostMetrics.rootPath | default "/hostfs" }}
               readOnly: true
               mountPropagation: HostToContainer
             {{- end }}

--- a/charts/k8s-infra/tests/otel-agent_host_metrics_test.yaml
+++ b/charts/k8s-infra/tests/otel-agent_host_metrics_test.yaml
@@ -1,0 +1,555 @@
+suite: Test hostMetrics setting with rootPath
+templates:
+  - otel-agent/daemonset.yaml
+  - otel-agent/configmap.yaml
+set:
+  presets:
+    prometheus:
+      enabled: false
+    debugExporter:
+      enabled: false
+    otlpExporter:
+      enabled: false
+    logsCollection:
+      enabled: false
+    hostMetrics:
+      enabled: true
+    kubeletMetrics:
+      enabled: false
+    kubernetesAttributes:
+      enabled: false
+    clusterMetrics:
+      enabled: false
+    resourceDetection:
+      enabled: false
+    k8sEvents:
+      enabled: false
+    kubeletstats:
+      enabled: false
+
+# Test cases 1: for default hostMetrics with rootPath (for backward compatibility when rootPath key is not present)
+tests:
+  - it: should have hostMetrics present in configmap with default rootPath
+    asserts:
+      - equal:
+          path: data["otel-agent-config.yaml"]
+          value: |-
+            exporters: {}
+            extensions:
+              health_check:
+                endpoint: 0.0.0.0:13133
+              pprof:
+                endpoint: localhost:1777
+              zpages:
+                endpoint: localhost:55679
+            processors:
+              batch:
+                send_batch_size: 10000
+                timeout: 200ms
+            receivers:
+              hostmetrics:
+                collection_interval: 30s
+                root_path: /hostfs
+                scrapers:
+                  cpu: {}
+                  disk:
+                    exclude:
+                      devices:
+                      - ^ram\d+$
+                      - ^zram\d+$
+                      - ^loop\d+$
+                      - ^fd\d+$
+                      - ^hd[a-z]\d+$
+                      - ^sd[a-z]\d+$
+                      - ^vd[a-z]\d+$
+                      - ^xvd[a-z]\d+$
+                      - ^nvme\d+n\d+p\d+$
+                      match_type: regexp
+                  filesystem:
+                    exclude_fs_types:
+                      fs_types:
+                      - autofs
+                      - binfmt_misc
+                      - bpf
+                      - cgroup2?
+                      - configfs
+                      - debugfs
+                      - devpts
+                      - devtmpfs
+                      - fusectl
+                      - hugetlbfs
+                      - iso9660
+                      - mqueue
+                      - nsfs
+                      - overlay
+                      - proc
+                      - procfs
+                      - pstore
+                      - rpc_pipefs
+                      - securityfs
+                      - selinuxfs
+                      - squashfs
+                      - sysfs
+                      - tracefs
+                      match_type: strict
+                    exclude_mount_points:
+                      match_type: regexp
+                      mount_points:
+                      - /dev/*
+                      - /proc/*
+                      - /sys/*
+                      - /run/credentials/*
+                      - /run/k3s/containerd/*
+                      - /var/lib/docker/*
+                      - /var/lib/containers/storage/*
+                      - /var/lib/kubelet/*
+                      - /snap/*
+                  load: {}
+                  memory: {}
+                  network:
+                    exclude:
+                      interfaces:
+                      - ^veth.*$
+                      - ^docker.*$
+                      - ^br-.*$
+                      - ^flannel.*$
+                      - ^cali.*$
+                      - ^cbr.*$
+                      - ^cni.*$
+                      - ^dummy.*$
+                      - ^tailscale.*$
+                      - ^lo$
+                      match_type: regexp
+              otlp:
+                protocols:
+                  grpc:
+                    endpoint: 0.0.0.0:4317
+                    max_recv_msg_size_mib: 4
+                  http:
+                    endpoint: 0.0.0.0:4318
+            service:
+              extensions:
+              - health_check
+              - zpages
+              - pprof
+              pipelines: {}
+              telemetry:
+                logs:
+                  encoding: json
+                metrics:
+                  address: 0.0.0.0:8888
+        template: otel-agent/configmap.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          any: true
+          content:
+            name: hostfs
+            hostPath:
+              path: /
+        template: otel-agent/daemonset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          any: true
+          content:
+            name: hostfs
+            mountPath: /hostfs
+            readOnly: true
+            mountPropagation: HostToContainer
+        template: otel-agent/daemonset.yaml
+
+# Test cases 2: hostMetrics with custom rootPath
+  - it: should have hostMetrics present in configmap with custom rootPath
+    set:
+      presets:
+        hostMetrics:
+          rootPath: "/host"
+    asserts:
+      - equal:
+          path: data["otel-agent-config.yaml"]
+          value: |-
+            exporters: {}
+            extensions:
+              health_check:
+                endpoint: 0.0.0.0:13133
+              pprof:
+                endpoint: localhost:1777
+              zpages:
+                endpoint: localhost:55679
+            processors:
+              batch:
+                send_batch_size: 10000
+                timeout: 200ms
+            receivers:
+              hostmetrics:
+                collection_interval: 30s
+                root_path: /host
+                scrapers:
+                  cpu: {}
+                  disk:
+                    exclude:
+                      devices:
+                      - ^ram\d+$
+                      - ^zram\d+$
+                      - ^loop\d+$
+                      - ^fd\d+$
+                      - ^hd[a-z]\d+$
+                      - ^sd[a-z]\d+$
+                      - ^vd[a-z]\d+$
+                      - ^xvd[a-z]\d+$
+                      - ^nvme\d+n\d+p\d+$
+                      match_type: regexp
+                  filesystem:
+                    exclude_fs_types:
+                      fs_types:
+                      - autofs
+                      - binfmt_misc
+                      - bpf
+                      - cgroup2?
+                      - configfs
+                      - debugfs
+                      - devpts
+                      - devtmpfs
+                      - fusectl
+                      - hugetlbfs
+                      - iso9660
+                      - mqueue
+                      - nsfs
+                      - overlay
+                      - proc
+                      - procfs
+                      - pstore
+                      - rpc_pipefs
+                      - securityfs
+                      - selinuxfs
+                      - squashfs
+                      - sysfs
+                      - tracefs
+                      match_type: strict
+                    exclude_mount_points:
+                      match_type: regexp
+                      mount_points:
+                      - /dev/*
+                      - /proc/*
+                      - /sys/*
+                      - /run/credentials/*
+                      - /run/k3s/containerd/*
+                      - /var/lib/docker/*
+                      - /var/lib/containers/storage/*
+                      - /var/lib/kubelet/*
+                      - /snap/*
+                  load: {}
+                  memory: {}
+                  network:
+                    exclude:
+                      interfaces:
+                      - ^veth.*$
+                      - ^docker.*$
+                      - ^br-.*$
+                      - ^flannel.*$
+                      - ^cali.*$
+                      - ^cbr.*$
+                      - ^cni.*$
+                      - ^dummy.*$
+                      - ^tailscale.*$
+                      - ^lo$
+                      match_type: regexp
+              otlp:
+                protocols:
+                  grpc:
+                    endpoint: 0.0.0.0:4317
+                    max_recv_msg_size_mib: 4
+                  http:
+                    endpoint: 0.0.0.0:4318
+            service:
+              extensions:
+              - health_check
+              - zpages
+              - pprof
+              pipelines: {}
+              telemetry:
+                logs:
+                  encoding: json
+                metrics:
+                  address: 0.0.0.0:8888
+        template: otel-agent/configmap.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          any: true
+          content:
+            name: hostfs
+            hostPath:
+              path: /
+        template: otel-agent/daemonset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          any: true
+          content:
+            name: hostfs
+            mountPath: /host
+            readOnly: true
+        template: otel-agent/daemonset.yaml
+
+# Test cases 3: hostMetrics with empty rootPath (for windows compatibility)
+  - it: should have hostMetrics present in configmap with empty rootPath
+    set:
+      presets:
+        hostMetrics:
+          rootPath: ""
+    asserts:
+      - equal:
+          path: data["otel-agent-config.yaml"]
+          value: |-
+            exporters: {}
+            extensions:
+              health_check:
+                endpoint: 0.0.0.0:13133
+              pprof:
+                endpoint: localhost:1777
+              zpages:
+                endpoint: localhost:55679
+            processors:
+              batch:
+                send_batch_size: 10000
+                timeout: 200ms
+            receivers:
+              hostmetrics:
+                collection_interval: 30s
+                scrapers:
+                  cpu: {}
+                  disk:
+                    exclude:
+                      devices:
+                      - ^ram\d+$
+                      - ^zram\d+$
+                      - ^loop\d+$
+                      - ^fd\d+$
+                      - ^hd[a-z]\d+$
+                      - ^sd[a-z]\d+$
+                      - ^vd[a-z]\d+$
+                      - ^xvd[a-z]\d+$
+                      - ^nvme\d+n\d+p\d+$
+                      match_type: regexp
+                  filesystem:
+                    exclude_fs_types:
+                      fs_types:
+                      - autofs
+                      - binfmt_misc
+                      - bpf
+                      - cgroup2?
+                      - configfs
+                      - debugfs
+                      - devpts
+                      - devtmpfs
+                      - fusectl
+                      - hugetlbfs
+                      - iso9660
+                      - mqueue
+                      - nsfs
+                      - overlay
+                      - proc
+                      - procfs
+                      - pstore
+                      - rpc_pipefs
+                      - securityfs
+                      - selinuxfs
+                      - squashfs
+                      - sysfs
+                      - tracefs
+                      match_type: strict
+                    exclude_mount_points:
+                      match_type: regexp
+                      mount_points:
+                      - /dev/*
+                      - /proc/*
+                      - /sys/*
+                      - /run/credentials/*
+                      - /run/k3s/containerd/*
+                      - /var/lib/docker/*
+                      - /var/lib/containers/storage/*
+                      - /var/lib/kubelet/*
+                      - /snap/*
+                  load: {}
+                  memory: {}
+                  network:
+                    exclude:
+                      interfaces:
+                      - ^veth.*$
+                      - ^docker.*$
+                      - ^br-.*$
+                      - ^flannel.*$
+                      - ^cali.*$
+                      - ^cbr.*$
+                      - ^cni.*$
+                      - ^dummy.*$
+                      - ^tailscale.*$
+                      - ^lo$
+                      match_type: regexp
+              otlp:
+                protocols:
+                  grpc:
+                    endpoint: 0.0.0.0:4317
+                    max_recv_msg_size_mib: 4
+                  http:
+                    endpoint: 0.0.0.0:4318
+            service:
+              extensions:
+              - health_check
+              - zpages
+              - pprof
+              pipelines: {}
+              telemetry:
+                logs:
+                  encoding: json
+                metrics:
+                  address: 0.0.0.0:8888
+        template: otel-agent/configmap.yaml
+      - notContains:
+          path: spec.template.spec.volumes
+          any: true
+          content:
+            name: hostfs
+            hostPath:
+              path: /
+        template: otel-agent/daemonset.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          any: true
+          content:
+            name: hostfs
+            mountPath: /host
+            readOnly: true
+            mountPropagation: HostToContainer
+        template: otel-agent/daemonset.yaml
+
+# Test cases 4: for default hostMetrics with null rootPath (check whether rootPath still exists)
+  - it: should have hostMetrics present in configmap with null rootPath
+    set:
+      presets:
+        hostMetrics:
+          rootPath:
+    asserts:
+      - equal:
+          path: data["otel-agent-config.yaml"]
+          value: |-
+            exporters: {}
+            extensions:
+              health_check:
+                endpoint: 0.0.0.0:13133
+              pprof:
+                endpoint: localhost:1777
+              zpages:
+                endpoint: localhost:55679
+            processors:
+              batch:
+                send_batch_size: 10000
+                timeout: 200ms
+            receivers:
+              hostmetrics:
+                collection_interval: 30s
+                root_path: /hostfs
+                scrapers:
+                  cpu: {}
+                  disk:
+                    exclude:
+                      devices:
+                      - ^ram\d+$
+                      - ^zram\d+$
+                      - ^loop\d+$
+                      - ^fd\d+$
+                      - ^hd[a-z]\d+$
+                      - ^sd[a-z]\d+$
+                      - ^vd[a-z]\d+$
+                      - ^xvd[a-z]\d+$
+                      - ^nvme\d+n\d+p\d+$
+                      match_type: regexp
+                  filesystem:
+                    exclude_fs_types:
+                      fs_types:
+                      - autofs
+                      - binfmt_misc
+                      - bpf
+                      - cgroup2?
+                      - configfs
+                      - debugfs
+                      - devpts
+                      - devtmpfs
+                      - fusectl
+                      - hugetlbfs
+                      - iso9660
+                      - mqueue
+                      - nsfs
+                      - overlay
+                      - proc
+                      - procfs
+                      - pstore
+                      - rpc_pipefs
+                      - securityfs
+                      - selinuxfs
+                      - squashfs
+                      - sysfs
+                      - tracefs
+                      match_type: strict
+                    exclude_mount_points:
+                      match_type: regexp
+                      mount_points:
+                      - /dev/*
+                      - /proc/*
+                      - /sys/*
+                      - /run/credentials/*
+                      - /run/k3s/containerd/*
+                      - /var/lib/docker/*
+                      - /var/lib/containers/storage/*
+                      - /var/lib/kubelet/*
+                      - /snap/*
+                  load: {}
+                  memory: {}
+                  network:
+                    exclude:
+                      interfaces:
+                      - ^veth.*$
+                      - ^docker.*$
+                      - ^br-.*$
+                      - ^flannel.*$
+                      - ^cali.*$
+                      - ^cbr.*$
+                      - ^cni.*$
+                      - ^dummy.*$
+                      - ^tailscale.*$
+                      - ^lo$
+                      match_type: regexp
+              otlp:
+                protocols:
+                  grpc:
+                    endpoint: 0.0.0.0:4317
+                    max_recv_msg_size_mib: 4
+                  http:
+                    endpoint: 0.0.0.0:4318
+            service:
+              extensions:
+              - health_check
+              - zpages
+              - pprof
+              pipelines: {}
+              telemetry:
+                logs:
+                  encoding: json
+                metrics:
+                  address: 0.0.0.0:8888
+        template: otel-agent/configmap.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          any: true
+          content:
+            name: hostfs
+            hostPath:
+              path: /
+        template: otel-agent/daemonset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          any: true
+          content:
+            name: hostfs
+            mountPath: /hostfs
+            readOnly: true
+            mountPropagation: HostToContainer
+        template: otel-agent/daemonset.yaml

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -249,6 +249,10 @@ presets:
     # presets.hostMetrics.enabled -- Enable host metrics collection.
     # @section -- Host Metrics Presets
     enabled: true
+    # presets.hostMetrics.rootPath -- Root path for host metrics collection (Linux only).
+    # @section -- Host Metrics Presets
+    # @default -- "/hostfs"
+    rootPath: 
     # presets.hostMetrics.collectionInterval -- Frequency at which to scrape host metrics.
     # @section -- Host Metrics Presets
     collectionInterval: 30s
@@ -562,6 +566,7 @@ otelAgent:
     # @section -- OpenTelemetry Agent (DaemonSet)
     repository: otel/opentelemetry-collector-contrib
     # otelAgent.image.tag -- Tag for the OtelAgent image.
+    # In case of your Host OS is windows, use the `0.123.0-windows-2022-amd64` tag.
     # @section -- OpenTelemetry Agent (DaemonSet)
     tag: 0.109.0
     # otelAgent.image.pullPolicy -- Image pull policy for the OtelAgent.

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -252,7 +252,7 @@ presets:
     # presets.hostMetrics.rootPath -- Root path for host metrics collection (Linux only).
     # @section -- Host Metrics Presets
     # @default -- "/hostfs"
-    rootPath: 
+    rootPath: "/hostfs"
     # presets.hostMetrics.collectionInterval -- Frequency at which to scrape host metrics.
     # @section -- Host Metrics Presets
     collectionInterval: 30s
@@ -1045,6 +1045,7 @@ otelDeployment:
     # @section -- OpenTelemetry Deployment
     repository: otel/opentelemetry-collector-contrib
     # otelDeployment.image.tag -- Tag for the OtelDeployment image.
+    # In case of your Host OS is windows, use the `0.123.0-windows-2022-amd64` tag.
     # @section -- OpenTelemetry Deployment
     tag: 0.109.0
     # otelDeployment.image.pullPolicy -- Image pull policy for the OtelDeployment.


### PR DESCRIPTION
Related: https://github.com/SigNoz/platform-pod/issues/407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance for Windows environments, including use of Windows-compatible container images and configuration notes.
  * Added a breaking changes warning for version 0.14.1, highlighting the deprecation of `presets.loggingExporter` in favor of `presets.debugExporter`, with migration instructions.
  * Clarified configuration tables and added details for the new `rootPath` option under host metrics.

* **New Features**
  * Introduced a configurable `rootPath` option for host metrics collection, allowing customization or omission (for Windows compatibility).

* **Bug Fixes**
  * Improved compatibility with Windows by conditionally handling host filesystem mounts and configuration.

* **Tests**
  * Added comprehensive tests to validate host metrics configuration and volume mounts for various `rootPath` scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->