### PR TITLE
chore(release): bump SigNoz to v0.110.0, OTel Collector to v0.129.13

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: signoz
-version: 0.108.0
-appVersion: "v0.108.0"
+version: 0.110.0
+appVersion: "v0.110.0"
 description: SigNoz Observability Platform Helm Chart
 type: application
 home: https://signoz.io/

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -1,7 +1,7 @@
 
 # SigNoz
 
-![Version: 0.108.0](https://img.shields.io/badge/Version-0.108.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.108.0](https://img.shields.io/badge/AppVersion-v0.108.0-informational?style=flat-square)
+![Version: 0.110.0](https://img.shields.io/badge/Version-0.110.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.110.0](https://img.shields.io/badge/AppVersion-v0.110.0-informational?style=flat-square)
 
 SigNoz is an open-source observability platform native to OpenTelemetry with logs, traces and metrics in a single application. An open-source alternative to DataDog, NewRelic, etc. 🔥 🖥. 👉 Open source Application Performance Monitoring (APM) & Observability tool
 
@@ -309,7 +309,7 @@ verify: false</pre>
                 <div style="max-width: 300px;"><pre lang="yaml">pullPolicy: IfNotPresent
 registry: docker.io
 repository: signoz/signoz
-tag: v0.108.0</pre>
+tag: v0.110.0</pre>
 </div>
             </td>
             <td>Image configuration for SigNoz.</td>
@@ -641,7 +641,7 @@ tls: []</pre>
                 <div style="max-width: 300px;"><pre lang="yaml">pullPolicy: IfNotPresent
 registry: docker.io
 repository: signoz/signoz-schema-migrator
-tag: v0.129.12</pre>
+tag: v0.129.13</pre>
 </div>
             </td>
             <td>Image configuration for the Schema Migrator.</td>

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -765,7 +765,7 @@ signoz:
     repository: signoz/signoz
     # signoz.image.tag - The container image tag.
     # @default -- "v0.90.1"
-    tag: v0.108.0
+    tag: v0.110.0
     # signoz.image.pullPolicy - The image pull policy.
     # @default -- "IfNotPresent"
     pullPolicy: IfNotPresent
@@ -1080,7 +1080,7 @@ schemaMigrator:
     repository: signoz/signoz-schema-migrator
     # schemaMigrator.image.tag - The container image tag.
     # @default -- "v0.128.2"
-    tag: v0.129.12
+    tag: v0.129.13
     # schemaMigrator.image.pullPolicy - The image pull policy.
     # @default -- "IfNotPresent"
     pullPolicy: IfNotPresent
@@ -1290,7 +1290,7 @@ otelCollector:
     repository: signoz/signoz-otel-collector
     # otelCollector.image.tag - The container image tag.
     # @default -- "v0.128.2"
-    tag: v0.129.12
+    tag: v0.129.13
     # otelCollector.image.pullPolicy - The image pull policy.
     # @default -- "IfNotPresent"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Summary

- Release SigNoz v0.110.0
- Bump SigNoz OTel Collector to v0.129.13
- Bump SigNoz Helm chart version to 0.110.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart to version 0.110.0 with refreshed component image versions. SigNoz now at v0.110.0, schema-migrator at v0.129.13, and OpenTelemetry Collector at v0.129.13. Updated documentation and configuration defaults accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->