### PR TITLE
fix(k8s-infra): grant persistentvolumes to otel-agent ClusterRole

### DIFF
--- a/charts/k8s-infra/values.yaml
+++ b/charts/k8s-infra/values.yaml
@@ -694,7 +694,7 @@ otelAgent:
     rules:
       # k8sattributes processor requires these permissions
       - apiGroups: [""]
-        resources: ["pods", "namespaces", "nodes", "persistentvolumeclaims"]
+        resources: ["pods", "namespaces", "nodes", "persistentvolumeclaims", "persistentvolumes"]
         verbs: ["get", "list", "watch"]
       - apiGroups: ["apps"]
         resources: ["replicasets"]


### PR DESCRIPTION
## What

Add `persistentvolumes` to the otel-agent ClusterRole rules.

## Why

Since #889 (released in k8s-infra 0.17.0), the kubeletstats receiver is configured with `k8s_api_config: {auth_type: serviceAccount}`. With API access configured, the receiver collects detailed PVC labels: it follows each PersistentVolumeClaim to its bound PersistentVolume to resolve the underlying volume type. When that lookup fails, the receiver skips metric collection for the volume entirely.

The ClusterRole grants `persistentvolumeclaims` but not `persistentvolumes`, so the PV lookup is forbidden and **all `k8s.volume.*` metrics for PVC-backed volumes are dropped** after upgrading to 0.17.0. The otel-agent logs the following for every PVC-backed volume on every scrape:

```
Failed to gather additional volume metadata. Skipping metric collection.
failed to set extra labels from metadata: failed to set labels from volume claim:
persistentvolumes "pvc-97589824-bdcb-48ee-8957-ff49e8959bd0" is forbidden:
User "system:serviceaccount:observability:signoz-k8s-infra-otel-agent"
cannot get resource "persistentvolumes" in API group "" at the cluster scope
```

Ref: the receiver's detailed PVC labels setter calls `GetPersistentVolume` ([kubeletstatsreceiver metadata](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kubeletstatsreceiver/internal/metadata/metadata.go)).


