### PR TITLE
feat: add update stategy for daemonset to values.yaml

### DIFF
--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -15,6 +15,10 @@ spec:
     matchLabels:
       {{- include "otelAgent.selectorLabels" . | nindent 6 }}
   minReadySeconds: {{ .Values.otelAgent.minReadySeconds }}
+  {{- with .Values.otelAgent.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -649,6 +649,16 @@ otelAgent:
   # otelAgent.minReadySeconds -- Minimum number of seconds for which a newly created Pod should be ready.
   # @section -- OpenTelemetry Agent (DaemonSet)
   minReadySeconds: 5
+  # otelAgent.updateStrategy -- Update strategy for the OtelAgent DaemonSet.
+  # @section -- OpenTelemetry Agent (DaemonSet)
+  # ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#update-strategy
+  # Example:
+  #   updateStrategy:
+  #     type: RollingUpdate
+  #     rollingUpdate:
+  #       maxUnavailable: 1
+  #       maxSurge: 0
+  updateStrategy: {}
   # otelAgent.clusterRole -- ClusterRole configuration for the OtelAgent.
   # @section -- OpenTelemetry Agent (DaemonSet)
   # @default -- "Please checkout the values.yml for default values"


### PR DESCRIPTION
At the moment the daemonset's update strategy isn't set, so it falls back to doing 1 node at a time.  This can be very slow for larger clusters, so it'd be nice to have the option to tweak the options for updating it.

Plumb the `updateStrategy` into the values.yaml file so consumers of the chart can tweak it without post-processing.