### PR TITLE
feat: support external postgresql for signoz

### DIFF
--- a/charts/signoz/templates/_helpers.tpl
+++ b/charts/signoz/templates/_helpers.tpl
@@ -271,6 +271,46 @@ Return the service name of Clickhouse
 {{- end }}
 
 {{/*
+Return true if external PostgreSQL is in use
+*/}}
+{{- define "postgresql.external" -}}
+{{- if and (not .Values.postgresql.enabled) .Values.externalPostgresql.host -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a secret object for external PostgreSQL should be created
+*/}}
+{{- define "postgresql.createSecret" -}}
+{{- if and (not .Values.postgresql.enabled) (not .Values.externalPostgresql.existingSecret) .Values.externalPostgresql.password -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the external PostgreSQL secret name
+*/}}
+{{- define "postgresql.secretName" -}}
+{{- if .Values.externalPostgresql.existingSecret -}}
+    {{- .Values.externalPostgresql.existingSecret -}}
+{{- else -}}
+    {{- printf "%s-postgresql-external" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the external PostgreSQL secret password key
+*/}}
+{{- define "postgresql.secretPasswordKey" -}}
+{{- if .Values.externalPostgresql.existingSecret -}}
+    {{- required "You need to provide existingSecretPasswordKey when an existingSecret is specified in externalPostgresql" .Values.externalPostgresql.existingSecretPasswordKey -}}
+{{- else -}}
+    {{- printf "postgresql-password" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the service fqdn of Postgresql
 */}}
 {{- define "postgresql.service" -}}
@@ -297,7 +337,15 @@ Return the service fqdn of Postgresql
 {{- else -}}
 {{ printf "postgres://%s:%s@%s:%s/%s?sslmode=disable" $username $password $name $port $database }}
 {{- end -}}
-{{- end }}
+{{- else if (include "postgresql.external" .) -}}
+{{- $username := "$(POSTGRES_USER)" -}}
+{{- $password := "$(POSTGRES_PASSWORD)" -}}
+{{- $database := "$(POSTGRES_DB)" -}}
+{{- $port := "$(POSTGRES_PORT)" -}}
+{{- $host := required "externalPostgresql.host is required if using external PostgreSQL" .Values.externalPostgresql.host -}}
+{{- $sslmode := default "disable" .Values.externalPostgresql.sslmode -}}
+{{ printf "postgres://%s:%s@%s:%s/%s?sslmode=%s" $username $password $host $port $database $sslmode }}
+{{- end -}}
 {{- end -}}
 
 
@@ -450,13 +498,22 @@ SQL STORE POSTGRES ENV
   {{- if .Values.postgresql.auth.database }}
     {{- $_ := set $sqlStorePostgresEnv "postgres_db" .Values.postgresql.auth.database }}
   {{- end }}
+{{- else if (include "postgresql.external" .) }}
+  {{- $_ := set $sqlStorePostgresEnv "postgres_port" .Values.externalPostgresql.port }}
+  {{- $_ := set $sqlStorePostgresEnv "postgres_user" .Values.externalPostgresql.user }}
+  {{- if .Values.externalPostgresql.existingSecret }}
+    {{- $_ := set $sqlStorePostgresEnv "postgres_password" (dict "valueFrom" (dict "secretKeyRef" (dict "name" .Values.externalPostgresql.existingSecret "key" (default "postgresql-password" .Values.externalPostgresql.existingSecretPasswordKey) ))) }}
+  {{- else }}
+    {{- $_ := set $sqlStorePostgresEnv "postgres_password" (dict "valueFrom" (dict "secretKeyRef" (dict "name" (include "postgresql.secretName" .) "key" (include "postgresql.secretPasswordKey" .) ))) }}
+  {{- end }}
+  {{- $_ := set $sqlStorePostgresEnv "postgres_db" .Values.externalPostgresql.database }}
 {{- end }}
 {{/*
 SQL STORE ENV
 Keep it seprate from sqlStorePostgresEnv to maintain the order of env variables
 */}}
 {{- $sqlStoreEnv := dict -}}
