### PR TITLE
fix(k8s-infra): default OTLP exporter to HTTP instead of gRPC

### DIFF
--- a/charts/k8s-infra/Chart.yaml
+++ b/charts/k8s-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-infra
 description: Helm chart for collecting metrics and logs in K8s
 type: application
-version: 0.15.1
+version: 0.16.0
 appVersion: "0.139.0"
 home: https://signoz.io
 icon: https://signoz.io/img/SigNozLogo-orange.svg

--- a/charts/k8s-infra/README.md
+++ b/charts/k8s-infra/README.md
@@ -1,7 +1,7 @@
 
 # K8s-Infra
 
-![Version: 0.15.1](https://img.shields.io/badge/Version-0.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.139.0](https://img.shields.io/badge/AppVersion-0.139.0-informational?style=flat-square)
+![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.139.0](https://img.shields.io/badge/AppVersion-0.139.0-informational?style=flat-square)
 
 Monitoring your Kubernetes cluster is essential for ensuring performance, stability, and reliability. The SigNoz k8s-infra Helm chart provides a comprehensive solution for collecting and analyzing metrics, logs, and events from your entire Kubernetes environment.
 
@@ -104,8 +104,27 @@ Sometimes everything doesn't get properly removed. If that happens try deleting 
 ```bash
 kubectl delete namespace platform
 ```
-> [!WARNING] 
+> [!WARNING]
 > ### Breaking Changes
+> #### Version 0.16.0
+>
+> **Default OTLP exporter changed from gRPC to HTTP.**
+> - `presets.otlpExporter.enabled` now defaults to `false`
+> - `presets.otlphttpExporter.enabled` now defaults to `true`
+>
+> **Migration:** if you have set a custom `otelCollectorEndpoint`, update it to the OTLP/HTTP endpoint:
+> ```yaml
+> # SigNoz Cloud
+> otelCollectorEndpoint: https://ingest.<region>.signoz.cloud:443
+>
+> # Self-hosted SigNoz
+> otelCollectorEndpoint: http://<signoz-otel-collector>:4318
+> ```
+>
+> > [!NOTE]
+> > OTLP/HTTP works more reliably across load balancers, ingresses, and proxies than gRPC, and is now the recommended protocol for sending telemetry to both SigNoz Cloud and self-hosted SigNoz.
+> > You can still use gRPC by setting `presets.otlpExporter.enabled: true` and `presets.otlphttpExporter.enabled: false`.
+>
 > #### Version 0.15.0
 > The following changes have been introduced in this version:
 > - Upgraded the OpenTelemetry Collector to version `0.139.0`
@@ -286,7 +305,7 @@ storageClass: null</pre>
                 <div style="max-width: 300px;"><pre lang="yaml">null</pre>
 </div>
             </td>
-            <td>Endpoint/IP Address of the SigNoz or any other OpenTelemetry backend. Set it to `ingest.signoz.io:4317` for SigNoz Cloud. If set to null and the chart is installed as a dependency, it will attempt to autogenerate the endpoint of the SigNoz OtelCollector.</td>
+            <td>Endpoint/IP Address of the SigNoz or any other OpenTelemetry backend. Set it to `https://ingest.<region>.signoz.cloud:443` for SigNoz Cloud. If set to null and the chart is installed as a dependency, it will attempt to autogenerate the endpoint of the SigNoz OtelCollector.</td>
         </tr>
         <tr>
             <td id="otelInsecure"><a href="./values.yaml#L46">otelInsecure</a></td>
@@ -495,7 +514,7 @@ verbosity: basic</pre>
             <td id="presets--otlpExporter"><a href="./values.yaml#L108">presets.otlpExporter</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="yaml">enabled: true</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">enabled: false</pre>
 </div>
             </td>
             <td>OTLP Exporter for the OTLP exporter.</td>
@@ -504,7 +523,7 @@ verbosity: basic</pre>
             <td id="presets--otlphttpExporter"><a href="./values.yaml#L115">presets.otlphttpExporter</a></td>
             <td>object</td>
             <td>
-                <div style="max-width: 300px;"><pre lang="yaml">enabled: false</pre>
+                <div style="max-width: 300px;"><pre lang="yaml">enabled: true</pre>
 </div>
             </td>
             <td>OTLP HTTP Exporter to which data will be sent. Set this to true to enable the OTLP HTTP exporter, which uses the HTTP endpoint instead of the gRPC endpoint.</td>

--- a/charts/k8s-infra/README.md.gotmpl
+++ b/charts/k8s-infra/README.md.gotmpl
@@ -105,8 +105,27 @@ Sometimes everything doesn't get properly removed. If that happens try deleting 
 ```bash
 kubectl delete namespace platform
 ```
-> [!WARNING]  
+> [!WARNING]
 > ### Breaking Changes
+> #### Version 0.16.0
+>
+> **Default OTLP exporter changed from gRPC to HTTP.**
+> - `presets.otlpExporter.enabled` now defaults to `false`
+> - `presets.otlphttpExporter.enabled` now defaults to `true`
+>
+> **Migration:** if you have set a custom `otelCollectorEndpoint`, update it to the OTLP/HTTP endpoint:
+> ```yaml
+> # SigNoz Cloud
+> otelCollectorEndpoint: https://ingest.<region>.signoz.cloud:443
+>
+> # Self-hosted SigNoz
+> otelCollectorEndpoint: http://<signoz-otel-collector>:4318
+> ```
+>
+> > [!NOTE]
+> > OTLP/HTTP works more reliably across load balancers, ingresses, and proxies than gRPC, and is now the recommended protocol for sending telemetry to both SigNoz Cloud and self-hosted SigNoz.
+> > You can still use gRPC by setting `presets.otlpExporter.enabled: true` and `presets.otlphttpExporter.enabled: false`.
+>
 > #### Version 0.15.0
 > The following changes have been introduced in this version:
 > - Upgraded the OpenTelemetry Collector to version `0.139.0`

--- a/charts/k8s-infra/templates/_helpers.tpl
+++ b/charts/k8s-infra/templates/_helpers.tpl
@@ -278,7 +278,7 @@ Return endpoint of OtelCollector.
 {{- if .Values.otelCollectorEndpoint }}
 {{- .Values.otelCollectorEndpoint }}
 {{- else if not .Chart.IsRoot }}
-{{- printf "%s:%s" (include "otel.servicename" .) "4317" }}
+{{- printf "%s:%s" (include "otel.servicename" .) "4318" }}
 {{- end }}
 {{- end }}
 

--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -36,7 +36,7 @@ enabled: true
 clusterName: ""
 # otelCollectorEndpoint -- Endpoint/IP Address of the SigNoz or any other OpenTelemetry backend.
 # @section -- General Configuration
-# Set it to `ingest.signoz.io:4317` for SigNoz Cloud.
+# Set it to `https://ingest.<region>.signoz.cloud:443` for SigNoz Cloud.
 # If set to null and the chart is installed as a dependency, it will attempt
 # to autogenerate the endpoint of the SigNoz OtelCollector.
 otelCollectorEndpoint: null
@@ -108,14 +108,14 @@ presets:
   otlpExporter:
     # presets.otlpExporter.enabled - Enable the OTLP exporter to send data to the backend.
     # @section -- OTLP Exporter Presets
-    enabled: true
+    enabled: false
   # presets.otlphttpExporter --  OTLP HTTP Exporter to which data will be sent.
   # Set this to true to enable the OTLP HTTP exporter, which uses the HTTP endpoint instead of the gRPC endpoint.
   # @section -- OTLP Exporter Presets
   otlphttpExporter:
     # presets.otlphttpExporter.enabled - Enable the OTLP HTTP exporter.
     # @section -- OTLP Exporter Presets
-    enabled: false
+    enabled: true
   # presets.selfTelemetry -- Configuration for sending the collector's own telemetry data.
   # By Default, the Collector generates basic metrics about itself and exposes them using the OpenTelemetry Go Prometheus
   # exporter for scraping at http://<otel-collector>:8888/metrics


### PR DESCRIPTION
### Summary
- Flip default OTLP exporter from gRPC to HTTP in k8s-infra
- Update the autogenerated in-cluster endpoint fallback in _helpers.tpl from port 4317 to 4318, so installs running k8s-infra as a sub-chart of signoz resolve to the OTLP/HTTP port out of the box.


Related: SigNoz/platform-pod#1951.