### PR TITLE
chore(release): bump SigNoz to v0.124.0, OTel Collector to v0.144.4

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: signoz
-version: 0.122.0
-appVersion: "v0.122.0"
+version: 0.124.0
+appVersion: "v0.124.0"
 description: SigNoz Observability Platform Helm Chart
 type: application
 home: https://signoz.io/

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -1,7 +1,7 @@
 
 # SigNoz
 
-![Version: 0.122.0](https://img.shields.io/badge/Version-0.122.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.122.0](https://img.shields.io/badge/AppVersion-v0.122.0-informational?style=flat-square)
+![Version: 0.124.0](https://img.shields.io/badge/Version-0.124.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.124.0](https://img.shields.io/badge/AppVersion-v0.124.0-informational?style=flat-square)
 
 SigNoz is an open-source observability platform native to OpenTelemetry with logs, traces and metrics in a single application. An open-source alternative to DataDog, NewRelic, etc. 🔥 🖥. 👉 Open source Application Performance Monitoring (APM) & Observability tool
 
@@ -355,7 +355,7 @@ verify: false</pre>
                 <div style="max-width: 300px;"><pre lang="yaml">pullPolicy: IfNotPresent
 registry: docker.io
 repository: signoz/signoz
-tag: v0.122.0</pre>
+tag: v0.124.0</pre>
 </div>
             </td>
             <td>Image configuration for SigNoz.</td>

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -765,7 +765,7 @@ signoz:
     repository: signoz/signoz
     # signoz.image.tag - The container image tag.
     # @default -- "v0.110.1"
-    tag: v0.122.0
+    tag: v0.124.0
     # signoz.image.pullPolicy - The image pull policy.
     # @default -- "IfNotPresent"
     pullPolicy: IfNotPresent
@@ -1085,7 +1085,7 @@ otelCollector:
     repository: signoz/signoz-otel-collector
     # otelCollector.image.tag - The container image tag.
     # @default -- "v0.144.0"
-    tag: v0.144.3
+    tag: v0.144.4
     # otelCollector.image.pullPolicy - The image pull policy.
     # @default -- "IfNotPresent"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
### Summary

- Bump SigNoz to `v0.124.0`
- Bump Otel Collector to `v0.144.0`