### PR TITLE
feat(otel-collector): add loadBalancerIP support to service spec

### DIFF
--- a/charts/signoz/templates/otel-collector/service.yaml
+++ b/charts/signoz/templates/otel-collector/service.yaml
@@ -14,6 +14,9 @@ metadata:
 {{- end }}
 spec:
   type: {{ .service.type }}
+  {{- if and (eq .service.type "LoadBalancer") .service.loadBalancerIP }}
+  loadBalancerIP: {{ .service.loadBalancerIP }}
+  {{- end }}
   {{- if and (eq .service.type "LoadBalancer") .service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- range .service.loadBalancerSourceRanges }}

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -1136,6 +1136,9 @@ otelCollector:
     # otelCollector.service.type - The service type (`ClusterIP`, `NodePort`, `LoadBalancer`).
     # @default -- "ClusterIP"
     type: ClusterIP
+    # otelCollector.service.loadBalancerIP - Static IP address to assign to the LoadBalancer (when service type is `LoadBalancer`).
+    # @default -- ""
+    loadBalancerIP: ""
     # otelCollector.service.loadBalancerSourceRanges - Allowed source ranges when service type is `LoadBalancer`.
     # @default -- []
     loadBalancerSourceRanges: []


### PR DESCRIPTION
## Summary

- Adds `otelCollector.service.loadBalancerIP` to the otel-collector service template and `values.yaml`, allowing users to pin a specific IP when the service type is `LoadBalancer`.
- The zookeeper subchart already supports this field; this brings the otel-collector service to parity.

## Motivation

In cross-cluster observability setups (e.g. a kernel cluster sending telemetry to a main cluster's SigNoz collector via an internal LoadBalancer), it's important to be able to assign a predictable static IP to the otel-collector service. Without this field, the Helm chart ignores any `loadBalancerIP` value passed via `--set` or `values.yaml`, and the cloud provider assigns a random IP.

## Changes

- **`charts/signoz/templates/otel-collector/service.yaml`**: Template `spec.loadBalancerIP` when `service.type == "LoadBalancer"` and `service.loadBalancerIP` is set.
- **`charts/signoz/values.yaml`**: Add `otelCollector.service.loadBalancerIP` with default `""`.

## Test plan

- [ ] `helm template` with `otelCollector.service.type=LoadBalancer` and `otelCollector.service.loadBalancerIP=10.0.0.50` — verify `loadBalancerIP: 10.0.0.50` appears in the rendered service spec.
- [ ] `helm template` with default values — verify no `loadBalancerIP` field appears.
- [ ] Deploy to a GKE cluster with an internal LB and confirm the service gets the specified IP.


Made with [Cursor](https://cursor.com)