### PR TITLE
fix(signoz): decouple container ports from service ports

### DIFF
--- a/charts/signoz/Chart.yaml
+++ b/charts/signoz/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: signoz
-version: 0.135.1
+version: 0.135.2
 appVersion: "v0.135.1"
 description: SigNoz Observability Platform Helm Chart
 type: application

--- a/charts/signoz/README.md
+++ b/charts/signoz/README.md
@@ -1,7 +1,7 @@
 
 # SigNoz
 
-![Version: 0.135.1](https://img.shields.io/badge/Version-0.135.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.135.1](https://img.shields.io/badge/AppVersion-v0.135.1-informational?style=flat-square)
+![Version: 0.135.2](https://img.shields.io/badge/Version-0.135.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.135.1](https://img.shields.io/badge/AppVersion-v0.135.1-informational?style=flat-square)
 
 SigNoz is an open-source observability platform native to OpenTelemetry with logs, traces and metrics in a single application. An open-source alternative to DataDog, NewRelic, etc. 🔥 🖥. 👉 Open source Application Performance Monitoring (APM) & Observability tool
 

--- a/charts/signoz/templates/otel-collector/configmap.yaml
+++ b/charts/signoz/templates/otel-collector/configmap.yaml
@@ -8,4 +8,4 @@ data:
   otel-collector-config.yaml: |-
     {{- toYaml .Values.otelCollector.config | nindent 4 }}
   otel-collector-opamp-config.yaml: |-
-    server_endpoint: "ws://{{ include "signoz.fullname" . }}:4320/v1/opamp"
+    server_endpoint: "ws://{{ include "signoz.fullname" . }}:{{ default 4320 .Values.signoz.service.opampPort }}/v1/opamp"

--- a/charts/signoz/templates/signoz/statefulset.yaml
+++ b/charts/signoz/templates/signoz/statefulset.yaml
@@ -60,14 +60,15 @@ spec:
             - {{ . | quote }}
             {{- end }}
           ports:
+            {{- /* SigNoz listens on fixed ports. The service ports are resolved by name. */}}
             - name: http
-              containerPort: {{ default 8080  .Values.signoz.service.port }}
+              containerPort: 8080
               protocol: TCP
             - name: http-internal
-              containerPort: {{ default 8085 .Values.signoz.service.internalPort }}
+              containerPort: 8085
               protocol: TCP
             - name: opamp-internal
-              containerPort: {{ default 4320 .Values.signoz.service.opampPort }}
+              containerPort: 4320
               protocol: TCP
           env:
             {{- include "snippet.clickhouse-credentials" . | nindent 12 }}

--- a/charts/signoz/tests/signoz-service_port_test.yaml
+++ b/charts/signoz/tests/signoz-service_port_test.yaml
@@ -1,0 +1,99 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Test SigNoz service ports are independent of the container ports
+
+templates:
+  - templates/signoz/statefulset.yaml
+  - templates/signoz/service.yaml
+  - templates/otel-collector/configmap.yaml
+
+release:
+  name: signoz
+  namespace: signoz
+
+tests:
+  - it: should render the default container ports on the SigNoz statefulset
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0]
+          value:
+            name: http
+            containerPort: 8080
+            protocol: TCP
+        template: templates/signoz/statefulset.yaml
+      - equal:
+          path: spec.template.spec.containers[0].ports[1]
+          value:
+            name: http-internal
+            containerPort: 8085
+            protocol: TCP
+        template: templates/signoz/statefulset.yaml
+      - equal:
+          path: spec.template.spec.containers[0].ports[2]
+          value:
+            name: opamp-internal
+            containerPort: 4320
+            protocol: TCP
+        template: templates/signoz/statefulset.yaml
+
+  - it: should target the container ports by name from the SigNoz service
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+        template: templates/signoz/service.yaml
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http
+        template: templates/signoz/service.yaml
+
+  - it: should keep the container port at 8080 when signoz.service.port is overridden
+    set:
+      signoz:
+        service:
+          port: 80
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8080
+        template: templates/signoz/statefulset.yaml
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+        template: templates/signoz/service.yaml
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http
+        template: templates/signoz/service.yaml
+
+  - it: should keep the container port at 4320 when signoz.service.opampPort is overridden
+    set:
+      signoz:
+        service:
+          opampPort: 4321
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[2].containerPort
+          value: 4320
+        template: templates/signoz/statefulset.yaml
+      - equal:
+          path: spec.ports[2].port
+          value: 4321
+        template: templates/signoz/service.yaml
+
+  - it: should point the Otel Collector OpAMP endpoint at the configured signoz.service.opampPort
+    asserts:
+      - matchRegex:
+          path: data["otel-collector-opamp-config.yaml"]
+          pattern: 'ws://signoz:4320/v1/opamp'
+        template: templates/otel-collector/configmap.yaml
+
+  - it: should follow signoz.service.opampPort in the Otel Collector OpAMP endpoint
+    set:
+      signoz:
+        service:
+          opampPort: 4321
+    asserts:
+      - matchRegex:
+          path: data["otel-collector-opamp-config.yaml"]
+          pattern: 'ws://signoz:4321/v1/opamp'
+        template: templates/otel-collector/configmap.yaml

--- a/charts/signoz/values.yaml
+++ b/charts/signoz/values.yaml
@@ -799,13 +799,13 @@ signoz:
     # signoz.service.type - The service type (`ClusterIP`, `NodePort`, `LoadBalancer`).
     # @default -- "ClusterIP"
     type: ClusterIP
-    # signoz.service.port - The external HTTP port for SigNoz.
+    # signoz.service.port - The external HTTP port for SigNoz. The container always listens on 8080.
     # @default -- 8080
     port: 8080
-    # signoz.service.internalPort - The internal gRPC port for SigNoz.
+    # signoz.service.internalPort - The internal gRPC port for SigNoz. The container always listens on 8085.
     # @default -- 8085
     internalPort: 8085
-    # signoz.service.opampPort - The internal OpAMP port for SigNoz.
+    # signoz.service.opampPort - The internal OpAMP port for SigNoz. The container always listens on 4320.
     # @default -- 4320
     opampPort: 4320
     # signoz.service.nodePort - Manually specify the nodePort for HTTP when `service.type` is `NodePort`.


### PR DESCRIPTION
### Problem

A basic install that sets `signoz.service.port` to anything other than the default puts `signoz-0` into `CrashLoopBackOff`, even though the container logs show the process starting cleanly. Reported in #762 with `signoz.service.port: 80` for a LoadBalancer service.

The statefulset derived its container ports from the service port values:

```yaml
ports:
  - name: http
    containerPort: {{ default 8080  .Values.signoz.service.port }}
```

but SigNoz always listens on 8080, 8085 and 4320 inside the container, and the chart has no way to change that. So `signoz.service.port: 80` only renamed the port the container declares, it did not move the listener:

- `signoz.livenessProbe.port` and `readinessProbe.port` default to the **named** port `http`, which now resolved to 80. Nothing was bound there, so the liveness probe failed and restarted the container in a loop.
- `Service.targetPort: http` resolves by name too, so even with probes disabled the Service routed to a dead port.

The chart already assumes the fixed in-container ports in two other places, which is what made this inconsistent rather than intentional: `signoz_alertmanager_signoz_external__url: http://localhost:8080` in `values.yaml`, and the hardcoded `:4320` in the collector's OpAMP config. `otelCollector.ports` already models this properly with separate `containerPort` and `servicePort` per entry.

### Changes

- `templates/signoz/statefulset.yaml`: pin the container ports to 8080 / 8085 / 4320, so `signoz.service.*Port` now describes the Service only. Named-port resolution then does the right thing for both the probes and `targetPort`.
- `templates/otel-collector/configmap.yaml`: the OpAMP `server_endpoint` dials the SigNoz **Service**, so it should follow `signoz.service.opampPort` instead of hardcoding 4320. Without this, changing `opampPort` moves the Service port and leaves the collector dialling 4320. Happy to drop this one if you would rather keep it separate.
- `values.yaml`: note on each of the three `signoz.service.*Port` keys that the container port is fixed.
- Bumped the chart to 0.135.2 and regenerated the README.

No new values keys: since the chart cannot change what the process binds to, a container-port knob would only be misleading. Let me know if you would prefer one anyway.

### Testing

- Added `tests/signoz-service_port_test.yaml`. The three regression cases fail on `main` and pass here; `helm unittest charts/signoz` is 4 suites / 18 tests green.
- `helm template charts/signoz` on default values is byte-identical to `main` apart from the version label and the config checksum that label feeds into.
- `helm template charts/signoz --set signoz.service.port=80` now renders `containerPort: 8080` with Service `port: 80` and `targetPort: http`.
- `helm template charts/signoz --set signoz.service.opampPort=4321` renders `ws://<release>-signoz:4321/v1/opamp`.
- `helm lint --strict charts/signoz` passes, and `make chart-docs CHARTS=charts/signoz,charts/k8s-infra` is clean after the commit.

Closes #762