### PR TITLE
fix dependency chart version

### DIFF
--- a/charts/signoz/Chart.lock
+++ b/charts/signoz/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: clickhouse
   repository: https://charts.signoz.io
-  version: 24.1.15
+  version: 24.1.18
 - name: signoz-otel-gateway
   repository: https://charts.signoz.io
   version: 0.0.1
-digest: sha256:6e9bc26aaa42990986a4564c9209f1d469e2d227f40eec8f153c3258753aea94
-generated: "2025-01-29T18:12:34.847081+05:30"
+digest: sha256:7359908b12d19f8c015b936a9aa668e8bd3b8f1d279d633c6b0f890d981801cb
+generated: "2025-08-13T14:08:25.92564+09:00"

--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
   - name: clickhouse
     repository: https://charts.signoz.io
     condition: clickhouse.enabled
-    version: 24.1.15
+    version: 24.1.18
   - name: signoz-otel-gateway
     repository: https://charts.signoz.io
     condition: signoz-otel-gateway.enabled


### PR DESCRIPTION
https://github.com/SigNoz/charts/blob/main/charts/clickhouse/Chart.yaml#L5 and dependency chart version is different.
This causes the following issue:
When defining a new Chart.yaml with
```yaml
dependencies:
  - name: signoz
    repository: https://charts.signoz.io
```
it fetches the wrong ClickHouse chart version.
As a result, several bugs remain unfixed, which causes problems. like this: https://github.com/SigNoz/charts/commit/af77f75f75a5c085cfa7b95b44fd58e33c25a10f


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added in this release.

- Chores
  - Upgraded ClickHouse dependency in the Helm chart from 24.1.15 to 24.1.18. This aligns deployments with the latest patch release and may include upstream fixes, performance improvements, and compatibility updates. Deployments using the chart will pull the newer ClickHouse version on install or upgrade. No other functional changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->