### PR TITLE
feat: add SigNoz Kustomize base and core overlays

### DIFF
--- a/kustomize/signoz/base/kustomization.yaml
+++ b/kustomize/signoz/base/kustomization.yaml
@@ -1,0 +1,49 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: signoz
+
+# Phase 1: Core infrastructure
+resources:
+  - namespace.yaml
+  - signoz-serviceaccount.yaml
+  - otel-collector-serviceaccount.yaml
+  - otel-collector-clusterrole.yaml
+  - otel-collector-clusterrolebinding.yaml
+  - schema-migrator-serviceaccount.yaml
+  - schema-migrator-role.yaml
+  - schema-migrator-rolebinding.yaml
+
+# Phase 2: Services and ConfigMaps
+  - signoz-service.yaml
+  - otel-collector-service.yaml
+  - otel-collector-configmap.yaml
+
+# Phase 3: Schema migrations (must complete before SigNoz starts)
+  - schema-migrator-sync-job.yaml
+  - schema-migrator-async-job.yaml
+
+# Phase 4: Main applications (after dependencies are ready)
+  - signoz-statefulset.yaml
+  - otel-collector-deployment.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/name: signoz
+      app.kubernetes.io/instance: signoz
+      app.kubernetes.io/version: "v0.93.0"
+      app.kubernetes.io/managed-by: kustomize
+
+images:
+  - name: docker.io/signoz/signoz
+    newTag: v0.93.0
+  - name: docker.io/signoz/signoz-otel-collector
+    newTag: v0.129.2
+  - name: docker.io/signoz/signoz-schema-migrator
+    newTag: v0.129.2
+  - name: docker.io/busybox
+    newTag: "1.35"
+  - name: docker.io/clickhouse/clickhouse-server
+    newTag: 24.1.2-alpine
+  - name: groundnuty/k8s-wait-for
+    newTag: v2.0

--- a/kustomize/signoz/base/kustomization.yaml
+++ b/kustomize/signoz/base/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 
 namespace: signoz
 
-# Phase 1: Core infrastructure
 resources:
   - namespace.yaml
   - signoz-serviceaccount.yaml
@@ -13,17 +12,11 @@ resources:
   - schema-migrator-serviceaccount.yaml
   - schema-migrator-role.yaml
   - schema-migrator-rolebinding.yaml
-
-# Phase 2: Services and ConfigMaps
   - signoz-service.yaml
   - otel-collector-service.yaml
   - otel-collector-configmap.yaml
-
-# Phase 3: Schema migrations (must complete before SigNoz starts)
   - schema-migrator-sync-job.yaml
   - schema-migrator-async-job.yaml
-
-# Phase 4: Main applications (after dependencies are ready)
   - signoz-statefulset.yaml
   - otel-collector-deployment.yaml
 

--- a/kustomize/signoz/base/namespace.yaml
+++ b/kustomize/signoz/base/namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: signoz
+  labels:
+    app.kubernetes.io/name: signoz
+    app.kubernetes.io/instance: signoz
+    app.kubernetes.io/version: "v0.93.0"
+    app.kubernetes.io/managed-by: kustomize

--- a/kustomize/signoz/base/otel-collector-clusterrole.yaml
+++ b/kustomize/signoz/base/otel-collector-clusterrole.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: signoz-otel-collector-signoz
+  namespace: signoz
+  labels:
+    app.kubernetes.io/name: signoz
+    app.kubernetes.io/instance: signoz
+    app.kubernetes.io/component: otel-collector
+    app.kubernetes.io/version: "v0.93.0"
+    app.kubernetes.io/managed-by: kustomize
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch"]

--- a/kustomize/signoz/base/otel-collector-clusterrolebinding.yaml
+++ b/kustomize/signoz/base/otel-collector-clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: signoz-otel-collector-signoz
+  namespace: signoz
+  labels:
+    app.kubernetes.io/name: signoz
+    app.kubernetes.io/instance: signoz
+    app.kubernetes.io/component: otel-collector
+    app.kubernetes.io/version: "v0.93.0"
+    app.kubernetes.io/managed-by: kustomize
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: signoz-otel-collector-signoz
+subjects:
+  - name: signoz-otel-collector
+    kind: ServiceAccount
+    namespace: signoz

