### PR TITLE
feat(clickhouse,signoz): expose securityContext for clickhouse-operator and telemetryStoreMigrator containers

### DIFF
--- a/charts/clickhouse/templates/clickhouse-operator/deployment.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/deployment.yaml
@@ -92,6 +92,10 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.clickhouseOperator.resources | nindent 12 }}
+          {{- with .Values.clickhouseOperator.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
 
         - name: metrics-exporter
           image: {{ include "metricsExporter.image" . }}
@@ -117,3 +121,7 @@ spec:
               name: metrics
           resources:
             {{- toYaml .Values.clickhouseOperator.metricsExporter.resources | nindent 12 }}
+          {{- with .Values.clickhouseOperator.metricsExporter.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/clickhouse/tests/clickhouse-operator_securitycontext_test.yaml
+++ b/charts/clickhouse/tests/clickhouse-operator_securitycontext_test.yaml
@@ -1,0 +1,67 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: clickhouse-operator securityContext
+templates:
+  - templates/clickhouse-operator/deployment.yaml
+  - templates/clickhouse-operator/configmaps/etc-files.yaml
+  - templates/clickhouse-operator/configmaps/etc-confd-files.yaml
+  - templates/clickhouse-operator/configmaps/etc-configd-files.yaml
+  - templates/clickhouse-operator/configmaps/etc-templatesd-files.yaml
+  - templates/clickhouse-operator/configmaps/etc-usersd-files.yaml
+release:
+  name: clickhouse
+  namespace: signoz
+tests:
+  - it: should not set securityContext on operator container when not configured
+    template: templates/clickhouse-operator/deployment.yaml
+    documentIndex: 0
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: should not set securityContext on metrics-exporter container when not configured
+    template: templates/clickhouse-operator/deployment.yaml
+    documentIndex: 0
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[1].securityContext
+
+  - it: should set securityContext on operator container when configured
+    template: templates/clickhouse-operator/deployment.yaml
+    documentIndex: 0
+    set:
+      clickhouseOperator.securityContext.allowPrivilegeEscalation: false
+      clickhouseOperator.securityContext.capabilities.drop:
+        - ALL
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+
+  - it: should set securityContext on metrics-exporter container when configured
+    template: templates/clickhouse-operator/deployment.yaml
+    documentIndex: 0
+    set:
+      clickhouseOperator.metricsExporter.securityContext.allowPrivilegeEscalation: false
+      clickhouseOperator.metricsExporter.securityContext.capabilities.drop:
+        - ALL
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.capabilities.drop[0]
+          value: ALL
+
+  - it: should set securityContext independently on each container
+    template: templates/clickhouse-operator/deployment.yaml
+    documentIndex: 0
+    set:
+      clickhouseOperator.securityContext.allowPrivilegeEscalation: false
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].securityContext
+      - notExists:
+          path: spec.template.spec.containers[1].securityContext

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -618,6 +618,13 @@ clickhouseOperator:
   podSecurityContext: {}
     # fsGroup: 2000
 
+  # -- Container-level security context for the operator container.
+  securityContext: {}
+    # allowPrivilegeEscalation: false
+    # capabilities:
+    #   drop:
+    #     - ALL
+
   # Clickhouse Operator secret for ClickHouse user password
   secret:
     # -- Specifies whether a secret should be created
@@ -755,6 +762,13 @@ clickhouseOperator:
       tag: 0.21.2
       # -- Metrics Exporter image pull policy.
       pullPolicy: IfNotPresent
+
+    # -- Container-level security context for the metrics-exporter container.
+    securityContext: {}
+      # allowPrivilegeEscalation: false
+      # capabilities:
+      #   drop:
+      #     - ALL
 
     # -- Additional environment variables for Metrics Exporter container.
     env: []

--- a/charts/signoz/templates/telemetrystore-migrator/job.yaml
+++ b/charts/signoz/templates/telemetrystore-migrator/job.yaml
@@ -52,6 +52,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.telemetryStoreMigrator.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         - name: bootstrap
           image: {{ include "otelCollector.image" . }}
           imagePullPolicy: {{ .Values.otelCollector.image.pullPolicy }}
@@ -62,6 +66,10 @@ spec:
             - "bootstrap"
           {{- with .Values.telemetryStoreMigrator.resources }}
           resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.telemetryStoreMigrator.securityContext }}
+          securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         - name: sync
@@ -77,6 +85,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.telemetryStoreMigrator.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       containers:
         - name: async
           image: {{ include "otelCollector.image" . }}
@@ -89,6 +101,10 @@ spec:
             - "up"
           {{- with .Values.telemetryStoreMigrator.resources }}
           resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.telemetryStoreMigrator.securityContext }}
+          securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       restartPolicy: OnFailure

--- a/charts/signoz/tests/telemetrystore-migrator_securitycontext_test.yaml
+++ b/charts/signoz/tests/telemetrystore-migrator_securitycontext_test.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: telemetryStoreMigrator securityContext
+templates:
+  - templates/telemetrystore-migrator/job.yaml
+release:
+  name: signoz
+  namespace: signoz
+tests:
+  - it: should not set securityContext on any container when not configured
+    set:
+      telemetryStoreMigrator.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers[0].securityContext
+      - notExists:
+          path: spec.template.spec.initContainers[1].securityContext
+      - notExists:
+          path: spec.template.spec.initContainers[2].securityContext
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: should set securityContext on all containers when configured
+    set:
+      telemetryStoreMigrator.enabled: true
+      telemetryStoreMigrator.securityContext.allowPrivilegeEscalation: false
+      telemetryStoreMigrator.securityContext.capabilities.drop:
+        - ALL
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.drop[0]
+          value: ALL
+      - equal:
+          path: spec.template.spec.initContainers[1].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.initContainers[2].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1052,6 +1052,14 @@ telemetryStoreMigrator:
   # @section -- Telemetry Store Migrator
   # @default -- {}
   resources: {}
+  # telemetryStoreMigrator.securityContext -- Container-level security context for all migrator containers.
+  # @section -- Telemetry Store Migrator
+  # @default -- {}
+  securityContext: {}
+    # allowPrivilegeEscalation: false
+    # capabilities:
+    #   drop:
+    #     - ALL
   # telemetryStoreMigrator.serviceAccount -- Service Account configuration for the Telemetry Store Migrator.
   # @section -- Telemetry Store Migrator
   serviceAccount:


### PR DESCRIPTION
### Summary

- Adds `clickhouseOperator.securityContext` and `clickhouseOperator.metricsExporter.securityContext` values, wired into the operator Deployment template
- Adds `telemetryStoreMigrator.securityContext` value, wired into all four containers of the migrator Job (`ready`, `bootstrap`, `sync`, `async`)
- Both default to `{}` — fully backward compatible
- Includes helm-unittest tests for both changes

Closes #875