### PR TITLE
Allow clickhouse operator to be disabled

### DIFF
--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-confd-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-confd-files.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.clickhouseOperator.disabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,3 +7,4 @@ metadata:
   labels:
     {{- include "clickhouseOperator.labels" . | nindent 4 }}
 data: {{ tpl (toYaml .Values.clickhouseOperator.configs.confdFiles) . | nindent 2 }}
+{{- end }}

--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-configd-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-configd-files.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.clickhouseOperator.disabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -159,3 +160,4 @@ data:
         </processors_profile_log>
     </yandex>
 
+{{- end }}

--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-files.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.clickhouseOperator.disabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -286,3 +287,4 @@ data:
         stderrthreshold: ""
         vmodule: ""
         log_backtrace_at: ""
+{{- end }}

--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-templatesd-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-templatesd-files.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.clickhouseOperator.disabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -88,3 +89,4 @@ data:
                   storage: 2Gi
   readme: |-
     Templates in this folder are packaged with an operator and available via 'useTemplate'
+{{- end }}

--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-usersd-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-usersd-files.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.clickhouseOperator.disabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -45,3 +46,4 @@ data:
             </default>
         </profiles>
     </yandex>
+{{- end }}

--- a/charts/clickhouse/templates/clickhouse-operator/deployment.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.clickhouseOperator.disabled }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -117,3 +118,4 @@ spec:
               name: metrics
           resources:
             {{- toYaml .Values.clickhouseOperator.metricsExporter.resources | nindent 12 }}
+{{- end }}

--- a/charts/clickhouse/templates/clickhouse-operator/role.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/role.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.clickhouseOperator.disabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -143,3 +144,4 @@ rules:
     verbs:
       - get
       - list
+{{- end }}

--- a/charts/clickhouse/templates/clickhouse-operator/rolebinding.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.clickhouseOperator.disabled }}
 # Setup RoleBinding between Role and ServiceAccount.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -18,3 +19,4 @@ subjects:
   name: {{ .Values.clickhouseOperator.serviceAccount.name }}
   {{- end }}
   namespace: {{ include "clickhouse.namespace" . }}
+{{- end }}

--- a/charts/clickhouse/templates/clickhouse-operator/secret.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.clickhouseOperator.disabled }}
 {{- if .Values.clickhouseOperator.secret.create -}}
 apiVersion: v1
 kind: Secret
@@ -9,4 +10,5 @@ type: Opaque
 data:
   username: {{ .Values.clickhouseOperator.secret.username | b64enc }}
   password: {{ .Values.clickhouseOperator.secret.password | b64enc }}
+{{- end -}}
 {{- end -}}

--- a/charts/clickhouse/templates/clickhouse-operator/service.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.clickhouseOperator.disabled }}
 {{- if .Values.clickhouseOperator.service.enabled }}
 kind: Service
 apiVersion: v1
@@ -18,5 +19,6 @@ spec:
       name: {{ include "clickhouseOperator.fullname" $ }}-metrics
   selector:
     {{- include "clickhouseOperator.selectorLabels" $ | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/clickhouse/templates/clickhouse-operator/serviceaccount.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.clickhouseOperator.disabled }}
 {{- if .Values.clickhouseOperator.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
@@ -11,4 +12,5 @@ metadata:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 {{- include "clickhouseOperator.imagePullSecrets" . }}
+{{- end }}
 {{- end }}

--- a/charts/clickhouse/templates/clickhouse-operator/servicemonitor.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/servicemonitor.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.clickhouseOperator.disabled }}
 {{- if .Values.clickhouseOperator.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -32,4 +33,5 @@ spec:
   metricRelabelings:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -569,6 +569,9 @@ installCustomStorageClass: false
 ###
 ###
 clickhouseOperator:
+  # -- Whether to disable Clickhouse Operator. Negation used to not break backwards compatibility.
+  disabled: false
+
   service:
     enabled: true
   # -- name of the component


### PR DESCRIPTION
There are cases where the clickhouse operator is already deployed in the cluster and we want to disable it from signoz.

I made it a negation so it does not break compatibility with other people's charts that won't have this value.