--- a/kustomize/signoz/base/otel-collector-configmap.yaml
+++ b/kustomize/signoz/base/otel-collector-configmap.yaml
@@ -1,0 +1,113 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: signoz-otel-collector
+  namespace: signoz
+  labels:
+    app.kubernetes.io/name: signoz
+    app.kubernetes.io/instance: signoz
+    app.kubernetes.io/component: otel-collector
+    app.kubernetes.io/version: "v0.93.0"
+    app.kubernetes.io/managed-by: kustomize
+data:
+  otel-collector-config.yaml: |-
+    connectors:
+      signozmeter:
+        metrics_flush_interval: 1h
+        dimensions:
+          - name: service.name
+          - name: deployment.environment
+          - name: host.name
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+            max_recv_msg_size_mib: 16
+          http:
+            endpoint: 0.0.0.0:4318
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:14250
+          thrift_http:
+            endpoint: 0.0.0.0:14268
+      httplogreceiver/heroku:
+        endpoint: 0.0.0.0:8081
+        source: heroku
+      httplogreceiver/json:
+        endpoint: 0.0.0.0:8082
+        source: json
+    processors:
+      batch:
+        send_batch_size: 50000
+        timeout: 1s
+      batch/meter:
+        send_batch_max_size: 25000
+        send_batch_size: 20000
+        timeout: 1s
+      signozspanmetrics/delta:
+        metrics_exporter: signozclickhousemetrics
+        latency_histogram_buckets: [100us, 1ms, 2ms, 6ms, 10ms, 50ms, 100ms, 250ms, 500ms, 1000ms, 1400ms, 2000ms, 5s, 10s, 20s, 40s, 60s]
+        dimensions_cache_size: 100000
+        dimensions:
+          - name: service.namespace
+            default: default
+          - name: deployment.environment
+            default: default
+          - name: signoz.collector.id
+        aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+      zpages:
+        endpoint: localhost:55679
+      pprof:
+        endpoint: localhost:1777
+    exporters:
+      clickhousetraces:
+        datasource: tcp://${env:CLICKHOUSE_USER}:${env:CLICKHOUSE_PASSWORD}@${env:CLICKHOUSE_HOST}:${env:CLICKHOUSE_PORT}/${env:CLICKHOUSE_TRACE_DATABASE}
+        low_cardinal_exception_grouping: ${env:LOW_CARDINAL_EXCEPTION_GROUPING}
+        use_new_schema: true
+      signozclickhousemetrics:
+        dsn: tcp://${env:CLICKHOUSE_USER}:${env:CLICKHOUSE_PASSWORD}@${env:CLICKHOUSE_HOST}:${env:CLICKHOUSE_PORT}/${env:CLICKHOUSE_DATABASE}
+        timeout: 45s
+      clickhouselogsexporter:
+        dsn: tcp://${env:CLICKHOUSE_USER}:${env:CLICKHOUSE_PASSWORD}@${env:CLICKHOUSE_HOST}:${env:CLICKHOUSE_PORT}/${env:CLICKHOUSE_LOG_DATABASE}
+        timeout: 10s
+        use_new_schema: true
+      metadataexporter:
+        dsn: tcp://${env:CLICKHOUSE_USER}:${env:CLICKHOUSE_PASSWORD}@${env:CLICKHOUSE_HOST}:${env:CLICKHOUSE_PORT}/signoz_metadata
+        timeout: 10s
+        tenant_id: ${env:TENANT_ID}
+        cache:
+          provider: in_memory
+      signozclickhousemeter:
+        dsn: tcp://${env:CLICKHOUSE_USER}:${env:CLICKHOUSE_PASSWORD}@${env:CLICKHOUSE_HOST}:${env:CLICKHOUSE_PORT}/${env:CLICKHOUSE_METER_DATABASE}
+        timeout: 45s
+        sending_queue:
+          enabled: false
+    service:
+      telemetry:
+        logs:
+          encoding: json
+      extensions: [health_check, zpages, pprof]
+      pipelines:
+        traces:
+          receivers: [otlp, jaeger]
+          processors: [signozspanmetrics/delta, batch]
+          exporters: [clickhousetraces, metadataexporter, signozmeter]
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [metadataexporter, signozclickhousemetrics, signozmeter]
+        logs:
+          receivers: [otlp, httplogreceiver/heroku, httplogreceiver/json]
+          processors: [batch]
+          exporters: [clickhouselogsexporter, metadataexporter, signozmeter]
+        metrics/meter:
+          receivers: [signozmeter]
+          processors: [batch/meter]
+          exporters: [signozclickhousemeter]
+  otel-collector-opamp-config.yaml: |-
+    server_endpoint: "ws://signoz:4320/v1/opamp"

--- a/kustomize/signoz/base/otel-collector-deployment.yaml
+++ b/kustomize/signoz/base/otel-collector-deployment.yaml
@@ -1,0 +1,154 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: signoz-otel-collector
+  namespace: signoz
+  labels:
+    app.kubernetes.io/name: signoz
+    app.kubernetes.io/instance: signoz
+    app.kubernetes.io/component: otel-collector
+    app.kubernetes.io/version: "v0.93.0"
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: signoz
+      app.kubernetes.io/instance: signoz
+      app.kubernetes.io/component: otel-collector
+  minReadySeconds: 5
+  progressDeadlineSeconds: 600
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        signoz.io/scrape: 'true'
+        signoz.io/port: '8888'
+        checksum/config: "placeholder"
+      labels:
+        app.kubernetes.io/name: signoz
+        app.kubernetes.io/instance: signoz
+        app.kubernetes.io/component: otel-collector
+    spec:
+      serviceAccountName: signoz-otel-collector
+      initContainers:
+        - name: "signoz-otel-collector-migrate-init"
+          image: groundnuty/k8s-wait-for:v2.0
+          imagePullPolicy: IfNotPresent
+          args:
+          - "job"
+          - "signoz-schema-migrator-sync"
+          resources: {}
+      containers:
+        - name: collector
+          image: docker.io/signoz/signoz-otel-collector:v0.129.2
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: logsheroku
+              containerPort: 8081
+              protocol: TCP
+            - name: logsjson
+              containerPort: 8082
+              protocol: TCP
+          command:
+            - "/signoz-otel-collector"
+          args:
+            - "--config=/conf/otel-collector-config.yaml"
+            - "--manager-config=/conf/otel-collector-opamp-config.yaml"
+            - "--copy-path=/var/tmp/collector-config.yaml"
+            - "--feature-gates=-pkg.translator.prometheus.NormalizeName"
+          env:
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: K8S_HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CLICKHOUSE_HOST
+              value: "clickhouse"
+            - name: CLICKHOUSE_PORT
+              value: "9000"
+            - name: CLICKHOUSE_HTTP_PORT
+              value: "8123"
+            - name: CLICKHOUSE_CLUSTER
+              value: "cluster"
+            - name: CLICKHOUSE_DATABASE
+              value: "signoz_metrics"
+            - name: CLICKHOUSE_TRACE_DATABASE
+              value: "signoz_traces"
+            - name: CLICKHOUSE_LOG_DATABASE
+              value: "signoz_logs"
+            - name: CLICKHOUSE_METER_DATABASE
+              value: "signoz_meter"
+            - name: CLICKHOUSE_USER
+              value: "admin"
+            - name: CLICKHOUSE_PASSWORD
+              value: "27ff0399-0d3a-4bd8-919d-17c2181e6fb9"
+            - name: CLICKHOUSE_SECURE
+              value: "false"
+            - name: CLICKHOUSE_VERIFY
+              value: "false"
+            - name: LOW_CARDINAL_EXCEPTION_GROUPING
+              value: "false"
+          volumeMounts:
+            - name: otel-collector-config-vol
+              mountPath: /conf
+          livenessProbe:
+            httpGet:
+              port: 13133
+              path: /
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+            successThreshold: 1
+          readinessProbe:
+            httpGet:
+              port: 13133
+              path: /
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+            successThreshold: 1
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+      volumes:
+        - name: otel-collector-config-vol
+          configMap:
+            name: signoz-otel-collector

