### PR TITLE
feat(k8s-infra): set dnsPolicy to ClusterFirstWithHostNet when hostNetwork is enabled

### DIFF
--- a/charts/k8s-infra/templates/otel-agent/daemonset.yaml
+++ b/charts/k8s-infra/templates/otel-agent/daemonset.yaml
@@ -77,6 +77,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       hostNetwork: {{ .Values.otelAgent.hostNetwork | default false }}
+      {{- if .Values.otelAgent.hostNetwork }}
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       containers:
         - name: {{ include "otelAgent.fullname" . }}
           image: {{ include "otelAgent.image" . }}


### PR DESCRIPTION
Set dnsPolicy to ClusterFirstWithHostNet to enable internal dns resolution, following [Kubernetes Best Practices ](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)