### PR TITLE
Update Zookeeper image tag to 3.9.3

### DIFF
--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -76,7 +76,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: signoz/zookeeper
-  tag: 3.7.1
+  tag: 3.9.3
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
The tag 3.7.1 does not exist https://hub.docker.com/r/signoz/zookeeper/tags
So, a version bump is needed. Currently image pulling is failing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ZooKeeper to version 3.9.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->