### PR TITLE
fix(clickhouse): upgrade ClickHouse Operator to v0.27.0

### DIFF
--- a/charts/clickhouse/crds/clickhouseinstallations.clickhouse.altinity.com.yaml
+++ b/charts/clickhouse/crds/clickhouseinstallations.clickhouse.altinity.com.yaml
@@ -4,13 +4,14 @@
 # SINGULAR=clickhouseinstallation
 # PLURAL=clickhouseinstallations
 # SHORT=chi
+# OPERATOR_VERSION=0.27.0
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallations.clickhouse.altinity.com
   labels:
-    clickhouse.altinity.com/chop: 0.21.2
+    clickhouse.altinity.com/chop: 0.27.0
 spec:
   group: clickhouse.altinity.com
   scope: Namespaced
@@ -25,6 +26,10 @@ spec:
       served: true
       storage: true
       additionalPrinterColumns:
+        - name: status
+          type: string
+          description: Resource status
+          jsonPath: .status.status
         - name: version
           type: string
           description: Operator version
@@ -48,10 +53,10 @@ spec:
           description: TaskID
           priority: 1 # show in wide view
           jsonPath: .status.taskID
-        - name: status
-          type: string
-          description: CHI status
-          jsonPath: .status.status
+        - name: hosts-completed
+          type: integer
+          description: Completed hosts count
+          jsonPath: .status.hostsCompleted
         - name: hosts-updated
           type: integer
           description: Updated hosts count
@@ -62,20 +67,11 @@ spec:
           description: Added hosts count
           priority: 1 # show in wide view
           jsonPath: .status.hostsAdded
-        - name: hosts-completed
-          type: integer
-          description: Completed hosts count
-          jsonPath: .status.hostsCompleted
         - name: hosts-deleted
           type: integer
           description: Hosts deleted count
           priority: 1 # show in wide view
           jsonPath: .status.hostsDeleted
-        - name: hosts-delete
-          type: integer
-          description: Hosts to be deleted count
-          priority: 1 # show in wide view
-          jsonPath: .status.hostsDelete
         - name: endpoint
           type: string
           description: Client access endpoint
@@ -86,39 +82,51 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
         openAPIV3Schema:
-          description: "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters"
+          description: "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more clusters"
           type: object
           required:
             - spec
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
             status:
               type: object
-              description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
+              description: |
+                Status contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other
               properties:
                 chop-version:
                   type: string
-                  description: "ClickHouse operator version"
+                  description: "Operator version"
                 chop-commit:
                   type: string
-                  description: "ClickHouse operator git commit SHA"
+                  description: "Operator git commit SHA"
                 chop-date:
                   type: string
-                  description: "ClickHouse operator build date"
+                  description: "Operator build date"
                 chop-ip:
                   type: string
-                  description: "IP address of the operator's pod which managed this CHI"
+                  description: "IP address of the operator's pod which managed this resource"
                 clusters:
                   type: integer
                   minimum: 0
@@ -144,11 +152,13 @@ spec:
                 taskIDsStarted:
                   type: array
                   description: "Started task ids"
+                  nullable: true
                   items:
                     type: string
                 taskIDsCompleted:
                   type: array
                   description: "Completed task ids"
+                  nullable: true
                   items:
                     type: string
                 action:
@@ -157,6 +167,7 @@ spec:
                 actions:
                   type: array
                   description: "Actions"
+                  nullable: true
                   items:
                     type: string
                 error:
@@ -165,8 +176,13 @@ spec:
                 errors:
                   type: array
                   description: "Errors"
+                  nullable: true
                   items:
                     type: string
+                hostsUnchanged:
+                  type: integer
+                  minimum: 0
+                  description: "Unchanged Hosts count"
                 hostsUpdated:
                   type: integer
                   minimum: 0
@@ -190,38 +206,69 @@ spec:
                 pods:
                   type: array
                   description: "Pods"
+                  nullable: true
                   items:
                     type: string
                 pod-ips:
                   type: array
                   description: "Pod IPs"
+                  nullable: true
                   items:
                     type: string
                 fqdns:
                   type: array
                   description: "Pods FQDNs"
+                  nullable: true
                   items:
                     type: string
                 endpoint:
                   type: string
                   description: "Endpoint"
+                endpoints:
+                  type: array
+                  description: "All endpoints"
+                  nullable: true
+                  items:
+                    type: string
                 generation:
                   type: integer
                   minimum: 0
                   description: "Generation"
                 normalized:
                   type: object
-                  description: "Normalized CHI requested"
+                  description: "Normalized resource requested"
+                  nullable: true
                   x-kubernetes-preserve-unknown-fields: true
                 normalizedCompleted:
                   type: object
-                  description: "Normalized CHI completed"
+                  description: "Normalized resource completed"
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                actionPlan:
+                  type: object
+                  description: "Action Plan"
+                  nullable: true
                   x-kubernetes-preserve-unknown-fields: true
                 hostsWithTablesCreated:
                   type: array
                   description: "List of hosts with tables created by the operator"
+                  nullable: true
                   items:
                     type: string
+                hostsWithReplicaCaughtUp:
+                  type: array
+                  description: "List of hosts with replica caught up"
+                  nullable: true
+                  items:
+                    type: string
+                usedTemplates:
+                  type: array
+                  description: "List of templates used to build this CHI"
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
               # x-kubernetes-preserve-unknown-fields: true
@@ -232,15 +279,16 @@ spec:
                 taskID:
                   type: string
                   description: |
-                    Allows to define custom taskID for named update operation and watch status of this update execution in .status.taskIDs field.
-                    By default every update of chi manifest will generate random taskID
+                    Allows to define custom taskID for CHI update and watch status of this update execution.
+                    Displayed in all .status.taskID* fields.
+                    By default (if not filled) every update of CHI manifest will generate random taskID
                 stop: &TypeStringBool
                   type: string
                   description: |
-                    Allow stop all ClickHouse clusters described in current chi.
-                    Stop mechanism works as follows:
-                     - When `stop` is `1` then setup `Replicas: 0` in each related to current `chi` StatefulSet resource, all `Pods` and `Service` resources will desctroy, but PVCs still live
-                     - When `stop` is `0` then `Pods` will created again and will attach retained PVCs and `Service` also will created again
+                    Allows to stop all ClickHouse clusters defined in a CHI.
+                    Works as the following:
+                     - When `stop` is `1` operator sets `Replicas: 0` in each StatefulSet. Thie leads to having all `Pods` and `Service` deleted. All PVCs are kept intact.
+                     - When `stop` is `0` operator sets `Replicas: 1` and `Pod`s and `Service`s will created again and all retained PVCs will be attached to `Pod`s.
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -268,86 +316,555 @@ spec:
                     - "enabled"
                 restart:
                   type: string
-                  description: "This is a 'soft restart' button. When set to 'RollingUpdate' operator will restart ClickHouse pods in a graceful way. Remove it after the use in order to avoid unneeded restarts"
+                  description: |
+                    In case 'RollingUpdate' specified, the operator will always restart ClickHouse pods during reconcile.
+                    This options is used in rare cases when force restart is required and is typically removed after the use in order to avoid unneeded restarts.
                   enum:
                     - ""
                     - "RollingUpdate"
+                suspend:
+                  !!merge <<: *TypeStringBool
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Installation.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all resources.
+                     - When `suspend` is `false` or not set, operator reconciles all resources.
                 troubleshoot:
                   !!merge <<: *TypeStringBool
-                  description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
+                  description: |
+                    Allows to troubleshoot Pods during CrashLoopBack state.
+                    This may happen when wrong configuration applied, in this case `clickhouse-server` wouldn't start.
+                    Command within ClickHouse container is modified with `sleep` in order to avoid quick restarts
+                    and give time to troubleshoot via CLI.
+                    Liveness and Readiness probes are disabled as well.
                 namespaceDomainPattern:
                   type: string
-                  description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
+                  description: |
+                    Custom domain pattern which will be used for DNS names of `Service` or `Pod`.
+                    Typical use scenario - custom cluster domain in Kubernetes cluster
+                    Example: %s.svc.my.test
                 templating:
                   type: object
                   # nullable: true
-                  description: "optional, define policy for auto applying ClickHouseInstallationTemplate inside ClickHouseInstallation"
+                  description: |
+                    Optional, applicable inside ClickHouseInstallationTemplate only.
+                    Defines current ClickHouseInstallationTemplate application options to target ClickHouseInstallation(s)."
                   properties:
                     policy:
                       type: string
-                      description: "when defined as `auto` inside ClickhouseInstallationTemplate, it will auto add into all ClickHouseInstallation, manual value is default"
+                      description: |
+                        When defined as `auto` inside ClickhouseInstallationTemplate, this ClickhouseInstallationTemplate
+                        will be auto-added into ClickHouseInstallation, selectable by `chiSelector`.
+                        Default value is `manual`, meaning ClickHouseInstallation should request this ClickhouseInstallationTemplate explicitly.
                       enum:
+                        - ""
                         - "auto"
                         - "manual"
-                reconciling:
+                    chiSelector:
+                      type: object
+                      description: "Optional, defines selector for ClickHouseInstallation(s) to be templated with ClickhouseInstallationTemplate"
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
+                reconciling: &TypeReconcile
                   type: object
-                  description: "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
+                  description: "[OBSOLETED] Optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
                   # nullable: true
                   properties:
                     policy:
                       type: string
-                      description: DEPRECATED
+                      description: |
+                        DISCUSSED TO BE DEPRECATED
+                        Syntax sugar
+                        Overrides all three 'reconcile.host.wait.{exclude, queries, include}' values from the operator's config
+                        Possible values:
+                         - wait - should wait to exclude host, complete queries and include host back into the cluster
+                         - nowait - should NOT wait to exclude host, complete queries and include host back into the cluster
+                      enum:
+                        - ""
+                        - "wait"
+                        - "nowait"
                     configMapPropagationTimeout:
                       type: integer
                       description: |
-                        timeout in seconds when `clickhouse-operator` will wait when applied `ConfigMap` during reconcile `ClickhouseInstallation` pods will updated from cache
-                        see details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
+                        Timeout in seconds for `clickhouse-operator` to wait for modified `ConfigMap` to propagate into the `Pod`
+                        More details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
                       minimum: 0
                       maximum: 3600
                     cleanup:
                       type: object
-                      description: "optional, define behavior for cleanup Kubernetes resources during reconcile cycle"
+                      description: "Optional, defines behavior for cleanup Kubernetes resources during reconcile cycle"
                       # nullable: true
                       properties:
                         unknownObjects:
                           type: object
-                          description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
+                          description: |
+                            Describes what clickhouse-operator should do with found Kubernetes resources which should be managed by clickhouse-operator,
+                            but do not have `ownerReference` to any currently managed `ClickHouseInstallation` resource.
+                            Default behavior is `Delete`"
                           # nullable: true
                           properties:
                             statefulSet: &TypeObjectsCleanup
                               type: string
-                              description: "behavior policy for unknown StatefulSet, Delete by default"
+                              description: "Behavior policy for unknown StatefulSet, `Delete` by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
+                                - ""
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
                               !!merge <<: *TypeObjectsCleanup
-                              description: "behavior policy for unknown PVC, Delete by default"
+                              description: "Behavior policy for unknown PVC, `Delete` by default"
                             configMap:
                               !!merge <<: *TypeObjectsCleanup
-                              description: "behavior policy for unknown ConfigMap, Delete by default"
+                              description: "Behavior policy for unknown ConfigMap, `Delete` by default"
                             service:
                               !!merge <<: *TypeObjectsCleanup
-                              description: "behavior policy for unknown Service, Delete by default"
+                              description: "Behavior policy for unknown Service, `Delete` by default"
                         reconcileFailedObjects:
                           type: object
-                          description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
+                          description: |
+                            Describes what clickhouse-operator should do with Kubernetes resources which are failed during reconcile.
+                            Default behavior is `Retain`"
                           # nullable: true
                           properties:
                             statefulSet:
                               !!merge <<: *TypeObjectsCleanup
