### PR TITLE
feat: Add annotations support to schema migrator templates

### DIFF
--- a/charts/signoz/templates/schema-migrator/migrations-async.yaml
+++ b/charts/signoz/templates/schema-migrator/migrations-async.yaml
@@ -24,6 +24,10 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        {{- with .Values.schemaMigrator.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "schemaMigrator.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/signoz/templates/schema-migrator/migrations-sync.yaml
+++ b/charts/signoz/templates/schema-migrator/migrations-sync.yaml
@@ -24,6 +24,10 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        {{- with .Values.schemaMigrator.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "schemaMigrator.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
Enhances the schema migrator templates to support annotations, allowing for greater customization and flexibility in deployment configurations. One major use-case for this change is when the namespace has Istio injection enabled, and init containers require istio injection to be turned off to complete the jobs.

This change updates both async and sync migration templates to include annotations specified in the Helm values.