### PR TITLE
chore(release): Bump the charts/signoz version to 0.88.2

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.88.1
+version: 0.88.2
 appVersion: "v0.91.0"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -1,7 +1,7 @@
 
 # SigNoz
 
-![Version: 0.88.1](https://img.shields.io/badge/Version-0.88.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.91.0](https://img.shields.io/badge/AppVersion-v0.91.0-informational?style=flat-square)
+![Version: 0.88.2](https://img.shields.io/badge/Version-0.88.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.91.0](https://img.shields.io/badge/AppVersion-v0.91.0-informational?style=flat-square)
 
 SigNoz is an open-source observability platform native to OpenTelemetry with logs, traces and metrics in a single application. An open-source alternative to DataDog, NewRelic, etc. 🔥 🖥. 👉 Open source Application Performance Monitoring (APM) & Observability tool
 


### PR DESCRIPTION
Bump the charts/signoz patch version to release the patch release with the following fixes:
- Add External Clickhouse Creds as environment variables in the signoz statefulset : https://github.com/SigNoz/charts/pull/712
- Add resources configuration for initContainers in SigNoz Chart : https://github.com/SigNoz/charts/pull/719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Helm chart version for the SigNoz observability platform to 0.88.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->