### PR TITLE
feat(signoz): bump ClickHouse to v25.12.5

### DIFF
--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -63,6 +63,11 @@ kubectl delete namespace platform
 
 > [!WARNING] 
 > ### Breaking Changes
+> #### Version 0.131.0
+> ClickHouse has been upgraded from `25.5.6` to `25.12.5`. This is a significant ClickHouse version jump, so review the upgrade guide before upgrading to avoid issues with your existing data.
+>
+> See the [upgrade guide](https://signoz.io/docs/operate/migration/upgrade-0-131) for details.
+>
 > #### Version 0.116.1
 > Support for legacy environment variable by using following values has been removed from the chart templates and users must migrate any custom templates or values that relied on the legacy env behavior:
 > - `signoz.configVars` has been remove

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -61,7 +61,7 @@ Sometimes everything doesn't get properly removed. If that happens try deleting 
 kubectl delete namespace platform
 ```
 
-> [!WARNING] 
+> [!WARNING]
 > ### Breaking Changes
 > #### Version 0.131.0
 > ClickHouse has been upgraded from `25.5.6` to `25.12.5`. This is a significant ClickHouse version jump, so review the upgrade guide before upgrading to avoid issues with your existing data.

--- a/charts/signoz/README.md.gotmpl
+++ b/charts/signoz/README.md.gotmpl
@@ -61,8 +61,13 @@ Sometimes everything doesn't get properly removed. If that happens try deleting 
 kubectl delete namespace platform
 ```
 
-> [!WARNING]  
+> [!WARNING]
 > ### Breaking Changes
+> #### Version 0.131.0
+> ClickHouse has been upgraded from `25.5.6` to `25.12.5`. This is a significant ClickHouse version jump, so review the upgrade guide before upgrading to avoid issues with your existing data.
+>
+> See the [upgrade guide](https://signoz.io/docs/operate/migration/upgrade-0-131) for details.
+>
 > #### Version 0.116.1
 > Support for legacy environment variable by using following values has been removed from the chart templates and users must migrate any custom templates or values that relied on the legacy env behavior:
 > - `signoz.configVars` has been remove

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -200,8 +200,8 @@ clickhouse:
     repository: clickhouse/clickhouse-server
     # clickhouse.image.tag -- ClickHouse image tag to use. SigNoz is not always tested with the latest version of ClickHouse.
     # Only override if you know what you are doing.
-    # @default -- "25.5.6"
-    tag: 25.5.6
+    # @default -- "25.12.5"
+    tag: 25.12.5
     # clickhouse.image.pullPolicy -- ClickHouse image pull policy.
     # @default -- "IfNotPresent"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
### Summary
- Bumps ClickHouse version to v25.12.5 from v25.5.6
- Links the upgrade guide for the ClickHouse version upgrade

Related: https://github.com/SigNoz/platform-pod/issues/2569