--- a/kustomize/signoz/base/otel-collector-service.yaml
+++ b/kustomize/signoz/base/otel-collector-service.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: signoz-otel-collector
+  namespace: signoz
+  labels:
+    app.kubernetes.io/name: signoz
+    app.kubernetes.io/instance: signoz
+    app.kubernetes.io/component: otel-collector
+    app.kubernetes.io/version: "v0.93.0"
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  type: ClusterIP
+  ports:
+    - name: otlp
+      port: 4317
+      targetPort: otlp
+      protocol: TCP
+    - name: otlp-http
+      port: 4318
+      targetPort: otlp-http
+      protocol: TCP
+    - name: jaeger-thrift
+      port: 14268
+      targetPort: jaeger-thrift
+      protocol: TCP
+    - name: jaeger-grpc
+      port: 14250
+      targetPort: jaeger-grpc
+      protocol: TCP
+    - name: metrics
+      port: 8888
+      targetPort: metrics
+      protocol: TCP
+    - name: logsheroku
+      port: 8081
+      targetPort: logsheroku
+      protocol: TCP
+    - name: logsjson
+      port: 8082
+      targetPort: logsjson
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: signoz
+    app.kubernetes.io/instance: signoz
+    app.kubernetes.io/component: otel-collector

--- a/kustomize/signoz/base/otel-collector-serviceaccount.yaml
+++ b/kustomize/signoz/base/otel-collector-serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: signoz-otel-collector
+  namespace: signoz
+  labels:
+    app.kubernetes.io/name: signoz
+    app.kubernetes.io/instance: signoz
+    app.kubernetes.io/component: otel-collector
+    app.kubernetes.io/version: "v0.93.0"
+    app.kubernetes.io/managed-by: kustomize

