### PR TITLE
fix(k8s-infra): add ca.pem mount

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.14.1
+version: 0.14.2
 appVersion: "0.109.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -62,12 +62,16 @@ spec:
         {{- if .Values.otelTlsSecrets.enabled }}
         - name: {{ include "k8s-infra.fullname" . }}-agent-secrets-vol
           secret:
-           secretName: {{ include "k8s-infra.otelTlsSecretName" . }}
-           items:
-             - key: cert.pem
-               path: cert.pem
-             - key: key.pem
-               path: key.pem
+            secretName: {{ include "k8s-infra.otelTlsSecretName" . }}
+            items:
+              - key: cert.pem
+                path: cert.pem
+              - key: key.pem
+                path: key.pem
+              {{- if .Values.otelTlsSecrets.ca }}
+              - key: ca.pem
+                path: ca.pem
+              {{- end }}
         {{- end }}
         {{- with .Values.otelAgent.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/k8s-infra/templates/otel-deployment/deployment.yaml
+++ b/charts/k8s-infra/templates/otel-deployment/deployment.yaml
@@ -61,6 +61,10 @@ spec:
                 path: cert.pem
               - key: key.pem
                 path: key.pem
+              {{- if .Values.otelTlsSecrets.ca }}
+              - key: ca.pem
+                path: ca.pem
+              {{- end }}
         {{- end }}
         {{- with .Values.otelDeployment.extraVolumes }}
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
### Summary
Added missing `ca.pem` mount to both otel-agent and otel-deployment

### Fixes
CA certificate support was added to values and exporter config, but `ca.pem` mounts were missing, rendering it unusable.
Related PR: https://github.com/SigNoz/charts/pull/252
Related issue: https://github.com/SigNoz/charts/issues/250


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional support for a TLS CA certificate in OpenTelemetry components. When provided, the CA is now mounted alongside existing cert and key, enabling connections that require a custom CA.
* **Chores**
  * Bumped chart version from 0.14.1 to 0.14.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->