### PR TITLE
feat(otel): allow envFrom in otel collector deployment configuration.

### DIFF
--- a/charts/signoz/templates/otel-collector/deployment.yaml
+++ b/charts/signoz/templates/otel-collector/deployment.yaml
@@ -104,6 +104,10 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.otelCollector.additionalEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             {{- include "snippet.clickhouse-env" . | nindent 12 }}
             {{- include "snippet.k8s-env" . | nindent 12 }}

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1153,6 +1153,13 @@ otelCollector:
   # @section -- Otel Collector
   # @default -- {}
   podLabels: {}
+  # otelCollector.additionalEnvFrom -- Additional environment variables from configmaps or secrets for the Otel Collector.
+  # @section -- Otel Collector
+  # @default -- []
+  additionalEnvFrom: []
+  # - secretRef:
+  #     name: some-secret
+
   # otelCollector.additionalEnvs -- Additional environment variables for the Otel Collector.
   # @section -- Otel Collector
   # @default -- {}


### PR DESCRIPTION
- Allow Users to define existing secrets or configmaps for their otelCollector via envFrom