--- a/kustomize/signoz/base/schema-migrator-async-job.yaml
+++ b/kustomize/signoz/base/schema-migrator-async-job.yaml
@@ -1,0 +1,153 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: signoz-schema-migrator-async
+  namespace: signoz
+  labels:
+    app.kubernetes.io/name: signoz
+    app.kubernetes.io/instance: signoz
+    app.kubernetes.io/component: schema-migrator
+    app.kubernetes.io/version: "v0.93.0"
+    app.kubernetes.io/managed-by: kustomize
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: signoz
+        app.kubernetes.io/instance: signoz
+        app.kubernetes.io/component: schema-migrator
+    spec:
+      serviceAccountName: signoz-schema-migrator-async
+      initContainers:
+        - name: schema-migrator-async-init
+          image: docker.io/busybox:1.35
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CLICKHOUSE_HOST
+              value: "clickhouse"
+            - name: CLICKHOUSE_PORT
+              value: "9000"
+            - name: CLICKHOUSE_HTTP_PORT
+              value: "8123"
+            - name: CLICKHOUSE_CLUSTER
+              value: "cluster"
+            - name: CLICKHOUSE_USER
+              value: "admin"
+            - name: CLICKHOUSE_PASSWORD
+              value: "27ff0399-0d3a-4bd8-919d-17c2181e6fb9"
+            - name: CLICKHOUSE_SECURE
+              value: "false"
+          command:
+            - sh
+            - -c
+            - until wget --user "$(CLICKHOUSE_USER):$(CLICKHOUSE_PASSWORD)" --spider -q http://$(CLICKHOUSE_HOST):$(CLICKHOUSE_HTTP_PORT)/ping; do echo -e "waiting for clickhouseDB"; sleep 5; done; echo -e "clickhouse ready, starting schema migrator now";
+          resources: {}
+        - name: schema-migrator-async-ch-ready
+          image: docker.io/clickhouse/clickhouse-server:24.1.2-alpine
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CLICKHOUSE_HOST
+              value: "clickhouse"
+            - name: CLICKHOUSE_PORT
+              value: "9000"
+            - name: CLICKHOUSE_HTTP_PORT
+              value: "8123"
+            - name: CLICKHOUSE_CLUSTER
+              value: "cluster"
+            - name: CLICKHOUSE_USER
+              value: "admin"
+            - name: CLICKHOUSE_PASSWORD
+              value: "27ff0399-0d3a-4bd8-919d-17c2181e6fb9"
+            - name: CLICKHOUSE_SECURE
+              value: "false"
+            - name: CLICKHOUSE_VERSION
+              value: "24.1.2"
+            - name: CLICKHOUSE_SHARDS
+              value: "1"
+            - name: CLICKHOUSE_REPLICAS
+              value: "1"
+          command:
+            - "sh"
+            - "-c"
+            - |
+              echo "Running clickhouse ready check"
+              while true
+              do
+                version="$(CLICKHOUSE_VERSION)"
+                shards="$(CLICKHOUSE_SHARDS)"
+                replicas="$(CLICKHOUSE_REPLICAS)"
+                current_version="$(clickhouse client --host ${CLICKHOUSE_HOST} --port ${CLICKHOUSE_PORT} --user "${CLICKHOUSE_USER}" --password "${CLICKHOUSE_PASSWORD}" -q "SELECT version()")"
+                if [ -z "$current_version" ]; then
+                  echo "waiting for clickhouse to be ready"
+                  sleep 5
+                  continue
+                fi
+                if [ -z "$(echo "$current_version" | grep "$version")" ]; then
+                  echo "expected version: $version, current version: $current_version"
+                  echo "waiting for clickhouse with correct version"
+                  sleep 5
+                  continue
+                fi
+                current_shards="$(clickhouse client --host ${CLICKHOUSE_HOST} --port ${CLICKHOUSE_PORT} --user "${CLICKHOUSE_USER}" --password "${CLICKHOUSE_PASSWORD}" -q "SELECT count(DISTINCT(shard_num)) FROM system.clusters WHERE cluster = '${CLICKHOUSE_CLUSTER}'")"
+                if [ -z "$current_shards" ]; then
+                  echo "waiting for clickhouse to be ready"
+                  sleep 5
+                  continue
+                fi
+                if [ "$current_shards" -ne "$shards" ]; then
+                  echo "expected shard count: $shards, current shard count: $current_shards"
+                  echo "waiting for clickhouse with correct shard count"
+                  sleep 5
+                  continue
+                fi
+                current_replicas="$(clickhouse client --host ${CLICKHOUSE_HOST} --port ${CLICKHOUSE_PORT} --user "${CLICKHOUSE_USER}" --password "${CLICKHOUSE_PASSWORD}" -q "SELECT count(DISTINCT(replica_num)) FROM system.clusters WHERE cluster = '${CLICKHOUSE_CLUSTER}'")"
+                if [ -z "$current_replicas" ]; then
+                  echo "waiting for clickhouse to be ready"
+                  sleep 5
+                  continue
+                fi
+                if [ "$current_replicas" -ne "$replicas" ]; then
+                  echo "expected replica count: $replicas, current replica count: $current_replicas"
+                  echo "waiting for clickhouse with correct replica count"
+                  sleep 5
+                  continue
+                fi
+                break
+              done
+              echo "clickhouse ready, starting schema migrator now"
+          resources: {}
+        - name: schema-migrator-async-wait-for-sync
+          image: groundnuty/k8s-wait-for:v2.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "job"
+            - "signoz-schema-migrator-sync"
+      containers:
+        - name: schema-migrator
+          image: docker.io/signoz/signoz-schema-migrator:v0.129.2
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CLICKHOUSE_HOST
+              value: "clickhouse"
+            - name: CLICKHOUSE_PORT
+              value: "9000"
+            - name: CLICKHOUSE_HTTP_PORT
+              value: "8123"
+            - name: CLICKHOUSE_CLUSTER
+              value: "cluster"
+            - name: CLICKHOUSE_USER
+              value: "admin"
+            - name: CLICKHOUSE_PASSWORD
+              value: "27ff0399-0d3a-4bd8-919d-17c2181e6fb9"
+            - name: CLICKHOUSE_SECURE
+              value: "false"
+          args:
+            - async
+            - "--cluster-name"
+            - "$(CLICKHOUSE_CLUSTER)"
+            - "--dsn"
+            - "tcp://$(CLICKHOUSE_USER):$(CLICKHOUSE_PASSWORD)@clickhouse:9000"
+      restartPolicy: OnFailure

--- a/kustomize/signoz/base/schema-migrator-role.yaml
+++ b/kustomize/signoz/base/schema-migrator-role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: signoz-schema-migrator-signoz-async
+  namespace: signoz
+  labels:
+    app.kubernetes.io/name: signoz
+    app.kubernetes.io/instance: signoz
+    app.kubernetes.io/component: schema-migrator
+    app.kubernetes.io/version: "v0.93.0"
+    app.kubernetes.io/managed-by: kustomize
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch"]

--- a/kustomize/signoz/base/schema-migrator-rolebinding.yaml
+++ b/kustomize/signoz/base/schema-migrator-rolebinding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: signoz-schema-migrator-signoz-async
+  namespace: signoz
+  labels:
+    app.kubernetes.io/name: signoz
+    app.kubernetes.io/instance: signoz
+    app.kubernetes.io/component: schema-migrator
+    app.kubernetes.io/version: "v0.93.0"
+    app.kubernetes.io/managed-by: kustomize
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: signoz-schema-migrator-signoz-async
+subjects:
+  - name: signoz-schema-migrator-async
+    kind: ServiceAccount
+    namespace: signoz

--- a/kustomize/signoz/base/schema-migrator-serviceaccount.yaml
+++ b/kustomize/signoz/base/schema-migrator-serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: signoz-schema-migrator-async
+  namespace: signoz
+  labels:
+    app.kubernetes.io/name: signoz
+    app.kubernetes.io/instance: signoz
+    app.kubernetes.io/component: schema-migrator
+    app.kubernetes.io/version: "v0.93.0"
+    app.kubernetes.io/managed-by: kustomize