-{{- if .Values.postgresql.enabled -}}
+{{- if or .Values.postgresql.enabled (include "postgresql.external" .) -}}
 {{ $sqlStoreEnv = merge $sqlStoreEnv ( dict "signoz_sqlstore_provider" "postgres")}}
 {{ $sqlStoreEnv = merge $sqlStoreEnv ( dict "signoz_sqlstore_postgres_dsn" (include "postgresql.service" .))}}
 {{- end }}

--- a/charts/signoz/templates/secrets-postgresql-external.yaml
+++ b/charts/signoz/templates/secrets-postgresql-external.yaml
@@ -1,0 +1,9 @@
+{{- if (include "postgresql.createSecret" .) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "postgresql.secretName" . }}
+type: Opaque
+data:
+  {{ include "postgresql.secretPasswordKey" . }}: {{ .Values.externalPostgresql.password | b64enc | quote }}
+{{- end }}

--- a/charts/signoz/templates/signoz/statefulset.yaml
+++ b/charts/signoz/templates/signoz/statefulset.yaml
@@ -99,7 +99,7 @@ spec:
           readinessProbe: {{- toYaml .Values.signoz.customReadinessProbe | nindent 12 }}
           {{- end }}
           volumeMounts:
-          {{- if not .Values.postgresql.enabled }}
+          {{- if and (not .Values.postgresql.enabled) (not (include "postgresql.external" .)) }}
           {{- if .Values.signoz.persistence.enabled }}
           {{- if .Values.signoz.persistence.existingClaim }}
             - name: signoz-db-existing-claim
@@ -119,10 +119,10 @@ spec:
       volumes:
         - name: dashboards
           emptyDir: {}
-        {{- if and (not .Values.signoz.persistence.enabled) (not .Values.postgresql.enabled )}}
+        {{- if and (not .Values.signoz.persistence.enabled) (not .Values.postgresql.enabled) (not (include "postgresql.external" .)) }}
         - name: signoz-db-volume
           emptyDir: {}
-        {{- else if and .Values.signoz.persistence.existingClaim (not .Values.postgresql.enabled )}}
+        {{- else if and .Values.signoz.persistence.existingClaim (not .Values.postgresql.enabled) (not (include "postgresql.external" .)) }}
         - name: signoz-db-existing-claim
           persistentVolumeClaim:
             claimName: {{ .Values.signoz.persistence.existingClaim }}
@@ -131,7 +131,7 @@ spec:
           {{- toYaml .Values.signoz.additionalVolumes | nindent 8 }}
         {{- end }}
 
-{{- if and (.Values.signoz.persistence.enabled) (not .Values.signoz.persistence.existingClaim) ( not .Values.postgresql.enabled )}}
+{{- if and (.Values.signoz.persistence.enabled) (not .Values.signoz.persistence.existingClaim) (not .Values.postgresql.enabled) (not (include "postgresql.external" .)) }}
   volumeClaimTemplates:
     - metadata:
         name: signoz-db

