### PR TITLE
feat(clickhouse): make operator configs customizable

### DIFF
--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-confd-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-confd-files.yaml
@@ -1,3 +1,4 @@
+{{- $files := dig "configs" "confdFiles" nil .Values.clickhouseOperator -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,4 +6,9 @@ metadata:
   namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "clickhouseOperator.labels" . | nindent 4 }}
-data: {{ tpl (toYaml .Values.clickhouseOperator.configs.confdFiles) . | nindent 2 }}
+data: {{- if $files }}
+{{- range $name, $contents := $files }}
+  {{ $name }}: {{ tpl ($contents | toString) $ | toYaml | nindent 4 }}
+{{- end }}
+{{- else }} {{ tpl (toYaml $files) . | nindent 2 }}
+{{- end }}

--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-confd-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-confd-files.yaml
@@ -6,8 +6,11 @@ metadata:
   namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
     {{- include "clickhouseOperator.labels" . | nindent 4 }}
-data: {{- if $files }}
+data: {{- if ne $files nil }}
 {{- range $name, $contents := $files }}
+{{- if not (kindIs "string" $contents) }}
+{{- fail (printf "clickhouseOperator.configs.confdFiles.%s must be a string" $name) }}
+{{- end }}
   {{ $name }}: {{ tpl ($contents | toString) $ | toYaml | nindent 4 }}
 {{- end }}
 {{- else }} {{ tpl (toYaml $files) . | nindent 2 }}

--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-configd-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-configd-files.yaml
@@ -1,3 +1,4 @@
+{{- $files := dig "configs" "configdFiles" nil .Values.clickhouseOperator -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,8 +7,10 @@ metadata:
   labels:
     {{- include "clickhouseOperator.labels" . | nindent 4 }}
 data:
-{{- if .Values.clickhouseOperator.configs.configdFiles }}
-{{ tpl (toYaml .Values.clickhouseOperator.configs.configdFiles) . | nindent 2 }}
+{{- if $files }}
+{{- range $name, $contents := $files }}
+  {{ $name }}: {{ tpl ($contents | toString) $ | toYaml | nindent 4 }}
+{{- end }}
 {{- else }}
   01-clickhouse-01-listen.xml: |
     <yandex>
@@ -161,4 +164,4 @@ data:
             <flush_interval_milliseconds>{{ .Values.clickhouseOperator.processorsProfileLog.flushInterval }}</flush_interval_milliseconds>
         </processors_profile_log>
     </yandex>
-{{- end }}
+{{ end }}

--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-configd-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-configd-files.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "clickhouseOperator.labels" . | nindent 4 }}
 data:
+{{- if .Values.clickhouseOperator.configs.configdFiles }}
+{{ tpl (toYaml .Values.clickhouseOperator.configs.configdFiles) . | nindent 2 }}
+{{- else }}
   01-clickhouse-01-listen.xml: |
     <yandex>
         <!-- Listen wildcard address to allow accepting connections from other containers and host network. -->
@@ -158,4 +161,4 @@ data:
             <flush_interval_milliseconds>{{ .Values.clickhouseOperator.processorsProfileLog.flushInterval }}</flush_interval_milliseconds>
         </processors_profile_log>
     </yandex>
-
+{{- end }}

--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-configd-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-configd-files.yaml
@@ -7,8 +7,11 @@ metadata:
   labels:
     {{- include "clickhouseOperator.labels" . | nindent 4 }}
 data:
-{{- if $files }}
+{{- if ne $files nil }}
 {{- range $name, $contents := $files }}
+{{- if not (kindIs "string" $contents) }}
+{{- fail (printf "clickhouseOperator.configs.configdFiles.%s must be a string" $name) }}
+{{- end }}
   {{ $name }}: {{ tpl ($contents | toString) $ | toYaml | nindent 4 }}
 {{- end }}
 {{- else }}

--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-files.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "clickhouseOperator.labels" . | nindent 4 }}
 data:
+{{- if .Values.clickhouseOperator.configs.etcFiles }}
+{{ tpl (toYaml .Values.clickhouseOperator.configs.etcFiles) . | nindent 2 }}
+{{- else }}
   config.yaml: |
       #
       # Template parameters available:
@@ -286,3 +289,4 @@ data:
         stderrthreshold: ""
         vmodule: ""
         log_backtrace_at: ""