--- a/kustomize/signoz/base/schema-migrator-sync-job.yaml
+++ b/kustomize/signoz/base/schema-migrator-sync-job.yaml
@@ -1,0 +1,146 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: signoz-schema-migrator-sync
+  namespace: signoz
+  labels:
+    app.kubernetes.io/name: signoz
+    app.kubernetes.io/instance: signoz
+    app.kubernetes.io/component: schema-migrator
+    app.kubernetes.io/version: "v0.93.0"
+    app.kubernetes.io/managed-by: kustomize
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: signoz
+        app.kubernetes.io/instance: signoz
+        app.kubernetes.io/component: schema-migrator
+    spec:
+      initContainers:
+        - name: schema-migrator-sync-init
+          image: docker.io/busybox:1.35
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CLICKHOUSE_HOST
+              value: "clickhouse"
+            - name: CLICKHOUSE_PORT
+              value: "9000"
+            - name: CLICKHOUSE_HTTP_PORT
+              value: "8123"
+            - name: CLICKHOUSE_CLUSTER
+              value: "cluster"
+            - name: CLICKHOUSE_USER
+              value: "admin"
+            - name: CLICKHOUSE_PASSWORD
+              value: "27ff0399-0d3a-4bd8-919d-17c2181e6fb9"
+            - name: CLICKHOUSE_SECURE
+              value: "false"
+          command:
+            - sh
+            - -c
+            - until wget --user "$(CLICKHOUSE_USER):$(CLICKHOUSE_PASSWORD)" --spider -q http://$(CLICKHOUSE_HOST):$(CLICKHOUSE_HTTP_PORT)/ping; do echo -e "waiting for clickhouseDB"; sleep 5; done; echo -e "clickhouse ready, starting schema migrator now";
+          resources: {}
+        - name: schema-migrator-sync-ch-ready
+          image: docker.io/clickhouse/clickhouse-server:24.1.2-alpine
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CLICKHOUSE_HOST
+              value: "clickhouse"
+            - name: CLICKHOUSE_PORT
+              value: "9000"
+            - name: CLICKHOUSE_HTTP_PORT
+              value: "8123"
+            - name: CLICKHOUSE_CLUSTER
+              value: "cluster"
+            - name: CLICKHOUSE_USER
+              value: "admin"
+            - name: CLICKHOUSE_PASSWORD
+              value: "27ff0399-0d3a-4bd8-919d-17c2181e6fb9"
+            - name: CLICKHOUSE_SECURE
+              value: "false"
+            - name: CLICKHOUSE_VERSION
+              value: "24.1.2"
+            - name: CLICKHOUSE_SHARDS
+              value: "1"
+            - name: CLICKHOUSE_REPLICAS
+              value: "1"
+          command:
+            - "sh"
+            - "-c"
+            - |
+              echo "Running clickhouse ready check"
+              while true
+              do
+                version="$(CLICKHOUSE_VERSION)"
+                shards="$(CLICKHOUSE_SHARDS)"
+                replicas="$(CLICKHOUSE_REPLICAS)"
+                current_version="$(clickhouse client --host ${CLICKHOUSE_HOST} --port ${CLICKHOUSE_PORT} --user "${CLICKHOUSE_USER}" --password "${CLICKHOUSE_PASSWORD}" -q "SELECT version()")"
+                if [ -z "$current_version" ]; then
+                  echo "waiting for clickhouse to be ready"
+                  sleep 5
+                  continue
+                fi
+                if [ -z "$(echo "$current_version" | grep "$version")" ]; then
+                  echo "expected version: $version, current version: $current_version"
+                  echo "waiting for clickhouse with correct version"
+                  sleep 5
+                  continue
+                fi
+                current_shards="$(clickhouse client --host ${CLICKHOUSE_HOST} --port ${CLICKHOUSE_PORT} --user "${CLICKHOUSE_USER}" --password "${CLICKHOUSE_PASSWORD}" -q "SELECT count(DISTINCT(shard_num)) FROM system.clusters WHERE cluster = '${CLICKHOUSE_CLUSTER}'")"
+                if [ -z "$current_shards" ]; then
+                  echo "waiting for clickhouse to be ready"
+                  sleep 5
+                  continue
+                fi
+                if [ "$current_shards" -ne "$shards" ]; then
+                  echo "expected shard count: $shards, current shard count: $current_shards"
+                  echo "waiting for clickhouse with correct shard count"
+                  sleep 5
+                  continue
+                fi
+                current_replicas="$(clickhouse client --host ${CLICKHOUSE_HOST} --port ${CLICKHOUSE_PORT} --user "${CLICKHOUSE_USER}" --password "${CLICKHOUSE_PASSWORD}" -q "SELECT count(DISTINCT(replica_num)) FROM system.clusters WHERE cluster = '${CLICKHOUSE_CLUSTER}'")"
+                if [ -z "$current_replicas" ]; then
+                  echo "waiting for clickhouse to be ready"
+                  sleep 5
+                  continue
+                fi
+                if [ "$current_replicas" -ne "$replicas" ]; then
+                  echo "expected replica count: $replicas, current replica count: $current_replicas"
+                  echo "waiting for clickhouse with correct replica count"
+                  sleep 5
+                  continue
+                fi
+                break
+              done
+              echo "clickhouse ready, starting schema migrator now"
+          resources: {}
+      containers:
+        - name: schema-migrator
+          image: docker.io/signoz/signoz-schema-migrator:v0.129.2
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CLICKHOUSE_HOST
+              value: "clickhouse"
+            - name: CLICKHOUSE_PORT
+              value: "9000"
+            - name: CLICKHOUSE_HTTP_PORT
+              value: "8123"
+            - name: CLICKHOUSE_CLUSTER
+              value: "cluster"
+            - name: CLICKHOUSE_USER
+              value: "admin"
+            - name: CLICKHOUSE_PASSWORD
+              value: "27ff0399-0d3a-4bd8-919d-17c2181e6fb9"
+            - name: CLICKHOUSE_SECURE
+              value: "false"
+          args:
+            - sync
+            - "--cluster-name"
+            - "$(CLICKHOUSE_CLUSTER)"
+            - "--dsn"
+            - "tcp://$(CLICKHOUSE_USER):$(CLICKHOUSE_PASSWORD)@clickhouse:9000"
+      restartPolicy: OnFailure

