### PR TITLE
feat(signoz-otel-gateway): add support for store config map

### DIFF
--- a/charts/signoz-otel-gateway/Chart.yaml
+++ b/charts/signoz-otel-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: signoz-otel-gateway
 description: A Helm chart for deploying SigNoz Opentelemetry Gateway
 type: application
-version: 0.0.1
+version: 0.0.2
 appVersion: "v0.0.16"
 home: https://signoz.io/
 icon: https://signoz.io/img/SigNozLogo-orange.svg
@@ -15,6 +15,4 @@ maintainers:
   - name: SigNoz
     email: devops@signoz.io
     url: https://signoz.io
-  - name: prashant-shahi
-    email: prashant@signoz.io
-    url: https://prashantshahi.dev
+

--- a/charts/signoz-otel-gateway/templates/store.yaml
+++ b/charts/signoz-otel-gateway/templates/store.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.store.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "opentelemetry-gateway.fullname" . }}-store
+  labels:
+    {{- include "opentelemetry-gateway.labels" . | nindent 4 }}
+data:
+  config.yaml: |-
+    {{- omit .Values.store "create" | toYaml | nindent 4 }}
+{{- end }}

--- a/charts/signoz-otel-gateway/values.yaml
+++ b/charts/signoz-otel-gateway/values.yaml
@@ -177,6 +177,11 @@ config:
   #       receivers:
   #         - otlp
 
+store:
+  # Create the in memory store
+  create: false
+
+
 externalSecrets:
   # Add integration with external secrets
   create: false


### PR DESCRIPTION
#### Features

- Add support for creating a store config map

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional “store” configuration that can generate a ConfigMap when enabled.
  * Expanded external secret configuration with support for specifying a Secret Store reference and example scaffolding.
* **Chores**
  * Bumped Helm chart version to 0.0.2.
* **Notes**
  * New options are disabled by default; enable them via values to take effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->