### PR TITLE
feat: add httpRoute resource to signoz chart

### DIFF
--- a/charts/signoz/templates/signoz/httproute.yaml
+++ b/charts/signoz/templates/signoz/httproute.yaml
@@ -21,10 +21,10 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
-    backendRefs:
-      - group: ''
-        kind: Service
-        name: {{ $fullName }}
-        port: {{ .Values.signoz.service.port }}
-        weight: 1
+    - backendRefs:
+        - group: ''
+          kind: Service
+          name: {{ $fullName }}
+          port: {{ .Values.signoz.service.port }}
+          weight: 1
 {{- end }}

--- a/charts/signoz/templates/signoz/httproute.yaml
+++ b/charts/signoz/templates/signoz/httproute.yaml
@@ -12,10 +12,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- with .Values.signoz.httproute.parentRefs }}
   parentRefs:
-    {{- with .Values.signoz.httproute.parentRefs }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.signoz.httproute.hostnames }}
   hostnames:
     {{- toYaml . | nindent 4 }}

--- a/charts/signoz/templates/signoz/httproute.yaml
+++ b/charts/signoz/templates/signoz/httproute.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.signoz.httproute.enabled -}}
+{{- $fullName := include "signoz.fullname" . -}}
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "signoz.labels" . | nindent 4 }}
+  {{- with .Values.signoz.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.signoz.httproute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.signoz.httproute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    backendRefs:
+      - group: ''
+        kind: Service
+        name: {{ $fullName }}
+        port: {{ .Values.signoz.service.port }}
+        weight: 1
+{{- end }}

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1006,6 +1006,29 @@ signoz:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - signoz.domain.com
+  # signoz.httproute -- (object) HttpRoute configuration for SigNoz.
+  # @section -- SigNoz Networking
+  httproute:
+    # signoz.httproute.enabled - Enable HttpRoute resource.
+    # @default -- false
+    enabled: false
+    # signoz.httproute.annotations - Annotations for the HttpRoute resource.
+    # @default -- {}
+    annotations: {}
+    # external-dns.alpha.kubernetes.io/hostname: signoz.domain.com
+    # signoz.httproute.parentRefs - parentRefs for the gateway(s) to attach the HttpRoute to.
+    # @default -- []
+    # @section -- SigNoz Networking
+    parentRefs: []
+    #  - group: gateway.networking.k8s.io 
+    #    kind: Gateway
+    #    name: gateway-example
+    #    namespace: gateway-namespace
+    # signoz.httproute.hostnames - Hostnames that will route to this HttpRoute.
+    # @default -- []
+    # @section -- SigNoz Networking
+    hostnames: []
+    #  - "signoz.domain.com"
   # signoz.resources -- Resource requests and limits.
   # Ref: http://kubernetes.io/docs/user-guide/compute-resources/
   # @section -- SigNoz


### PR DESCRIPTION
Since [Ingress NGINX is being retired](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/), more users will move to the Gateway API. Signoz doesn't have httpRoute resources so here is a simple one for general ingress to the platform.

I am using this internally as I moved everything to gateways from ingress.

I also have [a branch on my fork](https://github.com/dominicbinarly/charts/tree/feature/otelcollector-http-grpc-routes) with additional gateway configuration for the Otel Collector to use a gateway, but I cannot test this properly this year.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Kubernetes HTTPRoute networking option for deployments, enabling Gateway API–style traffic routing. Disabled by default.
  * Provides configurable annotations, parent references, hostnames, and backend targeting (service/port) so routing behavior can be customized per deployment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->