--- a/kustomize/signoz/base/signoz-service.yaml
+++ b/kustomize/signoz/base/signoz-service.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: signoz
+  namespace: signoz
+  labels:
+    app.kubernetes.io/name: signoz
+    app.kubernetes.io/instance: signoz
+    app.kubernetes.io/component: signoz
+    app.kubernetes.io/version: "v0.93.0"
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+    - name: http-internal
+      port: 8085
+      protocol: TCP
+      targetPort: http-internal
+    - name: opamp-internal
+      port: 4320
+      protocol: TCP
+      targetPort: opamp-internal
+  selector:
+    app.kubernetes.io/name: signoz
+    app.kubernetes.io/instance: signoz
+    app.kubernetes.io/component: signoz

--- a/kustomize/signoz/base/signoz-serviceaccount.yaml
+++ b/kustomize/signoz/base/signoz-serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: signoz
+  namespace: signoz
+  labels:
+    app.kubernetes.io/name: signoz
+    app.kubernetes.io/instance: signoz
+    app.kubernetes.io/component: signoz
+    app.kubernetes.io/version: "v0.93.0"
+    app.kubernetes.io/managed-by: kustomize

--- a/kustomize/signoz/base/signoz-statefulset.yaml
+++ b/kustomize/signoz/base/signoz-statefulset.yaml
@@ -48,28 +48,28 @@ spec:
             - sh
             - -c
             - |
-              echo "🔍 Validating ClickHouse dependency..."
+              echo "Validating ClickHouse dependency..."
 
               # Check if ClickHouse service exists
               if ! wget --spider -q http://$(CLICKHOUSE_HOST):$(CLICKHOUSE_HTTP_PORT)/ping 2>/dev/null; then
-                echo "❌ ERROR: ClickHouse service '$(CLICKHOUSE_HOST)' not found or not responding!"
-                echo "💡 Please deploy ClickHouse first:"
+                echo "ERROR: ClickHouse service '$(CLICKHOUSE_HOST)' not found or not responding!"
+                echo "Please deploy ClickHouse first:"
                 echo "   helm repo add signoz https://charts.signoz.io"
                 echo "   helm install clickhouse signoz/clickhouse -n signoz --create-namespace"
                 exit 1
               fi
 
-              echo "✅ ClickHouse service found: $(CLICKHOUSE_HOST)"
+              echo "ClickHouse service found: $(CLICKHOUSE_HOST)"
 
               # Check if ClickHouse is responding
-              echo "🔍 Checking ClickHouse connectivity..."
+              echo "Checking ClickHouse connectivity..."
               until wget --user "$(CLICKHOUSE_USER):$(CLICKHOUSE_PASSWORD)" --spider -q http://$(CLICKHOUSE_HOST):$(CLICKHOUSE_HTTP_PORT)/ping; do
-                echo "⏳ Waiting for ClickHouse to be ready...";
+                echo "Waiting for ClickHouse to be ready...";
                 sleep 5;
               done
 
-              echo "✅ ClickHouse is ready and responding!"
-              echo "🚀 Starting SigNoz..."
+              echo "ClickHouse is ready and responding!"
+              echo "Starting SigNoz..."
         - name: signoz-init
           image: docker.io/busybox:1.35
           imagePullPolicy: IfNotPresent

