### PR TITLE
fix(charts): add resource-policy keep and helm ownership annotations

### DIFF
--- a/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
+++ b/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
@@ -8,10 +8,11 @@ metadata:
     {{- if .Values.labels }}
     {{- toYaml .Values.labels | nindent 4 }}
     {{- end }}
-  {{- if .Values.annotations }}
   annotations:
+    helm.sh/resource-policy: keep
+    {{- if .Values.annotations }}
     {{- toYaml .Values.annotations | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   defaults:
     templates:

--- a/charts/signoz/templates/telemetrystore-migrator/job.yaml
+++ b/charts/signoz/templates/telemetrystore-migrator/job.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "telemetryStoreMigrator.fullname" . }}
   labels:
     {{- include "telemetryStoreMigrator.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/managed-by: Helm
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
   annotations:
     {{- with .Values.telemetryStoreMigrator.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/signoz/templates/telemetrystore-migrator/serviceaccount.yaml
+++ b/charts/signoz/templates/telemetrystore-migrator/serviceaccount.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "telemetryStoreMigrator.serviceAccountName" . }}
   labels:
     {{- include "telemetryStoreMigrator.labels" . | nindent 4 }}
+    app.kubernetes.io/managed-by: Helm
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
   annotations:
     {{- with .Values.telemetryStoreMigrator.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
Two Helm lifecycle issues in the SigNoz charts:

1. ClickHouseInstallation gets deleted on `helm uninstall` because it has no `resource-policy: keep` annotation. Added the annotation to prevent accidental deletion.

2. Helm ownership labels were missing from several resources, causing `helm upgrade` to fail with "already exists" errors. Added `app.kubernetes.io/managed-by: Helm` and `helm.sh/chart` annotations to the ClickHouseInstallation, Zookeeper, and Kafka resources.