+{{- end }}

--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-files.yaml
@@ -7,8 +7,11 @@ metadata:
   labels:
     {{- include "clickhouseOperator.labels" . | nindent 4 }}
 data:
-{{- if $files }}
+{{- if ne $files nil }}
 {{- range $name, $contents := $files }}
+{{- if not (kindIs "string" $contents) }}
+{{- fail (printf "clickhouseOperator.configs.etcFiles.%s must be a string" $name) }}
+{{- end }}
   {{ $name }}: {{ tpl ($contents | toString) $ | toYaml | nindent 4 }}
 {{- end }}
 {{- else }}

--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-files.yaml
@@ -1,3 +1,4 @@
+{{- $files := dig "configs" "etcFiles" nil .Values.clickhouseOperator -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,8 +7,10 @@ metadata:
   labels:
     {{- include "clickhouseOperator.labels" . | nindent 4 }}
 data:
-{{- if .Values.clickhouseOperator.configs.etcFiles }}
-{{ tpl (toYaml .Values.clickhouseOperator.configs.etcFiles) . | nindent 2 }}
+{{- if $files }}
+{{- range $name, $contents := $files }}
+  {{ $name }}: {{ tpl ($contents | toString) $ | toYaml | nindent 4 }}
+{{- end }}
 {{- else }}
   config.yaml: |
       #

--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-templatesd-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-templatesd-files.yaml
@@ -1,3 +1,4 @@
+{{- $files := dig "configs" "templatesdFiles" nil .Values.clickhouseOperator -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,8 +7,10 @@ metadata:
   labels:
     {{- include "clickhouseOperator.labels" . | nindent 4 }}
 data:
-{{- if .Values.clickhouseOperator.configs.templatesdFiles }}
-{{ tpl (toYaml .Values.clickhouseOperator.configs.templatesdFiles) . | nindent 2 }}
+{{- if $files }}
+{{- range $name, $contents := $files }}
+  {{ $name }}: {{ tpl ($contents | toString) $ | toYaml | nindent 4 }}
+{{- end }}
 {{- else }}
   001-templates.json.example: |
     {

--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-templatesd-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-templatesd-files.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "clickhouseOperator.labels" . | nindent 4 }}
 data:
+{{- if .Values.clickhouseOperator.configs.templatesdFiles }}
+{{ tpl (toYaml .Values.clickhouseOperator.configs.templatesdFiles) . | nindent 2 }}
+{{- else }}
   001-templates.json.example: |
     {
       "apiVersion": "clickhouse.altinity.com/v1",
@@ -88,3 +91,4 @@ data:
                   storage: 2Gi
   readme: |-
     Templates in this folder are packaged with an operator and available via 'useTemplate'
+{{- end }}

--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-templatesd-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-templatesd-files.yaml
@@ -7,8 +7,11 @@ metadata:
   labels:
     {{- include "clickhouseOperator.labels" . | nindent 4 }}
 data:
-{{- if $files }}
+{{- if ne $files nil }}
 {{- range $name, $contents := $files }}
+{{- if not (kindIs "string" $contents) }}
+{{- fail (printf "clickhouseOperator.configs.templatesdFiles.%s must be a string" $name) }}
+{{- end }}
   {{ $name }}: {{ tpl ($contents | toString) $ | toYaml | nindent 4 }}
 {{- end }}
 {{- else }}

--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-usersd-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-usersd-files.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "clickhouseOperator.labels" . | nindent 4 }}
 data:
+{{- if .Values.clickhouseOperator.configs.usersdFiles }}
+{{ tpl (toYaml .Values.clickhouseOperator.configs.usersdFiles) . | nindent 2 }}
+{{- else }}
   01-clickhouse-user.xml: |
     <yandex>
         <users>
@@ -45,3 +48,4 @@ data:
             </default>
         </profiles>
     </yandex>
+{{- end }}

--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-usersd-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-usersd-files.yaml
@@ -1,3 +1,4 @@
+{{- $files := dig "configs" "usersdFiles" nil .Values.clickhouseOperator -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,8 +7,10 @@ metadata:
   labels:
     {{- include "clickhouseOperator.labels" . | nindent 4 }}
 data:
-{{- if .Values.clickhouseOperator.configs.usersdFiles }}
-{{ tpl (toYaml .Values.clickhouseOperator.configs.usersdFiles) . | nindent 2 }}
+{{- if $files }}
+{{- range $name, $contents := $files }}
+  {{ $name }}: {{ tpl ($contents | toString) $ | toYaml | nindent 4 }}
+{{- end }}
 {{- else }}
   01-clickhouse-user.xml: |
     <yandex>

--- a/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-usersd-files.yaml
+++ b/charts/clickhouse/templates/clickhouse-operator/configmaps/etc-usersd-files.yaml
@@ -7,8 +7,11 @@ metadata:
   labels:
     {{- include "clickhouseOperator.labels" . | nindent 4 }}
 data:
-{{- if $files }}
+{{- if ne $files nil }}
 {{- range $name, $contents := $files }}
+{{- if not (kindIs "string" $contents) }}
+{{- fail (printf "clickhouseOperator.configs.usersdFiles.%s must be a string" $name) }}
+{{- end }}
   {{ $name }}: {{ tpl ($contents | toString) $ | toYaml | nindent 4 }}
 {{- end }}
 {{- else }}

--- a/charts/clickhouse/tests/clickhouse-operator_configs_test.yaml
+++ b/charts/clickhouse/tests/clickhouse-operator_configs_test.yaml
@@ -67,3 +67,15 @@ tests:
               <users password="quoted: value"/>
             </clickhouse>
         template: templates/clickhouse-operator/configmaps/etc-usersd-files.yaml
+
+  - it: should preserve defaults when the configs map is null
+    set:
+      clickhouseOperator:
+        configs: null
+    asserts:
+      - isNotNull:
+          path: data["config.yaml"]
+        template: templates/clickhouse-operator/configmaps/etc-files.yaml
+      - isNotNull:
+          path: data["01-clickhouse-user.xml"]
+        template: templates/clickhouse-operator/configmaps/etc-usersd-files.yaml

--- a/charts/clickhouse/tests/clickhouse-operator_configs_test.yaml
+++ b/charts/clickhouse/tests/clickhouse-operator_configs_test.yaml
@@ -10,6 +10,21 @@ release:
   name: clickhouse
   namespace: signoz
 tests:
+  - it: should preserve default operator configuration files
+    asserts:
+      - isNotNull:
+          path: data["config.yaml"]
+        template: templates/clickhouse-operator/configmaps/etc-files.yaml
+      - isNotNull:
+          path: data["01-clickhouse-01-listen.xml"]
+        template: templates/clickhouse-operator/configmaps/etc-configd-files.yaml
+      - isNotNull:
+          path: data["001-templates.json.example"]
+        template: templates/clickhouse-operator/configmaps/etc-templatesd-files.yaml
+      - isNotNull:
+          path: data["01-clickhouse-user.xml"]
+        template: templates/clickhouse-operator/configmaps/etc-usersd-files.yaml
+
   - it: should render custom operator configuration files
     set:
       clickhouseOperator:
@@ -23,7 +38,11 @@ tests:
           templatesdFiles:
             custom-template.yaml: "apiVersion: clickhouse.altinity.com/v1"
           usersdFiles:
-            custom-users.xml: "<clickhouse><users/></clickhouse>"
+            custom-users.xml: "{{ .Values.customUsers }}"
+      customUsers: |-
+        <clickhouse>
+          <users password="quoted: value"/>
+        </clickhouse>
     asserts:
       - equal:
           path: data["config.yaml"]
@@ -43,5 +62,8 @@ tests:
         template: templates/clickhouse-operator/configmaps/etc-templatesd-files.yaml
       - equal:
           path: data["custom-users.xml"]
-          value: "<clickhouse><users/></clickhouse>"
+          value: |-
+            <clickhouse>
+              <users password="quoted: value"/>
+            </clickhouse>
         template: templates/clickhouse-operator/configmaps/etc-usersd-files.yaml

--- a/charts/clickhouse/tests/clickhouse-operator_configs_test.yaml
+++ b/charts/clickhouse/tests/clickhouse-operator_configs_test.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: clickhouse-operator_configs_test.yaml
+templates:
+  - templates/clickhouse-operator/configmaps/etc-files.yaml
+  - templates/clickhouse-operator/configmaps/etc-confd-files.yaml
+  - templates/clickhouse-operator/configmaps/etc-configd-files.yaml
+  - templates/clickhouse-operator/configmaps/etc-templatesd-files.yaml
+  - templates/clickhouse-operator/configmaps/etc-usersd-files.yaml
+release:
+  name: clickhouse
+  namespace: signoz
+tests:
+  - it: should render custom operator configuration files
+    set:
+      clickhouseOperator:
+        configs:
+          etcFiles:
+            config.yaml: "watch: {namespaces: [{{ .Release.Namespace }}]}"
+          confdFiles:
+            custom-host.xml: "<clickhouse><listen_host>127.0.0.1</listen_host></clickhouse>"
+          configdFiles:
+            custom-common.xml: "<clickhouse><listen_host>0.0.0.0</listen_host></clickhouse>"
+          templatesdFiles:
+            custom-template.yaml: "apiVersion: clickhouse.altinity.com/v1"
+          usersdFiles:
+            custom-users.xml: "<clickhouse><users/></clickhouse>"
+    asserts:
+      - equal:
+          path: data["config.yaml"]
+          value: "watch: {namespaces: [signoz]}"
+        template: templates/clickhouse-operator/configmaps/etc-files.yaml
+      - equal:
+          path: data["custom-host.xml"]
+          value: "<clickhouse><listen_host>127.0.0.1</listen_host></clickhouse>"
+        template: templates/clickhouse-operator/configmaps/etc-confd-files.yaml
+      - equal:
+          path: data["custom-common.xml"]
+          value: "<clickhouse><listen_host>0.0.0.0</listen_host></clickhouse>"
+        template: templates/clickhouse-operator/configmaps/etc-configd-files.yaml
+      - equal:
+          path: data["custom-template.yaml"]
+          value: "apiVersion: clickhouse.altinity.com/v1"
+        template: templates/clickhouse-operator/configmaps/etc-templatesd-files.yaml
+      - equal:
+          path: data["custom-users.xml"]
+          value: "<clickhouse><users/></clickhouse>"
+        template: templates/clickhouse-operator/configmaps/etc-usersd-files.yaml

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -763,8 +763,16 @@ clickhouseOperator:
 
   # ClickHouse Operator configuration files
   configs:
+    # -- Replaces the default ClickHouse Operator root configuration files when set
+    etcFiles: null
     # -- ClickHouse Operator confd files
     confdFiles: null
+    # -- Replaces the default ClickHouse common configuration files when set
+    configdFiles: null
+    # -- Replaces the default ClickHouse installation template files when set
+    templatesdFiles: null
+    # -- Replaces the default ClickHouse user configuration files when set
+    usersdFiles: null
 
   serviceMonitor:
     # serviceMonitor.enabled -- ServiceMonitor Custom resource is created for a [prometheus-operator](https://github.com/prometheus-operator/prometheus-operator)

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -765,7 +765,7 @@ clickhouseOperator:
   configs:
     # -- Replaces the default ClickHouse Operator root configuration files when set
     etcFiles: null
-    # -- Replaces the ClickHouse Operator confd files when set
+    # -- Adds ClickHouse Operator confd files when set
     confdFiles: null
     # -- Replaces the default ClickHouse common configuration files when set
     configdFiles: null

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -765,7 +765,7 @@ clickhouseOperator:
   configs:
     # -- Replaces the default ClickHouse Operator root configuration files when set
     etcFiles: null
-    # -- ClickHouse Operator confd files
+    # -- Replaces the ClickHouse Operator confd files when set
     confdFiles: null
     # -- Replaces the default ClickHouse common configuration files when set
     configdFiles: null


### PR DESCRIPTION
## Summary

- allow replacing all five ClickHouse Operator configuration file maps through values
- preserve byte-identical default rendering when overrides are unset
- render each custom file before YAML serialization and reject non-string values clearly
- handle `clickhouseOperator.configs: null` safely
- add focused Helm unittest coverage

## Testing

- `helm lint charts/clickhouse`
- full default render compared byte-for-byte with `origin/main`
- full custom render with all five ConfigMaps parsed and checked for exact round-trip values
- null-config render succeeds
- structured/non-string input fails with the expected validation error
- independent adversarial Claude review: APPROVE

Authored with Codex and independently adversarially reviewed with Claude.

Fixes #575