### PR TITLE
feat(clickhouse): support volumeAttributesClassName on PVC template

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for ClickHouse
 type: application
-version: 24.1.18
+version: 24.1.19
 appVersion: "24.1.2"
 icon: https://github.com/ClickHouse/clickhouse-docs/raw/84f38d893eb7e561c7296279d7953b6a508ec413/static/img/clickhouse-logo.svg
 sources:

--- a/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
+++ b/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
@@ -390,6 +390,9 @@ spec:
           storageClassName: {{ $storageClass }}
         {{- end }}
     {{- end }}
+    {{- if .Values.persistence.volumeAttributesClassName }}
+          volumeAttributesClassName: {{ .Values.persistence.volumeAttributesClassName }}
+    {{- end }}
     {{- end }}
 
   {{- if and (.Values.templates.volumeClaimTemplates) (not .Values.persistence.enabled) }}
@@ -404,5 +407,8 @@ spec:
             requests:
               storage: {{ .resources.requests.storage }}
           storageClassName: {{ .storageClassName }}
+          {{- if .volumeAttributesClassName }}
+          volumeAttributesClassName: {{ .volumeAttributesClassName }}
+          {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -318,6 +318,13 @@ persistence:
   #
   storageClass: null
 
+  # -- VolumeAttributesClass to apply to the data PVC (Kubernetes 1.31+).
+  # When set, renders `volumeAttributesClassName: <name>` on the PVC, allowing
+  # in-place modification of volume parameters (e.g. EBS gp3 IOPS/throughput)
+  # without recreating the underlying volume.
+  #
+  volumeAttributesClassName: null
+
   # -- Access Modes for persistent volume
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
Allow setting `persistence.volumeAttributesClassName` (and a per-template `volumeAttributesClassName` on entries in `templates.volumeClaimTemplates`) so the data PVC can reference a Kubernetes 1.31+ VolumeAttributesClass.

This unlocks in-place modification of volume parameters — most usefully, raising EBS gp3 IOPS and throughput above the baseline 3000 / 125 MiB/s without recreating the volume. Defaults to null, so existing chart users see no rendering change.