--- a/charts/signoz/tests/signoz-external-postgres_test.yaml
+++ b/charts/signoz/tests/signoz-external-postgres_test.yaml
@@ -1,0 +1,144 @@
+suite: Test SigNoz Environment Variables and Volumes with External PostgreSQL
+
+templates:
+  - templates/signoz/statefulset.yaml
+  - templates/secrets-postgresql-external.yaml
+
+release:
+  name: signoz
+  namespace: signoz
+
+tests:
+  - it: should render the Environment variables for external PostgreSQL in signoz statefulset
+    set:
+      externalPostgresql:
+        host: "my-rds.example.com"
+        port: 5432
+        user: "signoz"
+        password: "secret123"
+        database: "signoz"
+        sslmode: "disable"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SIGNOZ_SQLSTORE_PROVIDER
+            value: postgres
+        template: templates/signoz/statefulset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_USER
+            value: "signoz"
+        template: templates/signoz/statefulset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_PORT
+            value: "5432"
+        template: templates/signoz/statefulset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_DB
+            value: "signoz"
+        template: templates/signoz/statefulset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: signoz-postgresql-external
+                key: postgresql-password
+        template: templates/signoz/statefulset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SIGNOZ_SQLSTORE_POSTGRES_DSN
+            value: "postgres://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@my-rds.example.com:$(POSTGRES_PORT)/$(POSTGRES_DB)?sslmode=disable"
+        template: templates/signoz/statefulset.yaml
+
+  - it: should create external PostgreSQL secret when password is provided and no existingSecret
+    set:
+      externalPostgresql:
+        host: "my-rds.example.com"
+        port: 5432
+        user: "signoz"
+        password: "secret123"
+        database: "signoz"
+    asserts:
+      - isKind:
+          of: Secret
+        template: templates/secrets-postgresql-external.yaml
+      - equal:
+          path: metadata.name
+          value: signoz-postgresql-external
+        template: templates/secrets-postgresql-external.yaml
+
+  - it: should NOT create external PostgreSQL secret when existingSecret is set
+    set:
+      externalPostgresql:
+        host: "my-rds.example.com"
+        user: "signoz"
+        password: "secret123"
+        existingSecret: "my-pg-secret"
+        existingSecretPasswordKey: "pg-pass"
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/secrets-postgresql-external.yaml
+
+  - it: should use existingSecret for password when set
+    set:
+      externalPostgresql:
+        host: "my-rds.example.com"
+        port: 5432
+        user: "signoz"
+        password: "ignored"
+        database: "signoz"
+        existingSecret: "my-pg-secret"
+        existingSecretPasswordKey: "pg-pass"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-pg-secret
+                key: pg-pass
+        template: templates/signoz/statefulset.yaml
+
+  - it: should render custom sslmode in DSN
+    set:
+      externalPostgresql:
+        host: "my-rds.example.com"
+        port: 5432
+        user: "signoz"
+        password: "secret123"
+        database: "signoz"
+        sslmode: "require"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SIGNOZ_SQLSTORE_POSTGRES_DSN
+            value: "postgres://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@my-rds.example.com:$(POSTGRES_PORT)/$(POSTGRES_DB)?sslmode=require"
+        template: templates/signoz/statefulset.yaml
+
+  - it: SigNoz StatefulSet should NOT render volumeMounts when external PostgreSQL is configured
+    set:
+      externalPostgresql:
+        host: "my-rds.example.com"
+        port: 5432
+        user: "signoz"
+        password: "secret123"
+        database: "signoz"
+      signoz:
+        additionalVolumeMounts: []
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers[0].volumeMounts
+          count: 0
+        template: templates/signoz/statefulset.yaml

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1720,6 +1720,33 @@ postgresql:
   # @default -- false
   # @section -- Postgres
   enabled: false
+# externalPostgresql -- External PostgreSQL configuration. Required when `postgresql.enabled` is false and you want to use an external PostgreSQL.
+# @section -- External Postgres
+externalPostgresql:
+  # externalPostgresql.host -- Host of the external PostgreSQL instance.
+  # @default -- ""
+  host: ""
+  # externalPostgresql.port -- Port of the external PostgreSQL instance.
+  # @default -- 5432
+  port: 5432
+  # externalPostgresql.user -- Username for the external PostgreSQL.
+  # @default -- ""
+  user: ""
+  # externalPostgresql.password -- Password for the external PostgreSQL. Ignored if `externalPostgresql.existingSecret` is set.
+  # @default -- ""
+  password: ""
+  # externalPostgresql.database -- Database name on the external PostgreSQL.
+  # @default -- "signoz"
+  database: "signoz"
+  # externalPostgresql.existingSecret -- Name of an existing Kubernetes secret containing the password.
+  # @default -- ""
+  existingSecret: ""
+  # externalPostgresql.existingSecretPasswordKey -- Key in the existing secret that contains the password.
+  # @default -- ""
+  existingSecretPasswordKey: ""
+  # externalPostgresql.sslmode -- SSL mode for the connection (disable, require, verify-ca, verify-full).
+  # @default -- "disable"
+  sslmode: "disable"
 # -- This component is configurable with licensed version of SigNoz.
 # @section -- Otel Gateway Settings
 signoz-otel-gateway:


### PR DESCRIPTION
add external postgresql for signoz helm chart 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External PostgreSQL support: Users can now configure connections to an external PostgreSQL database with customizable host, port, credentials, database name, and SSL mode options.
  * Kubernetes secret integration for secure credential management, with support for both generated and existing secrets.

* **Tests**
  * Added comprehensive test coverage for external PostgreSQL configurations and secret management scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->