-                              description: "behavior policy for failed StatefulSet reconciling, Retain by default"
+                              description: "Behavior policy for failed StatefulSet, `Retain` by default"
                             pvc:
                               !!merge <<: *TypeObjectsCleanup
-                              description: "behavior policy for failed PVC reconciling, Retain by default"
+                              description: "Behavior policy for failed PVC, `Retain` by default"
                             configMap:
                               !!merge <<: *TypeObjectsCleanup
-                              description: "behavior policy for failed ConfigMap reconciling, Retain by default"
+                              description: "Behavior policy for failed ConfigMap, `Retain` by default"
                             service:
                               !!merge <<: *TypeObjectsCleanup
-                              description: "behavior policy for failed Service reconciling, Retain by default"
+                              description: "Behavior policy for failed Service, `Retain` by default"
+                    macros:
+                      type: object
+                      description: "macros parameters"
+                      properties:
+                        sections:
+                          type: object
+                          description: "sections behaviour for macros"
+                          properties:
+                            users:
+                              type: object
+                              description: "sections behaviour for macros on users"
+                              properties:
+                                enabled:
+                                  !!merge <<: *TypeStringBool
+                                  description: "enabled or not"
+                            profiles:
+                              type: object
+                              description: "sections behaviour for macros on profiles"
+                              properties:
+                                enabled:
+                                  !!merge <<: *TypeStringBool
+                                  description: "enabled or not"
+                            quotas:
+                              type: object
+                              description: "sections behaviour for macros on quotas"
+                              properties:
+                                enabled:
+                                  !!merge <<: *TypeStringBool
+                                  description: "enabled or not"
+                            settings:
+                              type: object
+                              description: "sections behaviour for macros on settings"
+                              properties:
+                                enabled:
+                                  !!merge <<: *TypeStringBool
+                                  description: "enabled or not"
+                            files:
+                              type: object
+                              description: "sections behaviour for macros on files"
+                              properties:
+                                enabled:
+                                  !!merge <<: *TypeStringBool
+                                  description: "enabled or not"
+                    runtime: &TypeReconcileRuntime
+                      type: object
+                      description: "runtime parameters for clickhouse-operator process which are used during reconcile cycle"
+                      properties:
+                        reconcileShardsThreadsNumber:
+                          type: integer
+                          minimum: 1
+                          maximum: 65535
+                          description: "The maximum number of cluster shards that may be reconciled in parallel, 1 by default"
+                        reconcileShardsMaxConcurrencyPercent:
+                          type: integer
+                          minimum: 0
+                          maximum: 100
+                          description: "The maximum percentage of cluster shards that may be reconciled in parallel, 50 percent by default."
+                    statefulSet: &TypeReconcileStatefulSet
+                      type: object
+                      description: "Optional, StatefulSet reconcile behavior tuning"
+                      properties:
+                        create:
+                          type: object
+                          description: "Behavior during create StatefulSet"
+                          properties:
+                            onFailure:
+                              type: string
+                              description: |
+                                What to do in case created StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.
+                                2. delete - delete newly created problematic StatefulSet and follow 'abort' path afterwards.
+                                3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.
+                              enum:
+                                - ""
+                                - "abort"
+                                - "delete"
+                                - "ignore"
+                        update:
+                          type: object
+                          description: "Behavior during update StatefulSet"
+                          properties:
+                            timeout:
+                              type: integer
+                              description: "How many seconds to wait for StatefulSet to be 'Ready' during update"
+                              minimum: 0
+                              maximum: 3600
+                            pollInterval:
+                              type: integer
+                              description: "How many seconds to wait between checks for StatefulSet status during update"
+                              minimum: 1
+                              maximum: 600
+                            onFailure:
+                              type: string
+                              description: |
+                                What to do in case updated StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.
+                                2. rollback - delete Pod and rollback StatefulSet to previous Generation. Follow 'abort' path afterwards.
+                                3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.
+                              enum:
+                                - ""
+                                - "abort"
+                                - "rollback"
+                                - "ignore"
+                        recreate:
+                          type: object
+                          description: "Behavior during recreate StatefulSet"
+                          properties:
+                            onDataLoss:
+                              type: string
+                              description: |
+                                What to do in case operator needs to recreate StatefulSet due to PVC data loss or missing volumes.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet.
+                                2. recreate - proceed and recreate StatefulSet.
+                              enum:
+                                - ""
+                                - "abort"
+                                - "recreate"
+                            onUpdateFailure:
+                              type: string
+                              description: |
+                                What to do in case operator needs to recreate StatefulSet due to update failure or StatefulSet not ready.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet.
+                                2. recreate - proceed and recreate StatefulSet.
+                              enum:
+                                - ""
+                                - "abort"
+                                - "recreate"
+                    host: &TypeReconcileHost
+                      type: object
+                      description: |
+                        Whether the operator during reconcile procedure should wait for a ClickHouse host:
+                          - to be excluded from a ClickHouse cluster
+                          - to complete all running queries
+                          - to be included into a ClickHouse cluster
+                        respectfully before moving forward
+                      properties:
+                        wait:
+                          type: object
+                          properties:
+                            exclude:
+                              !!merge <<: *TypeStringBool
+                            queries:
+                              !!merge <<: *TypeStringBool
+                              description: "Whether the operator during reconcile procedure should wait for a ClickHouse host to complete all running queries"
+                            include:
+                              !!merge <<: *TypeStringBool
+                              description: "Whether the operator during reconcile procedure should wait for a ClickHouse host to be included into a ClickHouse cluster"
+                            replicas:
+                              type: object
+                              description: "Whether the operator during reconcile procedure should wait for replicas to catch-up"
+                              properties:
+                                all:
+                                  !!merge <<: *TypeStringBool
+                                  description: "Whether the operator during reconcile procedure should wait for all replicas to catch-up"
+                                new:
+                                  !!merge <<: *TypeStringBool
+                                  description: "Whether the operator during reconcile procedure should wait for new replicas to catch-up"
+                                delay:
+                                  type: integer
+                                  description: "replication max absolute delay to consider replica is not delayed"
+                            probes:
+                              type: object
+                              description: "What probes the operator should wait during host launch procedure"
+                              properties:
+                                startup:
+                                  !!merge <<: *TypeStringBool
+                                  description: |
+                                    Whether the operator during host launch procedure should wait for startup probe to succeed.
+                                    In case probe is unspecified wait is assumed to be completed successfully.
+                                    Default option value is to do not wait.
+                                readiness:
+                                  !!merge <<: *TypeStringBool
+                                  description: |
+                                    Whether the operator during host launch procedure should wait for ready probe to succeed.
+                                    In case probe is unspecified wait is assumed to be completed successfully.
+                                    Default option value is to wait.
+                        drop:
+                          type: object
+                          properties:
+                            replicas:
+                              type: object
+                              description: |
+                                Whether the operator during reconcile procedure should drop replicas when replica is deleted or recreated
+                              properties:
+                                onDelete:
+                                  !!merge <<: *TypeStringBool
+                                  description: |
+                                    Whether the operator during reconcile procedure should drop replicas when replica is deleted
+                                onLostVolume:
+                                  !!merge <<: *TypeStringBool
+                                  description: |
+                                    Whether the operator during reconcile procedure should drop replicas when replica volume is lost
+                                active:
+                                  !!merge <<: *TypeStringBool
+                                  description: |
+                                    Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated
+                        hooks: &TypeReconcileHooks
+                          type: object
+                          description: "hooks to execute before and after host reconcile"
+                          properties:
+                            pre:
+                              type: array
+                              description: "actions to execute before reconcile"
+                              nullable: true
+                              items: &TypeHookAction
+                                type: object
+                                required:
+                                  - events
+                                properties:
+                                  sql:
+                                    type: object
+                                    properties:
+                                      queries:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                  shell:
+                                    type: object
+                                    properties:
+                                      command:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                      container:
+                                        type: string
+                                  http:
+                                    type: object
+                                    properties:
+                                      url:
+                                        type: string
+                                      method:
+                                        type: string
+                                  target:
+                                    type: string
+                                    description: "where to execute hook for cluster-level hooks: FirstHost (default), AllHosts, AllShards"
+                                    # Both camelCase and all-lowercase forms are accepted; the
+                                    # runtime normalizes via strings.EqualFold (firstHost == firsthost).
+                                    enum:
+                                      - ""
+                                      - "FirstHost"
+                                      - "firsthost"
+                                      - "AllHosts"
+                                      - "allhosts"
+                                      - "AllShards"
+                                      - "allshards"
+                                  events:
+                                    type: array
+                                    minItems: 1
+                                    description: |
+                                      Reconcile lifecycle events that trigger this hook. Required, must be non-empty.
+                                      The hook is skipped on any reconcile whose classifier does not emit at least one
+                                      of the listed events. Supported values:
+                                        Any               - wildcard match: fires on every hook-evaluation point,
+                                                            including the pre-delete sweep on the dying host
+                                        HostCreate        - first reconcile that creates a host (no ancestor); best
+                                                            paired with POST hooks because PRE hooks on first creation
+                                                            are skipped (no live pod yet)
+                                        HostUpdate        - reconcile that has prior state for the host; catch-all
+                                                            for ongoing reconciles
+                                        HostStart         - host transitions from stopped to running
+                                        HostStop          - host is being stopped (current spec marks it stopped)
+                                        HostConfigRestart - in-place software restart for a configuration change
+                                        HostRollout       - pod-template change forces a StatefulSet rollout
+                                        HostShutdown      - aggregate: fires whenever the pod is going down for any
+                                                            reason (Stop, ConfigRestart, Rollout, or Delete)
+                                        HostDelete        - host is being removed from the cluster (downsize); fires
+                                                            on the dying host before tear-down. Always emitted
+                                                            alongside HostShutdown.
+                                    items:
+                                      type: string
+                                      # Both PascalCase and all-lowercase forms are accepted; the
+                                      # runtime comparison is case-insensitive (strings.EqualFold).
+                                      enum:
+                                        - "Any"
+                                        - "any"
+                                        - "HostCreate"
+                                        - "hostcreate"
+                                        - "HostDelete"
+                                        - "hostdelete"
+                                        - "HostUpdate"
+                                        - "hostupdate"
+                                        - "HostStart"
+                                        - "hoststart"
+                                        - "HostStop"
+                                        - "hoststop"
+                                        - "HostConfigRestart"
+                                        - "hostconfigrestart"
+                                        - "HostRollout"
+                                        - "hostrollout"
+                                        - "HostShutdown"
+                                        - "hostshutdown"
+                                  failurePolicy:
+                                    type: string
+                                    description: |
+                                      Controls what happens when this hook returns an error.
+                                      Fail (default): error propagates — pre-hook aborts reconcile / host deletion.
+                                      Ignore: error is logged and the reconcile continues.
+                                    # Both PascalCase and all-lowercase forms are accepted; the
+                                    # runtime normalizes via strings.EqualFold (Fail == fail).
+                                    enum:
+                                      - "Fail"
+                                      - "fail"
+                                      - "Ignore"
+                                      - "ignore"
+                            post:
+                              type: array
+                              description: "actions to execute after reconcile"
+                              nullable: true
+                              items:
+                                !!merge <<: *TypeHookAction
+                    cluster:
+                      type: object
+                      description: |
+                        CHI-level cluster reconcile defaults inherited by every cluster's
+                        spec.configuration.clusters[N].reconcile section. Use this as a single
+                        place to define cluster-level hooks that should apply to all clusters
+                        in this CHI; per-cluster hooks (under clusters[N].reconcile.hooks)
+                        are appended to (and dedup'd against) the inherited set.
+                      properties:
+                        hooks:
+                          type: object
+                          description: "cluster-level hooks inherited by every cluster"
+                          properties:
+                            pre:
+                              type: array
+                              description: "actions to execute before each cluster reconcile"
+                              nullable: true
+                              items: &TypeClusterHookAction
+                                type: object
+                                required:
+                                  - events
+                                properties:
+                                  sql:
+                                    type: object
+                                    properties:
+                                      queries:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                  shell:
+                                    type: object
+                                    properties:
+                                      command:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                      container:
+                                        type: string
+                                  http:
+                                    type: object
+                                    properties:
+                                      url:
+                                        type: string
+                                      method:
+                                        type: string
+                                  target:
+                                    type: string
+                                    description: "where to execute hook for cluster-level hooks: FirstHost (default), AllHosts, AllShards"
+                                    # Both camelCase and all-lowercase forms are accepted; the
+                                    # runtime normalizes via strings.EqualFold (firstHost == firsthost).
+                                    enum:
+                                      - ""
+                                      - "FirstHost"
+                                      - "firsthost"
+                                      - "AllHosts"
+                                      - "allhosts"
+                                      - "AllShards"
+                                      - "allshards"
+                                  events:
+                                    type: array
+                                    minItems: 1
+                                    description: |
+                                      Cluster-scope reconcile lifecycle events. Required, non-empty.
+                                        Any              - wildcard match: fires on every cluster reconcile pass
+                                                           and the cluster delete sweep
+                                        ClusterCreate    - all hosts in the cluster are new (no ancestor); fires
+                                                           only on the first reconcile of a brand-new cluster
+                                        ClusterReconcile - ongoing reconcile pass over an existing cluster (at
+                                                           least one host has prior state). Fires on every
+                                                           operator reconcile cycle the upstream gates allow,
+                                                           including taskID-only force-reconciles. NOT a "spec
+                                                           changed" signal.
+                                        ClusterDelete    - cluster is being removed (delete sweep — wiring follow-up)
+                                    items:
+                                      type: string
+                                      # Both PascalCase and all-lowercase forms are accepted; the
+                                      # runtime comparison is case-insensitive (strings.EqualFold).
+                                      enum:
+                                        - "Any"
+                                        - "any"
+                                        - "ClusterCreate"
+                                        - "clustercreate"
+                                        - "ClusterDelete"
+                                        - "clusterdelete"
+                                        - "ClusterReconcile"
+                                        - "clusterreconcile"
+                                  failurePolicy:
+                                    type: string
+                                    description: |
+                                      Controls what happens when this hook returns an error.
+                                      Fail (default) propagates the error; Ignore logs a warning and continues.
+                                    # Both PascalCase and all-lowercase forms are accepted; the
+                                    # runtime normalizes via strings.EqualFold (Fail == fail).
+                                    enum:
+                                      - "Fail"
+                                      - "fail"
+                                      - "Ignore"
+                                      - "ignore"
+                            post:
+                              type: array
+                              description: "actions to execute after each cluster reconcile"
+                              nullable: true
+                              items:
+                                !!merge <<: *TypeClusterHookAction
+                reconcile:
+                  !!merge <<: *TypeReconcile
+                  description: "Optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
                 defaults:
                   type: object
                   description: |
@@ -360,7 +877,7 @@ spec:
                       description: |
                         define should replicas be specified by FQDN in `<host></host>`.
                         In case of "no" will use short hostname and clickhouse-server will use kubernetes default suffixes for DNS lookup
-                        "yes" by default
+                        "no" by default
                     distributedDDL:
                       type: object
                       description: |
@@ -410,7 +927,13 @@ spec:
                           description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         serviceTemplate:
                           type: string
-                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                          description: "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                        serviceTemplates:
+                          type: array
+                          description: "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                          nullable: true
+                          items:
+                            type: string
                         clusterServiceTemplate:
                           type: string
                           description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
@@ -422,7 +945,7 @@ spec:
                           description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
                         volumeClaimTemplate:
                           type: string
-                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                          description: "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                 configuration:
                   type: object
                   description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
@@ -457,6 +980,33 @@ spec:
                               secure:
                                 !!merge <<: *TypeStringBool
                                 description: "if a secure connection to Zookeeper is required"
+                              availabilityZone:
+                                type: string
+                                description: "availability zone for Zookeeper node"
+                        keeper:
+                          type: object
+                          description: |
+                            reference to a ClickHouseKeeperInstallation (CHK) resource.
+                            The operator resolves this to ZooKeeper node addresses automatically.
+                          properties:
+                            name:
+                              type: string
+                              description: "name of the ClickHouseKeeperInstallation custom resource"
+                            namespace:
+                              type: string
+                              description: "namespace of the CHK resource, defaults to the CHI namespace if omitted"
+                            serviceType:
+                              type: string
+                              description: |
+                                how to discover keeper endpoints:
+                                  replicas (default) — enumerate per-host services, one ZK node per keeper replica
+                                  service — use the CR-level headless service as a single ZK node entry
+                              enum:
+                                - ""
+                                - "Replicas"
+                                - "replicas"
+                                - "Service"
+                                - "service"
                         session_timeout_ms:
                           type: integer
                           description: "session timeout during connect to Zookeeper"
@@ -469,6 +1019,9 @@ spec:
                         identity:
                           type: string
                           description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
+                        use_compression:
+                          !!merge <<: *TypeStringBool
+                          description: "Enables compression in Keeper protocol if set to true"
                     users:
                       type: object
                       description: |
@@ -476,6 +1029,20 @@ spec:
                         you can configure password hashed, authorization restrictions, database level security row filters etc.
                         More details: https://clickhouse.tech/docs/en/operations/settings/settings-users/
                         Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers
+
+                        any key could contains `valueFrom` with `secretKeyRef` which allow pass password from kubernetes secrets
+                        secret value will pass in `pod.spec.containers.evn`, and generate with from_env=XXX in XML in /etc/clickhouse-server/users.d/chop-generated-users.xml
+                        it not allow automatically updates when updates `secret`, change spec.taskID for manually trigger reconcile cycle
+
+                        look into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples
+
+                        any key with prefix `k8s_secret_` shall has value with format namespace/secret/key or secret/key
+                        in this case value from secret will write directly into XML tag during render *-usersd ConfigMap
+
+                        any key with prefix `k8s_secret_env` shall has value with format namespace/secret/key or secret/key
+                        in this case value from secret will write into environment variable and write to XML tag via from_env=XXX
+
+                        look into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples
                       # nullable: true
                       x-kubernetes-preserve-unknown-fields: true
                     profiles:
@@ -502,6 +1069,12 @@ spec:
                         allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
                         More details: https://clickhouse.tech/docs/en/operations/settings/settings/
                         Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
+
+                        any key could contains `valueFrom` with `secretKeyRef` which allow pass password from kubernetes secrets
+                        look into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples
+
+                        secret value will pass in `pod.spec.env`, and generate with from_env=XXX in XML in /etc/clickhouse-server/config.d/chop-generated-settings.xml
+                        it not allow automatically updates when updates `secret`, change spec.taskID for manually trigger reconcile cycle
                       # nullable: true
                       x-kubernetes-preserve-unknown-fields: true
                     files: &TypeFiles
@@ -511,14 +1084,20 @@ spec:
                         every key in this object is the file name
                         every value in this object is the file content
                         you can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html
-                        each key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored
+                        each key could contains prefix like {common}, {users}, {hosts} or config.d, users.d, conf.d, wrong prefixes will be ignored, subfolders also will be ignored
                         More details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml
+
+                        any key could contains `valueFrom` with `secretKeyRef` which allow pass values from kubernetes secrets
+                        secrets will mounted into pod as separate volume in /etc/clickhouse-server/secrets.d/
+                        and will automatically update when update secret
+                        it useful for pass SSL certificates from cert-manager or similar tool
+                        look into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples
                       # nullable: true
                       x-kubernetes-preserve-unknown-fields: true
                     clusters:
                       type: array
                       description: |
-                        describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level
+                        describes clusters layout and allows change settings on cluster-level, shard-level and replica-level
                         every cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`
                         all Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`
                         Clusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
@@ -531,7 +1110,7 @@ spec:
                         properties:
                           name:
                             type: string
-                            description: "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources"
+                            description: "cluster name, used to identify set of servers and wide used during generate names of related Kubernetes resources"
                             minLength: 1
                             # See namePartClusterMaxLen const
                             maxLength: 15
@@ -567,6 +1146,7 @@ spec:
                                 description: "how schema is propagated within a replica"
                                 enum:
                                   # List SchemaPolicyReplicaXXX constants from model
+                                  - ""
                                   - "None"
                                   - "All"
                               shard:
@@ -574,6 +1154,7 @@ spec:
                                 description: "how schema is propagated between shards"
                                 enum:
                                   # List SchemaPolicyShardXXX constants from model
+                                  - ""
                                   - "None"
                                   - "All"
                                   - "DistributedTablesOnly"
@@ -617,6 +1198,51 @@ spec:
                                     required:
                                       - name
                                       - key
+                          pdbManaged:
+                            !!merge <<: *TypeStringBool
+                            description: |
+                              Specifies whether the Pod Disruption Budget (PDB) should be managed.
+                              During the next installation, if PDB management is enabled, the operator will
+                              attempt to retrieve any existing PDB. If none is found, it will create a new one
+                              and initiate a reconciliation loop. If PDB management is disabled, the existing PDB
+                              will remain intact, and the reconciliation loop will not be executed. By default,
+                              PDB management is enabled.
+                          pdbMaxUnavailable:
+                            type: integer
+                            description: |
+                              Pod eviction is allowed if at most "pdbMaxUnavailable" pods are unavailable after the eviction,
+                              i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions
+                              by specifying 0. This is a mutually exclusive setting with "minAvailable".
+                            minimum: 0
+                            maximum: 65535
+                          reconcile:
+                            type: object
+                            description: "allow tuning reconciling process"
+                            properties:
+                              runtime:
+                                !!merge <<: *TypeReconcileRuntime
+                              host:
+                                !!merge <<: *TypeReconcileHost
+                              hooks:
+                                # Per-cluster cluster-scope hooks. The schema (TypeClusterHookAction) is
+                                # defined once at spec.reconcile.cluster.hooks above; this block just
+                                # references it. Hooks defined here are merged with any inherited from
+                                # CHI-level spec.reconcile.cluster.hooks via dedup'd MergeFrom.
+                                type: object
+                                description: "cluster-level hooks to execute before and after cluster reconcile"
+                                properties:
+                                  pre:
+                                    type: array
+                                    description: "actions to execute before cluster reconcile"
+                                    nullable: true
+                                    items:
+                                      !!merge <<: *TypeClusterHookAction
+                                  post:
+                                    type: array
+                                    description: "actions to execute after cluster reconcile"
+                                    nullable: true
+                                    items:
+                                      !!merge <<: *TypeClusterHookAction
                           layout:
                             type: object
                             description: |
@@ -624,18 +1250,24 @@ spec:
                               allows override settings on each shard and replica separatelly
                             # nullable: true
                             properties:
-                              type:
-                                type: string
-                                description: "DEPRECATED - to be removed soon"
                               shardsCount:
                                 type: integer
-                                description: "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
+                                description: |
+                                  how much shards for current ClickHouse cluster will run in Kubernetes,
+                                  each shard contains shared-nothing part of data and contains set of replicas,
+                                  cluster contains 1 shard by default"
                               replicasCount:
                                 type: integer
-                                description: "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
+                                description: |
+                                  how much replicas in each shards for current cluster will run in Kubernetes,
+                                  each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,
+                                  every shard contains 1 replica by default"
                               shards:
                                 type: array
-                                description: "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do"
+                                description: |
+                                  optional, allows override top-level `chi.spec.configuration`, cluster-level
+                                  `chi.spec.configuration.clusters` settings for each shard separately,
+                                  use it only if you fully understand what you do"
                                 # nullable: true
                                 items:
                                   type: object
@@ -897,7 +1529,7 @@ spec:
                             properties:
                               name:
                                 type: string
-                                description: "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`"
+                                description: "by default, hostname will generate, but this allows define custom name for each `clickhouse-server`"
                                 minLength: 1
                                 # See namePartReplicaMaxLen const
                                 maxLength: 15
@@ -970,7 +1602,7 @@ spec:
                             description: "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
                           generateName:
                             type: string
-                            description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
+                            description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about available template variables"
                           zone:
                             type: object
                             description: "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
@@ -1042,13 +1674,9 @@ spec:
                                   maximum: 65535
                                 topologyKey:
                                   type: string
-                                  description: "use for inter-pod affinity look to `pod.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.topologyKey`, More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity"
-                          spec:
-                            # TODO specify PodSpec
-                            type: object
-                            description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
-                            # nullable: true
-                            x-kubernetes-preserve-unknown-fields: true
+                                  description: |
+                                    use for inter-pod affinity look to `pod.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.topologyKey`,
+                                    more info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity"
                           metadata:
                             type: object
                             description: |
@@ -1056,9 +1684,16 @@ spec:
                               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                             # nullable: true
                             x-kubernetes-preserve-unknown-fields: true
+                          spec:
+                            # TODO specify PodSpec
+                            type: object
+                            description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                     volumeClaimTemplates:
                       type: array
-                      description: "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else"
+                      description: |
+                        allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else
                       # nullable: true
                       items:
                         type: object
@@ -1111,14 +1746,17 @@ spec:
                               replica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`
                           generateName:
                             type: string
-                            description: "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
+                            description: |
+                              allows define format for generated `Service` name,
+                              look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates
+                              for details about available template variables"
                           metadata:
                             # TODO specify ObjectMeta
                             type: object
                             description: |
                               allows pass standard object's metadata from template to Service
                               Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
-                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                             # nullable: true
                             x-kubernetes-preserve-unknown-fields: true
                           spec:
@@ -1131,7 +1769,9 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                 useTemplates:
                   type: array
-                  description: "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters"
+                  description: |
+                    list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `CHI`
+                    manifest during render Kubernetes resources to create related ClickHouse clusters"
                   # nullable: true
                   items:
                     type: object
@@ -1143,7 +1783,7 @@ spec:
                         description: "name of `ClickHouseInstallationTemplate` (chit) resource"
                       namespace:
                         type: string
-                        description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
+                        description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clickhouse-operator`"
                       useType:
                         type: string
                         description: "optional, current strategy is only merge, and current `chi` settings have more priority than merged template `chit`"

--- a/charts/clickhouse/crds/clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
+++ b/charts/clickhouse/crds/clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
@@ -4,13 +4,14 @@
 # SINGULAR=clickhouseinstallationtemplate
 # PLURAL=clickhouseinstallationtemplates
 # SHORT=chit
+# OPERATOR_VERSION=0.27.0
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clickhouseinstallationtemplates.clickhouse.altinity.com
   labels:
-    clickhouse.altinity.com/chop: 0.21.2
+    clickhouse.altinity.com/chop: 0.27.0
 spec:
   group: clickhouse.altinity.com
   scope: Namespaced
@@ -25,6 +26,10 @@ spec:
       served: true
       storage: true
       additionalPrinterColumns:
+        - name: status
+          type: string
+          description: Resource status
+          jsonPath: .status.status
         - name: version
           type: string
           description: Operator version
@@ -48,10 +53,10 @@ spec:
           description: TaskID
           priority: 1 # show in wide view
           jsonPath: .status.taskID
-        - name: status
-          type: string
-          description: CHI status
-          jsonPath: .status.status
+        - name: hosts-completed
+          type: integer
+          description: Completed hosts count
+          jsonPath: .status.hostsCompleted
         - name: hosts-updated
           type: integer
           description: Updated hosts count
@@ -62,20 +67,11 @@ spec:
           description: Added hosts count
           priority: 1 # show in wide view
           jsonPath: .status.hostsAdded
-        - name: hosts-completed
-          type: integer
-          description: Completed hosts count
-          jsonPath: .status.hostsCompleted
         - name: hosts-deleted
           type: integer
           description: Hosts deleted count
           priority: 1 # show in wide view
           jsonPath: .status.hostsDeleted
-        - name: hosts-delete
-          type: integer
-          description: Hosts to be deleted count
-          priority: 1 # show in wide view
-          jsonPath: .status.hostsDelete
         - name: endpoint
           type: string
           description: Client access endpoint
@@ -86,39 +82,51 @@ spec:
           description: Age of the resource
           # Displayed in all priorities
           jsonPath: .metadata.creationTimestamp
+        - name: suspend
+          type: string
+          description: Suspend reconciliation
+          # Displayed in all priorities
+          jsonPath: .spec.suspend
       subresources:
         status: {}
       schema:
         openAPIV3Schema:
-          description: "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters"
+          description: "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more clusters"
           type: object
           required:
             - spec
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
             status:
               type: object
-              description: "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other"
+              description: |
+                Status contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other
               properties:
                 chop-version:
                   type: string
-                  description: "ClickHouse operator version"
+                  description: "Operator version"
                 chop-commit:
                   type: string
-                  description: "ClickHouse operator git commit SHA"
+                  description: "Operator git commit SHA"
                 chop-date:
                   type: string
-                  description: "ClickHouse operator build date"
+                  description: "Operator build date"
                 chop-ip:
                   type: string
-                  description: "IP address of the operator's pod which managed this CHI"
+                  description: "IP address of the operator's pod which managed this resource"
                 clusters:
                   type: integer
                   minimum: 0
@@ -144,11 +152,13 @@ spec:
                 taskIDsStarted:
                   type: array
                   description: "Started task ids"
+                  nullable: true
                   items:
                     type: string
                 taskIDsCompleted:
                   type: array
                   description: "Completed task ids"
+                  nullable: true
                   items:
                     type: string
                 action:
@@ -157,6 +167,7 @@ spec:
                 actions:
                   type: array
                   description: "Actions"
+                  nullable: true
                   items:
                     type: string
                 error:
@@ -165,8 +176,13 @@ spec:
                 errors:
                   type: array
                   description: "Errors"
+                  nullable: true
                   items:
                     type: string
+                hostsUnchanged:
+                  type: integer
+                  minimum: 0
+                  description: "Unchanged Hosts count"
                 hostsUpdated:
                   type: integer
                   minimum: 0
@@ -190,38 +206,69 @@ spec:
                 pods:
                   type: array
                   description: "Pods"
+                  nullable: true
                   items:
                     type: string
                 pod-ips:
                   type: array
                   description: "Pod IPs"
+                  nullable: true
                   items:
                     type: string
                 fqdns:
                   type: array
                   description: "Pods FQDNs"
+                  nullable: true
                   items:
                     type: string
                 endpoint:
                   type: string
                   description: "Endpoint"
+                endpoints:
+                  type: array
+                  description: "All endpoints"
+                  nullable: true
+                  items:
+                    type: string
                 generation:
                   type: integer
                   minimum: 0
                   description: "Generation"
                 normalized:
                   type: object
-                  description: "Normalized CHI requested"
+                  description: "Normalized resource requested"
+                  nullable: true
                   x-kubernetes-preserve-unknown-fields: true
                 normalizedCompleted:
                   type: object
-                  description: "Normalized CHI completed"
+                  description: "Normalized resource completed"
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                actionPlan:
+                  type: object
+                  description: "Action Plan"
+                  nullable: true
                   x-kubernetes-preserve-unknown-fields: true
                 hostsWithTablesCreated:
                   type: array
                   description: "List of hosts with tables created by the operator"
+                  nullable: true
                   items:
                     type: string
+                hostsWithReplicaCaughtUp:
+                  type: array
+                  description: "List of hosts with replica caught up"
+                  nullable: true
+                  items:
+                    type: string
+                usedTemplates:
+                  type: array
+                  description: "List of templates used to build this CHI"
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
               # x-kubernetes-preserve-unknown-fields: true
@@ -232,15 +279,16 @@ spec:
                 taskID:
                   type: string
                   description: |
-                    Allows to define custom taskID for named update operation and watch status of this update execution in .status.taskIDs field.
-                    By default every update of chi manifest will generate random taskID
+                    Allows to define custom taskID for CHI update and watch status of this update execution.
+                    Displayed in all .status.taskID* fields.
+                    By default (if not filled) every update of CHI manifest will generate random taskID
                 stop: &TypeStringBool
                   type: string
                   description: |
-                    Allow stop all ClickHouse clusters described in current chi.
-                    Stop mechanism works as follows:
-                     - When `stop` is `1` then setup `Replicas: 0` in each related to current `chi` StatefulSet resource, all `Pods` and `Service` resources will desctroy, but PVCs still live
-                     - When `stop` is `0` then `Pods` will created again and will attach retained PVCs and `Service` also will created again
+                    Allows to stop all ClickHouse clusters defined in a CHI.
+                    Works as the following:
+                     - When `stop` is `1` operator sets `Replicas: 0` in each StatefulSet. Thie leads to having all `Pods` and `Service` deleted. All PVCs are kept intact.
+                     - When `stop` is `0` operator sets `Replicas: 1` and `Pod`s and `Service`s will created again and all retained PVCs will be attached to `Pod`s.
                   enum:
                     # List StringBoolXXX constants from model
                     - ""
@@ -268,86 +316,555 @@ spec:
                     - "enabled"
                 restart:
                   type: string
-                  description: "This is a 'soft restart' button. When set to 'RollingUpdate' operator will restart ClickHouse pods in a graceful way. Remove it after the use in order to avoid unneeded restarts"
+                  description: |
+                    In case 'RollingUpdate' specified, the operator will always restart ClickHouse pods during reconcile.
+                    This options is used in rare cases when force restart is required and is typically removed after the use in order to avoid unneeded restarts.
                   enum:
                     - ""
                     - "RollingUpdate"
+                suspend:
+                  !!merge <<: *TypeStringBool
+                  description: |
+                    Suspend reconciliation of resources managed by a ClickHouse Installation.
+                    Works as the following:
+                     - When `suspend` is `true` operator stops reconciling all resources.
+                     - When `suspend` is `false` or not set, operator reconciles all resources.
                 troubleshoot:
                   !!merge <<: *TypeStringBool
-                  description: "allows troubleshoot Pods during CrashLoopBack state, when you apply wrong configuration, `clickhouse-server` wouldn't startup"
+                  description: |
+                    Allows to troubleshoot Pods during CrashLoopBack state.
+                    This may happen when wrong configuration applied, in this case `clickhouse-server` wouldn't start.
+                    Command within ClickHouse container is modified with `sleep` in order to avoid quick restarts
+                    and give time to troubleshoot via CLI.
+                    Liveness and Readiness probes are disabled as well.
                 namespaceDomainPattern:
                   type: string
-                  description: "custom domain suffix which will add to end of `Service` or `Pod` name, use it when you use custom cluster domain in your Kubernetes cluster"
+                  description: |
+                    Custom domain pattern which will be used for DNS names of `Service` or `Pod`.
+                    Typical use scenario - custom cluster domain in Kubernetes cluster
+                    Example: %s.svc.my.test
                 templating:
                   type: object
                   # nullable: true
-                  description: "optional, define policy for auto applying ClickHouseInstallationTemplate inside ClickHouseInstallation"
+                  description: |
+                    Optional, applicable inside ClickHouseInstallationTemplate only.
+                    Defines current ClickHouseInstallationTemplate application options to target ClickHouseInstallation(s)."
                   properties:
                     policy:
                       type: string
-                      description: "when defined as `auto` inside ClickhouseInstallationTemplate, it will auto add into all ClickHouseInstallation, manual value is default"
+                      description: |
+                        When defined as `auto` inside ClickhouseInstallationTemplate, this ClickhouseInstallationTemplate
+                        will be auto-added into ClickHouseInstallation, selectable by `chiSelector`.
+                        Default value is `manual`, meaning ClickHouseInstallation should request this ClickhouseInstallationTemplate explicitly.
                       enum:
+                        - ""
                         - "auto"
                         - "manual"
-                reconciling:
+                    chiSelector:
+                      type: object
+                      description: "Optional, defines selector for ClickHouseInstallation(s) to be templated with ClickhouseInstallationTemplate"
+                      # nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
+                reconciling: &TypeReconcile
                   type: object
-                  description: "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
+                  description: "[OBSOLETED] Optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
                   # nullable: true
                   properties:
                     policy:
                       type: string
-                      description: DEPRECATED
+                      description: |
+                        DISCUSSED TO BE DEPRECATED
+                        Syntax sugar
+                        Overrides all three 'reconcile.host.wait.{exclude, queries, include}' values from the operator's config
+                        Possible values:
+                         - wait - should wait to exclude host, complete queries and include host back into the cluster
+                         - nowait - should NOT wait to exclude host, complete queries and include host back into the cluster
+                      enum:
+                        - ""
+                        - "wait"
+                        - "nowait"
                     configMapPropagationTimeout:
                       type: integer
                       description: |
-                        timeout in seconds when `clickhouse-operator` will wait when applied `ConfigMap` during reconcile `ClickhouseInstallation` pods will updated from cache
-                        see details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
+                        Timeout in seconds for `clickhouse-operator` to wait for modified `ConfigMap` to propagate into the `Pod`
+                        More details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically
                       minimum: 0
                       maximum: 3600
                     cleanup:
                       type: object
-                      description: "optional, define behavior for cleanup Kubernetes resources during reconcile cycle"
+                      description: "Optional, defines behavior for cleanup Kubernetes resources during reconcile cycle"
                       # nullable: true
                       properties:
                         unknownObjects:
                           type: object
-                          description: "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`"
+                          description: |
+                            Describes what clickhouse-operator should do with found Kubernetes resources which should be managed by clickhouse-operator,
+                            but do not have `ownerReference` to any currently managed `ClickHouseInstallation` resource.
+                            Default behavior is `Delete`"
                           # nullable: true
                           properties:
                             statefulSet: &TypeObjectsCleanup
                               type: string
-                              description: "behavior policy for unknown StatefulSet, Delete by default"
+                              description: "Behavior policy for unknown StatefulSet, `Delete` by default"
                               enum:
                                 # List ObjectsCleanupXXX constants from model
+                                - ""
                                 - "Retain"
                                 - "Delete"
                             pvc:
                               type: string
                               !!merge <<: *TypeObjectsCleanup
-                              description: "behavior policy for unknown PVC, Delete by default"
+                              description: "Behavior policy for unknown PVC, `Delete` by default"
                             configMap:
                               !!merge <<: *TypeObjectsCleanup
-                              description: "behavior policy for unknown ConfigMap, Delete by default"
+                              description: "Behavior policy for unknown ConfigMap, `Delete` by default"
                             service:
                               !!merge <<: *TypeObjectsCleanup
-                              description: "behavior policy for unknown Service, Delete by default"
+                              description: "Behavior policy for unknown Service, `Delete` by default"
                         reconcileFailedObjects:
                           type: object
-                          description: "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`"
+                          description: |
+                            Describes what clickhouse-operator should do with Kubernetes resources which are failed during reconcile.
+                            Default behavior is `Retain`"
                           # nullable: true
                           properties:
                             statefulSet:
                               !!merge <<: *TypeObjectsCleanup
-                              description: "behavior policy for failed StatefulSet reconciling, Retain by default"
+                              description: "Behavior policy for failed StatefulSet, `Retain` by default"
                             pvc:
                               !!merge <<: *TypeObjectsCleanup
-                              description: "behavior policy for failed PVC reconciling, Retain by default"
+                              description: "Behavior policy for failed PVC, `Retain` by default"
                             configMap:
                               !!merge <<: *TypeObjectsCleanup
-                              description: "behavior policy for failed ConfigMap reconciling, Retain by default"
+                              description: "Behavior policy for failed ConfigMap, `Retain` by default"
                             service:
                               !!merge <<: *TypeObjectsCleanup
-                              description: "behavior policy for failed Service reconciling, Retain by default"
+                              description: "Behavior policy for failed Service, `Retain` by default"
+                    macros:
+                      type: object
+                      description: "macros parameters"
+                      properties:
+                        sections:
+                          type: object
+                          description: "sections behaviour for macros"
+                          properties:
+                            users:
+                              type: object
+                              description: "sections behaviour for macros on users"
+                              properties:
+                                enabled:
+                                  !!merge <<: *TypeStringBool
+                                  description: "enabled or not"
+                            profiles:
+                              type: object
+                              description: "sections behaviour for macros on profiles"
+                              properties:
+                                enabled:
+                                  !!merge <<: *TypeStringBool
+                                  description: "enabled or not"
+                            quotas:
+                              type: object
+                              description: "sections behaviour for macros on quotas"
+                              properties:
+                                enabled:
+                                  !!merge <<: *TypeStringBool
+                                  description: "enabled or not"
+                            settings:
+                              type: object
+                              description: "sections behaviour for macros on settings"
+                              properties:
+                                enabled:
+                                  !!merge <<: *TypeStringBool
+                                  description: "enabled or not"
+                            files:
+                              type: object
+                              description: "sections behaviour for macros on files"
+                              properties:
+                                enabled:
+                                  !!merge <<: *TypeStringBool
+                                  description: "enabled or not"
+                    runtime: &TypeReconcileRuntime
+                      type: object
+                      description: "runtime parameters for clickhouse-operator process which are used during reconcile cycle"
+                      properties:
+                        reconcileShardsThreadsNumber:
+                          type: integer
+                          minimum: 1
+                          maximum: 65535
+                          description: "The maximum number of cluster shards that may be reconciled in parallel, 1 by default"
+                        reconcileShardsMaxConcurrencyPercent:
+                          type: integer
+                          minimum: 0
+                          maximum: 100
+                          description: "The maximum percentage of cluster shards that may be reconciled in parallel, 50 percent by default."
+                    statefulSet: &TypeReconcileStatefulSet
+                      type: object
+                      description: "Optional, StatefulSet reconcile behavior tuning"
+                      properties:
+                        create:
+                          type: object
+                          description: "Behavior during create StatefulSet"
+                          properties:
+                            onFailure:
+                              type: string
+                              description: |
+                                What to do in case created StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.
+                                2. delete - delete newly created problematic StatefulSet and follow 'abort' path afterwards.
+                                3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.
+                              enum:
+                                - ""
+                                - "abort"
+                                - "delete"
+                                - "ignore"
+                        update:
+                          type: object
+                          description: "Behavior during update StatefulSet"
+                          properties:
+                            timeout:
+                              type: integer
+                              description: "How many seconds to wait for StatefulSet to be 'Ready' during update"
+                              minimum: 0
+                              maximum: 3600
+                            pollInterval:
+                              type: integer
+                              description: "How many seconds to wait between checks for StatefulSet status during update"
+                              minimum: 1
+                              maximum: 600
+                            onFailure:
+                              type: string
+                              description: |
+                                What to do in case updated StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.
+                                2. rollback - delete Pod and rollback StatefulSet to previous Generation. Follow 'abort' path afterwards.
+                                3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.
+                              enum:
+                                - ""
+                                - "abort"
+                                - "rollback"
+                                - "ignore"
+                        recreate:
+                          type: object
+                          description: "Behavior during recreate StatefulSet"
+                          properties:
+                            onDataLoss:
+                              type: string
+                              description: |
+                                What to do in case operator needs to recreate StatefulSet due to PVC data loss or missing volumes.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet.
+                                2. recreate - proceed and recreate StatefulSet.
+                              enum:
+                                - ""
+                                - "abort"
+                                - "recreate"
+                            onUpdateFailure:
+                              type: string
+                              description: |
+                                What to do in case operator needs to recreate StatefulSet due to update failure or StatefulSet not ready.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet.
+                                2. recreate - proceed and recreate StatefulSet.
+                              enum:
+                                - ""
+                                - "abort"
+                                - "recreate"
+                    host: &TypeReconcileHost
+                      type: object
+                      description: |
+                        Whether the operator during reconcile procedure should wait for a ClickHouse host:
+                          - to be excluded from a ClickHouse cluster
+                          - to complete all running queries
+                          - to be included into a ClickHouse cluster
+                        respectfully before moving forward
+                      properties:
+                        wait:
+                          type: object
+                          properties:
+                            exclude:
+                              !!merge <<: *TypeStringBool
+                            queries:
+                              !!merge <<: *TypeStringBool
+                              description: "Whether the operator during reconcile procedure should wait for a ClickHouse host to complete all running queries"
+                            include:
+                              !!merge <<: *TypeStringBool
+                              description: "Whether the operator during reconcile procedure should wait for a ClickHouse host to be included into a ClickHouse cluster"
+                            replicas:
+                              type: object
+                              description: "Whether the operator during reconcile procedure should wait for replicas to catch-up"
+                              properties:
+                                all:
+                                  !!merge <<: *TypeStringBool
+                                  description: "Whether the operator during reconcile procedure should wait for all replicas to catch-up"
+                                new:
+                                  !!merge <<: *TypeStringBool
+                                  description: "Whether the operator during reconcile procedure should wait for new replicas to catch-up"
+                                delay:
+                                  type: integer
+                                  description: "replication max absolute delay to consider replica is not delayed"
+                            probes:
+                              type: object
+                              description: "What probes the operator should wait during host launch procedure"
+                              properties:
+                                startup:
+                                  !!merge <<: *TypeStringBool
+                                  description: |
+                                    Whether the operator during host launch procedure should wait for startup probe to succeed.
+                                    In case probe is unspecified wait is assumed to be completed successfully.
+                                    Default option value is to do not wait.
+                                readiness:
+                                  !!merge <<: *TypeStringBool
+                                  description: |
+                                    Whether the operator during host launch procedure should wait for ready probe to succeed.
+                                    In case probe is unspecified wait is assumed to be completed successfully.
+                                    Default option value is to wait.
+                        drop:
+                          type: object
+                          properties:
+                            replicas:
+                              type: object
+                              description: |
+                                Whether the operator during reconcile procedure should drop replicas when replica is deleted or recreated
+                              properties:
+                                onDelete:
+                                  !!merge <<: *TypeStringBool
+                                  description: |
+                                    Whether the operator during reconcile procedure should drop replicas when replica is deleted
+                                onLostVolume:
+                                  !!merge <<: *TypeStringBool
+                                  description: |
+                                    Whether the operator during reconcile procedure should drop replicas when replica volume is lost
+                                active:
+                                  !!merge <<: *TypeStringBool
+                                  description: |
+                                    Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated
+                        hooks: &TypeReconcileHooks
+                          type: object
+                          description: "hooks to execute before and after host reconcile"
+                          properties:
+                            pre:
+                              type: array
+                              description: "actions to execute before reconcile"
+                              nullable: true
+                              items: &TypeHookAction
+                                type: object
+                                required:
+                                  - events
+                                properties:
+                                  sql:
+                                    type: object
+                                    properties:
+                                      queries:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                  shell:
+                                    type: object
+                                    properties:
+                                      command:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                      container:
+                                        type: string
+                                  http:
+                                    type: object
+                                    properties:
+                                      url:
+                                        type: string
+                                      method:
+                                        type: string
+                                  target:
+                                    type: string
+                                    description: "where to execute hook for cluster-level hooks: FirstHost (default), AllHosts, AllShards"
+                                    # Both camelCase and all-lowercase forms are accepted; the
+                                    # runtime normalizes via strings.EqualFold (firstHost == firsthost).
+                                    enum:
+                                      - ""
+                                      - "FirstHost"
+                                      - "firsthost"
+                                      - "AllHosts"
+                                      - "allhosts"
+                                      - "AllShards"
+                                      - "allshards"
+                                  events:
+                                    type: array
+                                    minItems: 1
+                                    description: |
+                                      Reconcile lifecycle events that trigger this hook. Required, must be non-empty.
+                                      The hook is skipped on any reconcile whose classifier does not emit at least one
+                                      of the listed events. Supported values:
+                                        Any               - wildcard match: fires on every hook-evaluation point,
+                                                            including the pre-delete sweep on the dying host
+                                        HostCreate        - first reconcile that creates a host (no ancestor); best
+                                                            paired with POST hooks because PRE hooks on first creation
+                                                            are skipped (no live pod yet)
+                                        HostUpdate        - reconcile that has prior state for the host; catch-all
+                                                            for ongoing reconciles
+                                        HostStart         - host transitions from stopped to running
+                                        HostStop          - host is being stopped (current spec marks it stopped)
+                                        HostConfigRestart - in-place software restart for a configuration change
+                                        HostRollout       - pod-template change forces a StatefulSet rollout
+                                        HostShutdown      - aggregate: fires whenever the pod is going down for any
+                                                            reason (Stop, ConfigRestart, Rollout, or Delete)
+                                        HostDelete        - host is being removed from the cluster (downsize); fires
+                                                            on the dying host before tear-down. Always emitted
+                                                            alongside HostShutdown.
+                                    items:
+                                      type: string
+                                      # Both PascalCase and all-lowercase forms are accepted; the
+                                      # runtime comparison is case-insensitive (strings.EqualFold).
+                                      enum:
+                                        - "Any"
+                                        - "any"
+                                        - "HostCreate"
+                                        - "hostcreate"
+                                        - "HostDelete"
+                                        - "hostdelete"
+                                        - "HostUpdate"
+                                        - "hostupdate"
+                                        - "HostStart"
+                                        - "hoststart"
+                                        - "HostStop"
+                                        - "hoststop"
+                                        - "HostConfigRestart"
+                                        - "hostconfigrestart"
+                                        - "HostRollout"
+                                        - "hostrollout"
+                                        - "HostShutdown"
+                                        - "hostshutdown"
+                                  failurePolicy:
+                                    type: string
+                                    description: |
+                                      Controls what happens when this hook returns an error.
+                                      Fail (default): error propagates — pre-hook aborts reconcile / host deletion.
+                                      Ignore: error is logged and the reconcile continues.
+                                    # Both PascalCase and all-lowercase forms are accepted; the
+                                    # runtime normalizes via strings.EqualFold (Fail == fail).
+                                    enum:
+                                      - "Fail"
+                                      - "fail"
+                                      - "Ignore"
+                                      - "ignore"
+                            post:
+                              type: array
+                              description: "actions to execute after reconcile"
+                              nullable: true
+                              items:
+                                !!merge <<: *TypeHookAction
+                    cluster:
+                      type: object
+                      description: |
+                        CHI-level cluster reconcile defaults inherited by every cluster's
+                        spec.configuration.clusters[N].reconcile section. Use this as a single
+                        place to define cluster-level hooks that should apply to all clusters
+                        in this CHI; per-cluster hooks (under clusters[N].reconcile.hooks)
+                        are appended to (and dedup'd against) the inherited set.
+                      properties:
+                        hooks:
+                          type: object
+                          description: "cluster-level hooks inherited by every cluster"
+                          properties:
+                            pre:
+                              type: array
+                              description: "actions to execute before each cluster reconcile"
+                              nullable: true
+                              items: &TypeClusterHookAction
+                                type: object
+                                required:
+                                  - events
+                                properties:
+                                  sql:
+                                    type: object
+                                    properties:
+                                      queries:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                  shell:
+                                    type: object
+                                    properties:
+                                      command:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                      container:
+                                        type: string
+                                  http:
+                                    type: object
+                                    properties:
+                                      url:
+                                        type: string
+                                      method:
+                                        type: string
+                                  target:
+                                    type: string
+                                    description: "where to execute hook for cluster-level hooks: FirstHost (default), AllHosts, AllShards"
+                                    # Both camelCase and all-lowercase forms are accepted; the
+                                    # runtime normalizes via strings.EqualFold (firstHost == firsthost).
+                                    enum:
+                                      - ""
+                                      - "FirstHost"
+                                      - "firsthost"
+                                      - "AllHosts"
+                                      - "allhosts"
+                                      - "AllShards"
+                                      - "allshards"
+                                  events:
+                                    type: array
+                                    minItems: 1
+                                    description: |
+                                      Cluster-scope reconcile lifecycle events. Required, non-empty.
+                                        Any              - wildcard match: fires on every cluster reconcile pass
+                                                           and the cluster delete sweep
+                                        ClusterCreate    - all hosts in the cluster are new (no ancestor); fires
+                                                           only on the first reconcile of a brand-new cluster
+                                        ClusterReconcile - ongoing reconcile pass over an existing cluster (at
+                                                           least one host has prior state). Fires on every
+                                                           operator reconcile cycle the upstream gates allow,
+                                                           including taskID-only force-reconciles. NOT a "spec
+                                                           changed" signal.
+                                        ClusterDelete    - cluster is being removed (delete sweep — wiring follow-up)
+                                    items:
+                                      type: string
+                                      # Both PascalCase and all-lowercase forms are accepted; the
+                                      # runtime comparison is case-insensitive (strings.EqualFold).
+                                      enum:
+                                        - "Any"
+                                        - "any"
+                                        - "ClusterCreate"
+                                        - "clustercreate"
+                                        - "ClusterDelete"
+                                        - "clusterdelete"
+                                        - "ClusterReconcile"
+                                        - "clusterreconcile"
+                                  failurePolicy:
+                                    type: string
+                                    description: |
+                                      Controls what happens when this hook returns an error.
+                                      Fail (default) propagates the error; Ignore logs a warning and continues.
+                                    # Both PascalCase and all-lowercase forms are accepted; the
+                                    # runtime normalizes via strings.EqualFold (Fail == fail).
+                                    enum:
+                                      - "Fail"
+                                      - "fail"
+                                      - "Ignore"
+                                      - "ignore"
+                            post:
+                              type: array
+                              description: "actions to execute after each cluster reconcile"
+                              nullable: true
+                              items:
+                                !!merge <<: *TypeClusterHookAction
+                reconcile:
+                  !!merge <<: *TypeReconcile
+                  description: "Optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side"
                 defaults:
                   type: object
                   description: |
@@ -360,7 +877,7 @@ spec:
                       description: |
                         define should replicas be specified by FQDN in `<host></host>`.
                         In case of "no" will use short hostname and clickhouse-server will use kubernetes default suffixes for DNS lookup
-                        "yes" by default
+                        "no" by default
                     distributedDDL:
                       type: object
                       description: |
@@ -410,7 +927,13 @@ spec:
                           description: "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                         serviceTemplate:
                           type: string
-                          description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                          description: "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                        serviceTemplates:
+                          type: array
+                          description: "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                          nullable: true
+                          items:
+                            type: string
                         clusterServiceTemplate:
                           type: string
                           description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
@@ -422,7 +945,7 @@ spec:
                           description: "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
                         volumeClaimTemplate:
                           type: string
-                          description: "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                          description: "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                 configuration:
                   type: object
                   description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
@@ -457,6 +980,33 @@ spec:
                               secure:
                                 !!merge <<: *TypeStringBool
                                 description: "if a secure connection to Zookeeper is required"
+                              availabilityZone:
+                                type: string
+                                description: "availability zone for Zookeeper node"
+                        keeper:
+                          type: object
+                          description: |
+                            reference to a ClickHouseKeeperInstallation (CHK) resource.
+                            The operator resolves this to ZooKeeper node addresses automatically.
+                          properties:
+                            name:
+                              type: string
+                              description: "name of the ClickHouseKeeperInstallation custom resource"
+                            namespace:
+                              type: string
+                              description: "namespace of the CHK resource, defaults to the CHI namespace if omitted"
+                            serviceType:
+                              type: string
+                              description: |
+                                how to discover keeper endpoints:
+                                  replicas (default) — enumerate per-host services, one ZK node per keeper replica
+                                  service — use the CR-level headless service as a single ZK node entry
+                              enum:
+                                - ""
+                                - "Replicas"
+                                - "replicas"
+                                - "Service"
+                                - "service"
                         session_timeout_ms:
                           type: integer
                           description: "session timeout during connect to Zookeeper"
@@ -469,6 +1019,9 @@ spec:
                         identity:
                           type: string
                           description: "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
+                        use_compression:
+                          !!merge <<: *TypeStringBool
+                          description: "Enables compression in Keeper protocol if set to true"
                     users:
                       type: object
                       description: |
@@ -476,6 +1029,20 @@ spec:
                         you can configure password hashed, authorization restrictions, database level security row filters etc.
                         More details: https://clickhouse.tech/docs/en/operations/settings/settings-users/
                         Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers
+
+                        any key could contains `valueFrom` with `secretKeyRef` which allow pass password from kubernetes secrets
+                        secret value will pass in `pod.spec.containers.evn`, and generate with from_env=XXX in XML in /etc/clickhouse-server/users.d/chop-generated-users.xml
+                        it not allow automatically updates when updates `secret`, change spec.taskID for manually trigger reconcile cycle
+
+                        look into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples
+
+                        any key with prefix `k8s_secret_` shall has value with format namespace/secret/key or secret/key
+                        in this case value from secret will write directly into XML tag during render *-usersd ConfigMap
+
+                        any key with prefix `k8s_secret_env` shall has value with format namespace/secret/key or secret/key
+                        in this case value from secret will write into environment variable and write to XML tag via from_env=XXX
+
+                        look into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples
                       # nullable: true
                       x-kubernetes-preserve-unknown-fields: true
                     profiles:
@@ -502,6 +1069,12 @@ spec:
                         allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`
                         More details: https://clickhouse.tech/docs/en/operations/settings/settings/
                         Your yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings
+
+                        any key could contains `valueFrom` with `secretKeyRef` which allow pass password from kubernetes secrets
+                        look into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples
+
+                        secret value will pass in `pod.spec.env`, and generate with from_env=XXX in XML in /etc/clickhouse-server/config.d/chop-generated-settings.xml
+                        it not allow automatically updates when updates `secret`, change spec.taskID for manually trigger reconcile cycle
                       # nullable: true
                       x-kubernetes-preserve-unknown-fields: true
                     files: &TypeFiles
@@ -511,14 +1084,20 @@ spec:
                         every key in this object is the file name
                         every value in this object is the file content
                         you can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html
-                        each key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored
+                        each key could contains prefix like {common}, {users}, {hosts} or config.d, users.d, conf.d, wrong prefixes will be ignored, subfolders also will be ignored
                         More details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml
+
+                        any key could contains `valueFrom` with `secretKeyRef` which allow pass values from kubernetes secrets
+                        secrets will mounted into pod as separate volume in /etc/clickhouse-server/secrets.d/
+                        and will automatically update when update secret
+                        it useful for pass SSL certificates from cert-manager or similar tool
+                        look into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples
                       # nullable: true
                       x-kubernetes-preserve-unknown-fields: true
                     clusters:
                       type: array
                       description: |
-                        describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level
+                        describes clusters layout and allows change settings on cluster-level, shard-level and replica-level
                         every cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`
                         all Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`
                         Clusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/
@@ -531,7 +1110,7 @@ spec:
                         properties:
                           name:
                             type: string
-                            description: "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources"
+                            description: "cluster name, used to identify set of servers and wide used during generate names of related Kubernetes resources"
                             minLength: 1
                             # See namePartClusterMaxLen const
                             maxLength: 15
@@ -567,6 +1146,7 @@ spec:
                                 description: "how schema is propagated within a replica"
                                 enum:
                                   # List SchemaPolicyReplicaXXX constants from model
+                                  - ""
                                   - "None"
                                   - "All"
                               shard:
@@ -574,6 +1154,7 @@ spec:
                                 description: "how schema is propagated between shards"
                                 enum:
                                   # List SchemaPolicyShardXXX constants from model
+                                  - ""
                                   - "None"
                                   - "All"
                                   - "DistributedTablesOnly"
@@ -617,6 +1198,51 @@ spec:
                                     required:
                                       - name
                                       - key
+                          pdbManaged:
+                            !!merge <<: *TypeStringBool
+                            description: |
+                              Specifies whether the Pod Disruption Budget (PDB) should be managed.
+                              During the next installation, if PDB management is enabled, the operator will
+                              attempt to retrieve any existing PDB. If none is found, it will create a new one
+                              and initiate a reconciliation loop. If PDB management is disabled, the existing PDB
+                              will remain intact, and the reconciliation loop will not be executed. By default,
+                              PDB management is enabled.
+                          pdbMaxUnavailable:
+                            type: integer
+                            description: |
+                              Pod eviction is allowed if at most "pdbMaxUnavailable" pods are unavailable after the eviction,
+                              i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions
+                              by specifying 0. This is a mutually exclusive setting with "minAvailable".
+                            minimum: 0
+                            maximum: 65535
+                          reconcile:
+                            type: object
+                            description: "allow tuning reconciling process"
+                            properties:
+                              runtime:
+                                !!merge <<: *TypeReconcileRuntime
+                              host:
+                                !!merge <<: *TypeReconcileHost
+                              hooks:
+                                # Per-cluster cluster-scope hooks. The schema (TypeClusterHookAction) is
+                                # defined once at spec.reconcile.cluster.hooks above; this block just
+                                # references it. Hooks defined here are merged with any inherited from
+                                # CHI-level spec.reconcile.cluster.hooks via dedup'd MergeFrom.
+                                type: object
+                                description: "cluster-level hooks to execute before and after cluster reconcile"
+                                properties:
+                                  pre:
+                                    type: array
+                                    description: "actions to execute before cluster reconcile"
+                                    nullable: true
+                                    items:
+                                      !!merge <<: *TypeClusterHookAction
+                                  post:
+                                    type: array
+                                    description: "actions to execute after cluster reconcile"
+                                    nullable: true
+                                    items:
+                                      !!merge <<: *TypeClusterHookAction
                           layout:
                             type: object
                             description: |
@@ -624,18 +1250,24 @@ spec:
                               allows override settings on each shard and replica separatelly
                             # nullable: true
                             properties:
-                              type:
-                                type: string
-                                description: "DEPRECATED - to be removed soon"
                               shardsCount:
                                 type: integer
-                                description: "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
+                                description: |
+                                  how much shards for current ClickHouse cluster will run in Kubernetes,
+                                  each shard contains shared-nothing part of data and contains set of replicas,
+                                  cluster contains 1 shard by default"
                               replicasCount:
                                 type: integer
-                                description: "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
+                                description: |
+                                  how much replicas in each shards for current cluster will run in Kubernetes,
+                                  each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,
+                                  every shard contains 1 replica by default"
                               shards:
                                 type: array
-                                description: "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do"
+                                description: |
+                                  optional, allows override top-level `chi.spec.configuration`, cluster-level
+                                  `chi.spec.configuration.clusters` settings for each shard separately,
+                                  use it only if you fully understand what you do"
                                 # nullable: true
                                 items:
                                   type: object
@@ -897,7 +1529,7 @@ spec:
                             properties:
                               name:
                                 type: string
-                                description: "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`"
+                                description: "by default, hostname will generate, but this allows define custom name for each `clickhouse-server`"
                                 minLength: 1
                                 # See namePartReplicaMaxLen const
                                 maxLength: 15
@@ -970,7 +1602,7 @@ spec:
                             description: "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
                           generateName:
                             type: string
-                            description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
+                            description: "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about available template variables"
                           zone:
                             type: object
                             description: "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`"
@@ -1042,13 +1674,9 @@ spec:
                                   maximum: 65535
                                 topologyKey:
                                   type: string
-                                  description: "use for inter-pod affinity look to `pod.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.topologyKey`, More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity"
-                          spec:
-                            # TODO specify PodSpec
-                            type: object
-                            description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
-                            # nullable: true
-                            x-kubernetes-preserve-unknown-fields: true
+                                  description: |
+                                    use for inter-pod affinity look to `pod.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.topologyKey`,
+                                    more info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity"
                           metadata:
                             type: object
                             description: |
@@ -1056,9 +1684,16 @@ spec:
                               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                             # nullable: true
                             x-kubernetes-preserve-unknown-fields: true
+                          spec:
+                            # TODO specify PodSpec
+                            type: object
+                            description: "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details"
+                            # nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
                     volumeClaimTemplates:
                       type: array
-                      description: "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else"
+                      description: |
+                        allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else
                       # nullable: true
                       items:
                         type: object
@@ -1111,14 +1746,17 @@ spec:
                               replica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`
                           generateName:
                             type: string
-                            description: "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
+                            description: |
+                              allows define format for generated `Service` name,
+                              look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates
+                              for details about available template variables"
                           metadata:
                             # TODO specify ObjectMeta
                             type: object
                             description: |
                               allows pass standard object's metadata from template to Service
                               Could be use for define specificly for Cloud Provider metadata which impact to behavior of service
-                              More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                             # nullable: true
                             x-kubernetes-preserve-unknown-fields: true
                           spec:
@@ -1131,7 +1769,9 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                 useTemplates:
                   type: array
-                  description: "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters"
+                  description: |
+                    list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `CHI`
+                    manifest during render Kubernetes resources to create related ClickHouse clusters"
                   # nullable: true
                   items:
                     type: object
@@ -1143,7 +1783,7 @@ spec:
                         description: "name of `ClickHouseInstallationTemplate` (chit) resource"
                       namespace:
                         type: string
-                        description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
+                        description: "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clickhouse-operator`"
                       useType:
                         type: string
                         description: "optional, current strategy is only merge, and current `chi` settings have more priority than merged template `chit`"

--- a/charts/clickhouse/crds/clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
+++ b/charts/clickhouse/crds/clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
@@ -7,7 +7,7 @@ kind: CustomResourceDefinition
 metadata:
   name: clickhouseoperatorconfigurations.clickhouse.altinity.com
   labels:
-    clickhouse.altinity.com/chop: 0.21.2
+    clickhouse.altinity.com/chop: 0.27.0
 spec:
   group: clickhouse.altinity.com
   scope: Namespaced
@@ -53,10 +53,23 @@ spec:
                   description: "Parameters for watch kubernetes resources which used by clickhouse-operator deployment"
                   properties:
                     namespaces:
-                      type: array
+                      type: object
                       description: "List of namespaces where clickhouse-operator watches for events."
-                      items:
-                        type: string
+                      x-kubernetes-preserve-unknown-fields: true
+                    configuration:
+                      type: object
+                      description: "Behavior when ClickHouseOperatorConfiguration resources change"
+                      properties:
+                        onChange:
+                          type: string
+                          enum:
+                            - none
+                            - None
+                            - ignore
+                            - Ignore
+                            - restart
+                            - Restart
+                          description: "none/ignore — do nothing; restart — exit process so the operator pod restarts"
                 clickhouse:
                   type: object
                   description: "Clickhouse related parameters used by clickhouse-operator"
@@ -69,16 +82,27 @@ spec:
                           properties:
                             path:
                               type: object
+                              description: |
+                                Each 'path' can be either absolute or relative.
+                                In case path is absolute - it is used as is.
+                                In case path is relative - it is relative to the folder where configuration file you are reading right now is located.
                               properties:
                                 common:
                                   type: string
-                                  description: "Path to the folder where ClickHouse configuration files common for all instances within a CHI are located. Default - config.d"
+                                  description: |
+                                    Path to the folder where ClickHouse configuration files common for all instances within a CHI are located.
+                                    Default value - config.d
                                 host:
                                   type: string
-                                  description: "Path to the folder where ClickHouse configuration files unique for each instance (host) within a CHI are located. Default - conf.d"
+                                  description: |
+                                    Path to the folder where ClickHouse configuration files unique for each instance (host) within a CHI are located.
+                                    Default value - conf.d
                                 user:
                                   type: string
-                                  description: "Path to the folder where ClickHouse configuration files with users settings are located. Files are common for all instances within a CHI. Default - users.d"
+                                  description: |
+                                    Path to the folder where ClickHouse configuration files with users settings are located.
+                                    Files are common for all instances within a CHI.
+                                    Default value - users.d
                         user:
                           type: object
                           description: "Default parameters for any user which will create"
@@ -126,6 +150,7 @@ spec:
                                 items:
                                   type: object
                                   description: "setting: value pairs for configuration restart policy"
+                                  x-kubernetes-preserve-unknown-fields: true
                     access:
                       type: object
                       description: "parameters which use for connect to clickhouse from clickhouse-operator deployment"
@@ -164,25 +189,84 @@ spec:
                               type: integer
                               minimum: 1
                               maximum: 10
-                              description: "Connect timeout. In seconds."
+                              description: "Timout to setup connection from the operator to ClickHouse instances. In seconds."
                             query:
                               type: integer
                               minimum: 1
                               maximum: 600
-                              description: "Query timeout. In seconds."
+                              description: "Timout to perform SQL query from the operator to ClickHouse instances. In seconds."
+                    addons:
+                      type: object
+                      description: "Configuration addons specifies additional settings"
+                      properties:
+                        rules:
+                          type: array
+                          description: "Array of set of rules per specified ClickHouse versions"
+                          items:
+                            type: object
+                            properties:
+                              version:
+                                type: string
+                                description: "ClickHouse version expression"
+                              spec:
+                                type: object
+                                description: "spec"
+                                properties:
+                                  configuration:
+                                    type: object
+                                    description: "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource"
+                                    properties:
+                                      users:
+                                        type: object
+                                        description: "see same section from CR spec"
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      profiles:
+                                        type: object
+                                        description: "see same section from CR spec"
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      quotas:
+                                        type: object
+                                        description: "see same section from CR spec"
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      settings:
+                                        type: object
+                                        description: "see same section from CR spec"
+                                        x-kubernetes-preserve-unknown-fields: true
+                                      files:
+                                        type: object
+                                        description: "see same section from CR spec"
+                                        x-kubernetes-preserve-unknown-fields: true
                     metrics:
                       type: object
                       description: "parameters which use for connect to fetch metrics from clickhouse by clickhouse-operator"
                       properties:
                         timeouts:
                           type: object
-                          description: "Timeouts used to limit connection and queries from the operator to ClickHouse instances, In seconds"
+                          description: |
+                            Timeouts used to limit connection and queries from the metrics exporter to ClickHouse instances
+                            Specified in seconds.
                           properties:
                             collect:
                               type: integer
                               minimum: 1
                               maximum: 600
-                              description: "Collect timeout. In seconds."
+                              description: |
+                                Timeout used to limit metrics collection request. In seconds.
+                                Upon reaching this timeout metrics collection is aborted and no more metrics are collected in this cycle.
+                                All collected metrics are returned.
+                        tablesRegexp:
+                          type: string
+                          description: |
+                            Regexp to match tables in system database to fetch metrics from.
+                            Multiple tables can be matched using regexp. Matched tables are merged using merge() table function.
+                            Default is "^(metrics|custom_metrics)$".
+                        excludeRegexp:
+                          type: array
+                          items:
+                            type: string
+                          description: |
+                            List of regexps to match ClickHouse metrics to exclude from export.
+                            Regexps match internal metric names before Prometheus normalization and prefixing.
                 template:
                   type: object
                   description: "Parameters which are used if you want to generate ClickHouseInstallationTemplate custom resources from files which are stored inside clickhouse-operator deployment"
@@ -190,6 +274,17 @@ spec:
                     chi:
                       type: object
                       properties:
+                        policy:
+                          type: string
+                          description: |
+                            CHI template updates handling policy
+                            Possible policy values:
+                              - ReadOnStart. Accept CHIT updates on the operators start only.
+                              - ApplyOnNextReconcile. Accept CHIT updates at all time. Apply news CHITs on next regular reconcile of the CHI
+                          enum:
+                            - ""
+                            - "ReadOnStart"
+                            - "ApplyOnNextReconcile"
                         path:
                           type: string
                           description: "Path to folder where ClickHouseInstallationTemplate .yaml manifests are located."
@@ -250,16 +345,39 @@ spec:
                                 1. abort - do nothing, just break the process and wait for admin.
                                 2. rollback (default) - delete Pod and rollback StatefulSet to previous Generation. Pod would be recreated by StatefulSet based on rollback-ed configuration.
                                 3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet.
+                        recreate:
+                          type: object
+                          description: "Behavior during recreate StatefulSet"
+                          properties:
+                            onDataLoss:
+                              type: string
+                              description: |
+                                What to do in case operator needs to recreate StatefulSet due to PVC data loss or missing volumes.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet.
+                                2. recreate (default) - proceed and recreate StatefulSet.
+                            onUpdateFailure:
+                              type: string
+                              description: |
+                                What to do in case operator needs to recreate StatefulSet due to update failure or StatefulSet not ready.
+                                Possible options:
+                                1. abort - abort the process, do nothing with the problematic StatefulSet.
+                                2. recreate (default) - proceed and recreate StatefulSet.
                     host:
                       type: object
-                      description: "allow define how to wait host include to system.cluster behavior during scale up and scale down cluster operations"
+                      description: |
+                        Whether the operator during reconcile procedure should wait for a ClickHouse host:
+                          - to be excluded from a ClickHouse cluster
+                          - to complete all running queries
+                          - to be included into a ClickHouse cluster
+                        respectfully before moving forward
                       properties:
                         wait:
                           type: object
                           properties:
                             exclude: &TypeStringBool
                               type: string
-                              description: "wait when a pod will be removed from the cluster"
+                              description: "Whether the operator during reconcile procedure should wait for a ClickHouse host to be excluded from a ClickHouse cluster"
                               enum:
                                 # List StringBoolXXX constants from model
                                 - ""
@@ -285,9 +403,164 @@ spec:
                                 - "disabled"
                                 - "Enabled"
                                 - "enabled"
+                            queries:
+                              !!merge <<: *TypeStringBool
+                              description: "Whether the operator during reconcile procedure should wait for a ClickHouse host to complete all running queries"
                             include:
                               !!merge <<: *TypeStringBool
-                              description: "wait when a pod will be added to the cluster"
+                              description: "Whether the operator during reconcile procedure should wait for a ClickHouse host to be included into a ClickHouse cluster"
+                            replicas:
+                              type: object
+                              description: "Whether the operator during reconcile procedure should wait for replicas to catch-up"
+                              properties:
+                                all:
+                                  !!merge <<: *TypeStringBool
+                                  description: "Whether the operator during reconcile procedure should wait for all replicas to catch-up"
+                                new:
+                                  !!merge <<: *TypeStringBool
+                                  description: "Whether the operator during reconcile procedure should wait for new replicas to catch-up"
+                                delay:
+                                  type: integer
+                                  description: "replication max absolute delay to consider replica is not delayed"
+                            probes:
+                              type: object
+                              description: "What probes the operator should wait during host launch procedure"
+                              properties:
+                                startup:
+                                  !!merge <<: *TypeStringBool
+                                  description: |
+                                    Whether the operator during host launch procedure should wait for startup probe to succeed.
+                                    In case probe is unspecified wait is assumed to be completed successfully.
+                                    Default option value is to do not wait.
+                                readiness:
+                                  !!merge <<: *TypeStringBool
+                                  description: |
+                                    Whether the operator during host launch procedure should wait for readiness probe to succeed.
+                                    In case probe is unspecified wait is assumed to be completed successfully.
+                                    Default option value is to wait.
+                        drop:
+                          type: object
+                          properties:
+                            replicas:
+                              type: object
+                              description: |
+                                Whether the operator during reconcile procedure should drop replicas when replica is deleted or recreated
+                              properties:
+                                onDelete:
+                                  !!merge <<: *TypeStringBool
+                                  description: |
+                                    Whether the operator during reconcile procedure should drop replicas when replica is deleted
+                                onLostVolume:
+                                  !!merge <<: *TypeStringBool
+                                  description: |
+                                    Whether the operator during reconcile procedure should drop replicas when replica volume is lost
+                                active:
+                                  !!merge <<: *TypeStringBool
+                                  description: |
+                                    Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated
+                        hooks:
+                          type: object
+                          description: "default host-level hooks to execute before and after host reconcile"
+                          properties:
+                            pre:
+                              type: array
+                              description: "actions to execute before host reconcile"
+                              nullable: true
+                              items: &TypeHookActionChop
+                                type: object
+                                properties:
+                                  sql:
+                                    type: object
+                                    properties:
+                                      queries:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                  shell:
+                                    type: object
+                                    properties:
+                                      command:
+                                        type: array
+                                        nullable: true
+                                        items:
+                                          type: string
+                                      container:
+                                        type: string
+                                  http:
+                                    type: object
+                                    properties:
+                                      url:
+                                        type: string
+                                      method:
+                                        type: string
+                                  target:
+                                    type: string
+                                    description: "where to execute hook: FirstHost (default), AllHosts, AllShards"
+                                    enum:
+                                      - ""
+                                      - "FirstHost"
+                                      - "firsthost"
+                                      - "AllHosts"
+                                      - "allhosts"
+                                      - "AllShards"
+                                      - "allshards"
+                            post:
+                              type: array
+                              description: "actions to execute after host reconcile"
+                              nullable: true
+                              items:
+                                !!merge <<: *TypeHookActionChop
+                    coordination:
+                      type: object
+                      description: "Coordination with external systems during reconcile"
+                      properties:
+                        keeper:
+                          type: object
+                          description: "Keeper-related coordination settings"
+                          properties:
+                            readyTimeout:
+                              type: integer
+                              minimum: 1
+                              description: |
+                                How long the operator waits for a referenced ClickHouseKeeper to become ready
+                                before aborting CHI reconcile. In seconds. Default is 120.
+                            onKeeperResourceUpdate:
+                              type: string
+                              description: |
+                                Reaction when a referenced CHK resource changes.
+                                  none (default) — do nothing
+                                  reconcile — trigger CHI reconcile
+                              enum:
+                                - ""
+                                - "None"
+                                - "none"
+                                - "Reconcile"
+                                - "reconcile"
+                    recovery:
+                      type: object
+                      description: "Auto-recovery from reconcile failures, scoped by CHI state"
+                      properties:
+                        from:
+                          type: object
+                          description: "Recovery scopes keyed by CHI state being recovered from"
+                          properties:
+                            aborted:
+                              type: object
+                              description: "Recovery from Status=Aborted"
+                              properties:
+                                onPodReady:
+                                  type: string
+                                  description: |
+                                    Reaction when a pod belonging to an Aborted CHI transitions to Ready.
+                                      retry (default) — re-enqueue the CHI for reconcile
+                                      none — do nothing, CHI stays Aborted
+                                  enum:
+                                    - ""
+                                    - "None"
+                                    - "none"
+                                    - "Retry"
+                                    - "retry"
                 annotation:
                   type: object
                   description: "defines which metadata.annotations items will include or exclude during render StatefulSet, Pod, PVC resources"
@@ -338,6 +611,40 @@ spec:
                         - "LabelClusterScopeCycleSize"
                         - "LabelClusterScopeCycleIndex"
                         - "LabelClusterScopeCycleOffset"
+                metrics:
+                  type: object
+                  description: "defines metrics exporter options"
+                  properties:
+                    labels:
+                      type: object
+                      description: "defines metric labels options"
+                      properties:
+                        exclude:
+                          type: array
+                          description: |
+                            When adding labels to a metric exclude labels with names from the following list
+                          items:
+                            type: string
+                status:
+                  type: object
+                  description: "defines status options"
+                  properties:
+                    fields:
+                      type: object
+                      description: "defines status fields options"
+                      properties:
+                        action:
+                          !!merge <<: *TypeStringBool
+                          description: "Whether the operator should fill status field 'action'"
+                        actions:
+                          !!merge <<: *TypeStringBool
+                          description: "Whether the operator should fill status field 'actions'"
+                        error:
+                          !!merge <<: *TypeStringBool
+                          description: "Whether the operator should fill status field 'error'"
+                        errors:
+                          !!merge <<: *TypeStringBool
+                          description: "Whether the operator should fill status field 'errors'"
                 statefulSet:
                   type: object
                   description: "define StatefulSet-specific parameters"

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -575,7 +575,7 @@ clickhouseOperator:
   name: operator
 
   # -- Version of the operator
-  version: 0.21.2
+  version: 0.27.0
 
   # -- Clickhouse Operator image
   image:
@@ -584,7 +584,7 @@ clickhouseOperator:
     # -- Clickhouse Operator image repository to use.
     repository: altinity/clickhouse-operator
     # -- Clickhouse Operator image tag.
-    tag: 0.21.2
+    tag: 0.27.0
     # -- Clickhouse Operator image pull policy.
     pullPolicy: IfNotPresent
 
@@ -752,7 +752,7 @@ clickhouseOperator:
       # -- Metrics Exporter image repository to use.
       repository: altinity/metrics-exporter
       # -- Metrics Exporter image tag.
-      tag: 0.21.2
+      tag: 0.27.0
       # -- Metrics Exporter image pull policy.
       pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Fixes #852

## Summary

Upgrades the bundled ClickHouse Operator from **v0.21.2 → v0.27.0** to fix
container-level `securityContext` being silently dropped during Pod reconciliation.

---

## Problem

Users deploying SigNoz in security-hardened Kubernetes clusters (GKE, EKS, AKS,
OpenShift, Kyverno/Gatekeeper enforced) were unable to enforce Pod Security
Admission `restricted` policy on ClickHouse pods.

The root cause: **ClickHouse Operator v0.21.2 silently drops
`containers[].securityContext`** during reconciliation. Fields explicitly set in
the `ClickHouseInstallation` spec  including `allowPrivilegeEscalation`,
`capabilities`, and `seccompProfile`  are stripped before the Pod is created.

This means even when the Helm chart is correctly configured, the resulting Pod contains:

```yaml
securityContext: null 
```


Kubernetes does not inherit these fields from pod-level securityContext —
they must be set at the container level:

Field | Pod-level | Container-level
-- | -- | --
allowPrivilegeEscalation | ❌ | ✅ Required
capabilities | ❌ | ✅ Required
seccompProfile | ✅ | ✅ Required
privileged | ❌ | ✅ Require

This caused:

Admission failures in PSA restricted clusters
Security/compliance violations in regulated environments
Inability to run ClickHouse as non-root

Root Cause
The SigNoz chart was shipping ClickHouse Operator v0.21.2, released over
3 years ago. This was confirmed by an Altinity maintainer:

```
It is using 0.21.2 operator version that is more than 3 years old.
Please try changing version in the chart." — @alex-zaitsev, Altinity (Operator maintainer)
```

Operator versions v0.25+, v0.26+, and v0.27.0 all correctly propagate
containers[].securityContext into reconciled Pods.


Changes

File | Change
-- | --
charts/clickhouse/values.yaml | clickhouseOperator.version + image tags: 0.21.2 → 0.27.0
crds/clickhouseinstallations.clickhouse.altinity.com.yaml | Updated to v0.27.0 schema
crds/clickhouseinstallationtemplates.clickhouse.altinity.com.yaml | Updated to v0.27.0 schema
crds/clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml | Updated to v0.27.0 schema


How to Verify

```
kubectl get pod <chi-pod-name> -n <namespace> \
  -o jsonpath='{.spec.containers[*].securityContext}'
```

# Before this fix: null
# After this fix:  {"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},...}

Backward Compatibility
1. No behavior change for users not setting container-level securityContext
2.Fully backward compatible — existing deployments unaffected
3.Upstream CRD schemas sourced directly from the official Altinity Helm chart