### PR TITLE
Bump charts/signoz to v0.89.0

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.88.3
+version: 0.89.0
 appVersion: "v0.92.1"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -1,7 +1,7 @@
 
 # SigNoz
 
-![Version: 0.88.3](https://img.shields.io/badge/Version-0.88.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.92.1](https://img.shields.io/badge/AppVersion-v0.92.1-informational?style=flat-square)
+![Version: 0.89.0](https://img.shields.io/badge/Version-0.89.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.92.1](https://img.shields.io/badge/AppVersion-v0.92.1-informational?style=flat-square)
 
 SigNoz is an open-source observability platform native to OpenTelemetry with logs, traces and metrics in a single application. An open-source alternative to DataDog, NewRelic, etc. 🔥 🖥. 👉 Open source Application Performance Monitoring (APM) & Observability tool
 

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -63,6 +63,13 @@ kubectl delete namespace platform
 
 > [!WARNING] 
 > ### Breaking Changes
+> #### Version 0.89.0
+> After August 28, 2025, Bitnami will require paid subscriptions for their image updates. SigNoz utilises Bitnami container images and Helm charts for Zookeeper.
+>
+> To ensure continued stability, we have migrated the Zookeeper Images and Charts to our own repositories.
+>
+> You must upgrade to SigNoz `v0.89.0` to avoid any service interruption.
+> More details are available in [Issue #731](https://github.com/SigNoz/charts/issues/731)
 > #### Version 0.88.0
 > **Configuration Migration Required:**
 > - `signoz.configVars` has been deprecated

--- a/charts/signoz/README.md.gotmpl
+++ b/charts/signoz/README.md.gotmpl
@@ -63,6 +63,13 @@ kubectl delete namespace platform
 
 > [!WARNING]  
 > ### Breaking Changes
+> #### Version 0.89.0
+> After August 28, 2025, Bitnami will require paid subscriptions for their image updates. SigNoz utilises Bitnami container images and Helm charts for Zookeeper.
+> 
+> To ensure continued stability, we have migrated the Zookeeper Images and Charts to our own repositories.
+> 
+> You must upgrade to SigNoz `v0.89.0` to avoid any service interruption.
+> More details are available in [Issue #731](https://github.com/SigNoz/charts/issues/731)
 > #### Version 0.88.0
 > **Configuration Migration Required:**
 > - `signoz.configVars` has been deprecated


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Helm chart version to 0.89.0; application version remains v0.92.1.

* **Documentation**
  * Updated version badge to 0.89.0 and added a Breaking Changes section outlining Bitnami image subscription changes and migration of Zookeeper images/charts to SigNoz repositories; users must upgrade to v0.89.0 to avoid service interruption.

No functional changes; metadata/documentation update only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->