--- a/kustomize/signoz/base/signoz-statefulset.yaml
+++ b/kustomize/signoz/base/signoz-statefulset.yaml
@@ -1,0 +1,187 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: signoz
+  namespace: signoz
+  labels:
+    app.kubernetes.io/name: signoz
+    app.kubernetes.io/instance: signoz
+    app.kubernetes.io/component: signoz
+    app.kubernetes.io/version: "v0.93.0"
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  serviceName: signoz
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: signoz
+      app.kubernetes.io/instance: signoz
+      app.kubernetes.io/component: signoz
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: signoz
+        app.kubernetes.io/instance: signoz
+        app.kubernetes.io/component: signoz
+    spec:
+      serviceAccountName: signoz
+      initContainers:
+        - name: clickhouse-validation
+          image: docker.io/busybox:1.35
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CLICKHOUSE_HOST
+              value: "clickhouse"
+            - name: CLICKHOUSE_PORT
+              value: "9000"
+            - name: CLICKHOUSE_HTTP_PORT
+              value: "8123"
+            - name: CLICKHOUSE_CLUSTER
+              value: "cluster"
+            - name: CLICKHOUSE_USER
+              value: "admin"
+            - name: CLICKHOUSE_PASSWORD
+              value: "27ff0399-0d3a-4bd8-919d-17c2181e6fb9"
+            - name: CLICKHOUSE_SECURE
+              value: "false"
+          command:
+            - sh
+            - -c
+            - |
+              echo "🔍 Validating ClickHouse dependency..."
+
+              # Check if ClickHouse service exists
+              if ! wget --spider -q http://$(CLICKHOUSE_HOST):$(CLICKHOUSE_HTTP_PORT)/ping 2>/dev/null; then
+                echo "❌ ERROR: ClickHouse service '$(CLICKHOUSE_HOST)' not found or not responding!"
+                echo "💡 Please deploy ClickHouse first:"
+                echo "   helm repo add signoz https://charts.signoz.io"
+                echo "   helm install clickhouse signoz/clickhouse -n signoz --create-namespace"
+                exit 1
+              fi
+
+              echo "✅ ClickHouse service found: $(CLICKHOUSE_HOST)"
+
+              # Check if ClickHouse is responding
+              echo "🔍 Checking ClickHouse connectivity..."
+              until wget --user "$(CLICKHOUSE_USER):$(CLICKHOUSE_PASSWORD)" --spider -q http://$(CLICKHOUSE_HOST):$(CLICKHOUSE_HTTP_PORT)/ping; do
+                echo "⏳ Waiting for ClickHouse to be ready...";
+                sleep 5;
+              done
+
+              echo "✅ ClickHouse is ready and responding!"
+              echo "🚀 Starting SigNoz..."
+        - name: signoz-init
+          image: docker.io/busybox:1.35
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CLICKHOUSE_HOST
+              value: "clickhouse"
+            - name: CLICKHOUSE_PORT
+              value: "9000"
+            - name: CLICKHOUSE_HTTP_PORT
+              value: "8123"
+            - name: CLICKHOUSE_CLUSTER
+              value: "cluster"
+            - name: CLICKHOUSE_USER
+              value: "admin"
+            - name: CLICKHOUSE_PASSWORD
+              value: "27ff0399-0d3a-4bd8-919d-17c2181e6fb9"
+            - name: CLICKHOUSE_SECURE
+              value: "false"
+          command:
+            - sh
+            - -c
+            - until wget --user "$(CLICKHOUSE_USER):$(CLICKHOUSE_PASSWORD)" --spider -q http://$(CLICKHOUSE_HOST):$(CLICKHOUSE_HTTP_PORT)/ping; do echo -e "waiting for clickhouseDB"; sleep 5; done; echo -e "clickhouse ready, starting query service now";
+          resources: {}
+      containers:
+        - name: signoz
+          image: docker.io/signoz/signoz:v0.93.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: http-internal
+              containerPort: 8085
+              protocol: TCP
+            - name: opamp-internal
+              containerPort: 4320
+              protocol: TCP
+          env:
+            - name: CLICKHOUSE_HOST
+              value: "clickhouse"
+            - name: CLICKHOUSE_PORT
+              value: "9000"
+            - name: CLICKHOUSE_HTTP_PORT
+              value: "8123"
+            - name: CLICKHOUSE_CLUSTER
+              value: "cluster"
+            - name: CLICKHOUSE_DATABASE
+              value: "signoz_metrics"
+            - name: CLICKHOUSE_TRACE_DATABASE
+              value: "signoz_traces"
+            - name: CLICKHOUSE_LOG_DATABASE
+              value: "signoz_logs"
+            - name: CLICKHOUSE_METER_DATABASE
+              value: "signoz_meter"
+            - name: CLICKHOUSE_USER
+              value: "admin"
+            - name: CLICKHOUSE_PASSWORD
+              value: "27ff0399-0d3a-4bd8-919d-17c2181e6fb9"
+            - name: CLICKHOUSE_SECURE
+              value: "false"
+            - name: CLICKHOUSE_VERIFY
+              value: "false"
+            - name: SIGNOZ_TELEMETRYSTORE_PROVIDER
+              value: "clickhouse"
+            - name: DOT_METRICS_ENABLED
+              value: "true"
+            - name: SIGNOZ_EMAILING_ENABLED
+              value: "false"
+            - name: SIGNOZ_PROMETHEUS_ACTIVE_QUERY_TRACKER_ENABLED
+              value: "false"
+            - name: SIGNOZ_ALERTMANAGER_PROVIDER
+              value: "signoz"
+            - name: SIGNOZ_ALERTMANAGER_SIGNOZ_EXTERNAL_URL
+              value: "http://localhost:8080"
+            - name: SIGNOZ_JWT_SECRET
+              value: "your-jwt-secret-key-change-this-in-production"
+            - name: SIGNOZ_TELEMETRYSTORE_CLICKHOUSE_DSN
+              value: "tcp://clickhouse:9000/?username=$(CLICKHOUSE_USER)&password=$(CLICKHOUSE_PASSWORD)"
+          livenessProbe:
+            httpGet:
+              port: http
+              path: /api/v1/health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+            successThreshold: 1
+          readinessProbe:
+            httpGet:
+              port: http
+              path: /api/v1/health?live=1
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+            successThreshold: 1
+          volumeMounts:
+            - name: signoz-db
+              mountPath: /var/lib/signoz/
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+      volumes:
+        - name: dashboards
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: signoz-db
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi

--- a/kustomize/signoz/overlays/development/kustomization.yaml
+++ b/kustomize/signoz/overlays/development/kustomization.yaml
@@ -1,0 +1,63 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: signoz-dev
+
+resources:
+  - ../../base
+
+# Development-specific patches
+patches:
+  - target:
+      kind: StatefulSet
+      name: signoz
+      namespace: signoz-dev
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 512Mi
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: SIGNOZ_ENVIRONMENT
+          value: "development"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: SIGNOZ_LOG_LEVEL
+          value: "debug"
+
+  - target:
+      kind: Deployment
+      name: signoz-otel-collector
+      namespace: signoz-dev
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 512Mi
+
+# Development-specific labels
+labels:
+  - pairs:
+      environment: development
+      tier: dev
+
+# Development-specific images
+images:
+  - name: docker.io/signoz/signoz
+    newTag: v0.93.0

--- a/kustomize/signoz/overlays/ingress/ingress.yaml
+++ b/kustomize/signoz/overlays/ingress/ingress.yaml
@@ -1,0 +1,53 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: signoz-ingress
+  namespace: signoz-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+spec:
+  tls:
+  - hosts:
+    - signoz.example.com
+    secretName: signoz-tls
+  rules:
+  - host: signoz.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: signoz
+            port:
+              number: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: signoz-otel-collector-ingress
+  namespace: signoz-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+spec:
+  tls:
+  - hosts:
+    - otel.example.com
+    secretName: otel-tls
+  rules:
+  - host: otel.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: signoz-otel-collector
+            port:
+              number: 4317

