### PR TITLE
chore(release): bump SigNoz to v0.132.2

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: signoz
-version: 0.132.0
-appVersion: "v0.132.0"
+version: 0.132.2
+appVersion: "v0.132.2"
 description: SigNoz Observability Platform Helm Chart
 type: application
 home: https://signoz.io/

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -1,7 +1,7 @@
 
 # SigNoz
 
-![Version: 0.132.0](https://img.shields.io/badge/Version-0.132.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.132.0](https://img.shields.io/badge/AppVersion-v0.132.0-informational?style=flat-square)
+![Version: 0.132.2](https://img.shields.io/badge/Version-0.132.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.132.2](https://img.shields.io/badge/AppVersion-v0.132.2-informational?style=flat-square)
 
 SigNoz is an open-source observability platform native to OpenTelemetry with logs, traces and metrics in a single application. An open-source alternative to DataDog, NewRelic, etc. 🔥 🖥. 👉 Open source Application Performance Monitoring (APM) & Observability tool
 
@@ -360,7 +360,7 @@ verify: false</pre>
                 <div style="max-width: 300px;"><pre lang="yaml">pullPolicy: IfNotPresent
 registry: docker.io
 repository: signoz/signoz
-tag: v0.132.0</pre>
+tag: v0.132.2</pre>
 </div>
             </td>
             <td>Image configuration for SigNoz.</td>

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -765,7 +765,7 @@ signoz:
     repository: signoz/signoz
     # signoz.image.tag - The container image tag.
     # @default -- "v0.110.1"
-    tag: v0.132.0
+    tag: v0.132.2
     # signoz.image.pullPolicy - The image pull policy.
     # @default -- "IfNotPresent"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
### Summary

- Bump `SigNoz` to `v0.132.2`