### PR TITLE
fix(alertmanager): fix external url

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.93.1
+version: 0.93.2
 appVersion: "v0.96.1"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -1,7 +1,7 @@
 
 # SigNoz
 
-![Version: 0.93.1](https://img.shields.io/badge/Version-0.93.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.96.1](https://img.shields.io/badge/AppVersion-v0.96.1-informational?style=flat-square)
+![Version: 0.93.2](https://img.shields.io/badge/Version-0.93.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.96.1](https://img.shields.io/badge/AppVersion-v0.96.1-informational?style=flat-square)
 
 SigNoz is an open-source observability platform native to OpenTelemetry with logs, traces and metrics in a single application. An open-source alternative to DataDog, NewRelic, etc. 🔥 🖥. 👉 Open source Application Performance Monitoring (APM) & Observability tool
 
@@ -358,7 +358,7 @@ name: null</pre>
             <td>
                 <div style="max-width: 300px;"><pre lang="yaml">dot_metrics_enabled: true
 signoz_alertmanager_provider: signoz
-signoz_alertmanager_signoz_external_url: http://localhost:8080
+signoz_alertmanager_signoz_external__url: http://localhost:8080
 signoz_emailing_enabled: false
 signoz_prometheus_active_query_tracker_enabled: false
 signoz_telemetrystore_provider: clickhouse</pre>

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -862,7 +862,7 @@ signoz:
     # For more details see: https://signoz.io/docs/manage/administrator-guide/configuration/alertmanager/
     signoz_alertmanager_provider: signoz
     # The URL under which Alertmanager is externally reachable, Used for generating relative and absolute links back to Alertmanager itself.
-    signoz_alertmanager_signoz_external_url: http://localhost:8080
+    signoz_alertmanager_signoz_external__url: http://localhost:8080
   # signoz.initContainers -- Init containers for the SigNoz pod.
   # @section -- SigNoz
   # @default -- "Please checkout the default values in values.yml"


### PR DESCRIPTION
#### Fixes

- Fix env variable name of alertmanager external url

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Refactor
  - Renamed configuration key to use a double underscore in external URL settings, aligning environment-style naming. Update your values and env overrides to the new names.
- Documentation
  - Updated version badge to 0.93.2 and documentation to reflect the new configuration key names for external URLs.
- Chores
  - Bumped Helm chart version from 0.93.1 to 0.93.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->