--- a/kustomize/signoz/overlays/ingress/kustomization.yaml
+++ b/kustomize/signoz/overlays/ingress/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: signoz-ingress
+
+resources:
+  - ../../base
+  - ingress.yaml
+
+# Ingress configuration
+patches:
+  - target:
+      kind: Service
+      name: signoz
+      namespace: signoz-ingress
+    patch: |-
+      - op: add
+        path: /spec/type
+        value: ClusterIP
+
+# Ingress-specific labels
+labels:
+  - pairs:
+      ingress: enabled
+      access: external

--- a/kustomize/signoz/overlays/minimal/kustomization.yaml
+++ b/kustomize/signoz/overlays/minimal/kustomization.yaml
@@ -1,0 +1,53 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: signoz-minimal
+
+resources:
+  - ../../base
+
+# Minimal-specific patches
+patches:
+  - target:
+      kind: StatefulSet
+      name: signoz
+      namespace: signoz-minimal
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 25m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+
+  - target:
+      kind: Deployment
+      name: signoz-otel-collector
+      namespace: signoz-minimal
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 25m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+
+# Minimal-specific labels
+labels:
+  - pairs:
+      environment: minimal
+      tier: minimal
+
+# Minimal-specific images
+images:
+  - name: docker.io/signoz/signoz
+    newTag: v0.93.0

--- a/kustomize/signoz/overlays/production/kustomization.yaml
+++ b/kustomize/signoz/overlays/production/kustomization.yaml
@@ -1,0 +1,102 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: signoz-prod
+
+resources:
+  - ../../base
+
+# Production-specific patches
+patches:
+  - target:
+      kind: StatefulSet
+      name: signoz
+      namespace: signoz-prod
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 2
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 500m
+            memory: 1Gi
+          limits:
+            cpu: 2000m
+            memory: 4Gi
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: SIGNOZ_ENVIRONMENT
+          value: "production"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: SIGNOZ_LOG_LEVEL
+          value: "info"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: SIGNOZ_JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: signoz-secrets
+              key: jwt-secret
+      - op: add
+        path: /spec/template/spec/affinity
+        value:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                    - signoz
+                topologyKey: kubernetes.io/hostname
+
+  - target:
+      kind: Deployment
+      name: signoz-otel-collector
+      namespace: signoz-prod
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 3
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 200m
+            memory: 512Mi
+          limits:
+            cpu: 1000m
+            memory: 2Gi
+      - op: add
+        path: /spec/template/spec/affinity
+        value:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                    - signoz-otel-collector
+                topologyKey: kubernetes.io/hostname
+
+# Production-specific labels
+labels:
+  - pairs:
+      environment: production
+      tier: prod
+
+# Production-specific images
+images:
+  - name: docker.io/signoz/signoz
+    newTag: v0.93.0

--- a/kustomize/signoz/overlays/security/kustomization.yaml
+++ b/kustomize/signoz/overlays/security/kustomization.yaml
@@ -1,0 +1,91 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: signoz-security
+
+resources:
+  - ../../base
+
+# Security-specific patches
+patches:
+  - target:
+      kind: StatefulSet
+      name: signoz
+      namespace: signoz-security
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/securityContext
+        value:
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          fsGroup: 1000
+          seccompProfile:
+            type: RuntimeDefault
+      - op: add
+        path: /spec/template/spec/containers/0/securityContext
+        value:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          capabilities:
+            drop:
+            - ALL
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 200m
+            memory: 512Mi
+          limits:
+            cpu: 1000m
+            memory: 2Gi
+
+  - target:
+      kind: Deployment
+      name: signoz-otel-collector
+      namespace: signoz-security
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/securityContext
+        value:
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          fsGroup: 1000
+          seccompProfile:
+            type: RuntimeDefault
+      - op: add
+        path: /spec/template/spec/containers/0/securityContext
+        value:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          capabilities:
+            drop:
+            - ALL
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: 200m
+            memory: 512Mi
+          limits:
+            cpu: 1000m
+            memory: 2Gi
+
+# Security-specific labels
+labels:
+  - pairs:
+      environment: production
+      tier: security
+      security: hardened
+
+# Security-specific images
+images:
+  - name: docker.io/signoz/signoz
+    newTag: v0.93.0

--- a/kustomize/signoz/overlays/security/security-contexts.yaml
+++ b/kustomize/signoz/overlays/security/security-contexts.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: PodSecurityPolicy
+metadata:
+  name: signoz-psp
+  namespace: signoz-security
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: signoz-security-sa
+  namespace: signoz-security
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: signoz-security-role
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs: ['use']
+  resourceNames:
+  - signoz-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: signoz-security-binding
+roleRef:
+  kind: ClusterRole
+  name: signoz-security-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: signoz-security-sa
+  namespace: signoz-security


### PR DESCRIPTION
## Overview
Adds native Kustomize configuration for SigNoz.

## Prerequisites
ClickHouse must be installed first using Helm:
```bash
helm install clickhouse charts/clickhouse -n signoz-dev --create-namespace
```

## What's Included
- **Base configuration** with all SigNoz components
- **5 core overlays**: development, production, minimal, security, ingress

## Usage
```bash
# Testing
kubectl apply -k kustomize/signoz/overlays/development
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds Kubernetes deployment manifests for SigNoz and OpenTelemetry Collector with services, RBAC, health checks, and ClickHouse integration.
  - Introduces automated schema migration (sync and async) jobs.
  - Provides Ingress for UI and OTLP gRPC with TLS.
  - Includes Kustomize overlays for development, minimal, production, and security-hardened deployments.

- Chores
  - Pins container image versions and applies consistent app labels across resources for reliable, traceable releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->