### PR TITLE
fix: move interval field to endpoints in serviceMonitor definition

### DIFF
--- a/charts/clickhouse/templates/clickhouse-operator/servicemonitor.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/servicemonitor.yaml
@@ -15,12 +15,12 @@ spec:
       path: /metrics
       scheme: http
       honorLabels: true
+      {{- with .Values.clickhouseOperator.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
   selector:
     matchLabels:
       {{- include "clickhouseOperator.selectorLabels" $ | nindent 6 }}
-  {{- with .Values.clickhouseOperator.serviceMonitor.interval }}
-  interval: {{ . }}
-  {{- end }}
   {{- with .Values.clickhouseOperator.serviceMonitor.scrapeTimeout }}
   scrapeTimeout: {{ . }}
   {{- end }}


### PR DESCRIPTION
There is no `interval`  field in [ServiceMonitor spec](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.ServiceMonitorSpec) so we get an error when try to apply this CRD.
To fix this just move interval filed to [Endpoint](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.Endpoint) 