### PR TITLE
feat(clickhouse): make udf init container download url and credentials configurable

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clickhouse
 description: A Helm chart for ClickHouse
 type: application
-version: 24.1.18
+version: 24.1.19
 appVersion: "24.1.2"
 icon: https://github.com/ClickHouse/clickhouse-docs/raw/84f38d893eb7e561c7296279d7953b6a508ec413/static/img/clickhouse-logo.svg
 sources:

--- a/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
+++ b/charts/clickhouse/templates/clickhouse-instance/clickhouse-instance.yaml
@@ -197,8 +197,33 @@ spec:
             - name: {{ include "clickhouse.fullname" . }}-udf-init
               image: {{ include "clickhouse.initContainers.udf.image" . }}
               imagePullPolicy: {{ .Values.initContainers.udf.image.pullPolicy }}
+              {{- if .Values.initContainers.udf.env }}
+              env:
+                {{- toYaml .Values.initContainers.udf.env | nindent 16 }}
+              {{- end }}
+              {{- if .Values.initContainers.udf.envFrom }}
+              envFrom:
+                {{- toYaml .Values.initContainers.udf.envFrom | nindent 16 }}
+              {{- end }}
               command:
+                {{- if .Values.initContainers.udf.command }}
                 {{- toYaml .Values.initContainers.udf.command | nindent 16 }}
+                {{- else }}
+                - sh
+                - -c
+                - |
+                  set -e
+                  version="{{ .Values.initContainers.udf.version }}"
+                  node_os=$(uname -s | tr '[:upper:]' '[:lower:]')
+                  node_arch=$(uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)
+                  echo "Fetching histogram-binary for ${node_os}/${node_arch}"
+                  cd /tmp
+                  wget -O histogram-quantile.tar.gz "{{ .Values.initContainers.udf.downloadUrl }}"
+                  tar -xzf histogram-quantile.tar.gz
+                  chmod +x histogram-quantile
+                  mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
+                  echo "histogram-quantile installed successfully"
+                {{- end }}
               volumeMounts:
                 - name: shared-binary-volume
                   mountPath: /var/lib/clickhouse/user_scripts

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -352,21 +352,23 @@ initContainers:
       repository: alpine
       tag: 3.18.2
       pullPolicy: IfNotPresent
-    command:
-      - sh
-      - -c
-      - |
-        set -e
-        version="v0.0.1"
-        node_os=$(uname -s | tr '[:upper:]' '[:lower:]')
-        node_arch=$(uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)
-        echo "Fetching histogram-binary for ${node_os}/${node_arch}"
-        cd /tmp
-        wget -O histogram-quantile.tar.gz "https://github.com/SigNoz/signoz/releases/download/histogram-quantile%2F${version}/histogram-quantile_${node_os}_${node_arch}.tar.gz"
-        tar -xzf histogram-quantile.tar.gz
-        chmod +x histogram-quantile
-        mv histogram-quantile /var/lib/clickhouse/user_scripts/histogramQuantile
-        echo "histogram-quantile installed successfully"
+    # -- Version of the histogram-quantile release to fetch. Only used when `command` is not set.
+    version: v0.0.1
+    # -- URL template used to download the histogram-quantile release tarball. Evaluated inside
+    # the init container's shell, so `${version}`/`${node_os}`/`${node_arch}` are shell variables,
+    # not Helm template variables - keep them verbatim if you override this. Override to point at
+    # an internal mirror in network-restricted environments. Only used when `command` is not set.
+    downloadUrl: "https://github.com/SigNoz/signoz/releases/download/histogram-quantile%2F${version}/histogram-quantile_${node_os}_${node_arch}.tar.gz"
+    # -- Full override of the udf init container's command. Takes precedence over
+    # `version`/`downloadUrl` when set - use this for full control (e.g. fetching a
+    # pre-extracted binary, or a different tool entirely).
+    command: []
+    # -- Extra environment variables for the udf init container, e.g. credentials for an
+    # authenticated internal mirror, for use by a `command` override.
+    env: []
+    # -- envFrom for the udf init container, e.g. a Secret holding mirror credentials, for use
+    # by a `command` override.
+    envFrom: []
   init:
     enabled: false
     image:


### PR DESCRIPTION
#### Features

- Adds `initContainers.udf.version` and `initContainers.udf.downloadUrl` values, so the
  histogram-quantile binary's source can be pointed at an internal mirror without having to
  override the entire `initContainers.udf.command` shell script.
- Adds `initContainers.udf.env` and `initContainers.udf.envFrom`, so a `command` override can
  authenticate to a private/internal mirror (e.g. via a Secret-backed credential) without any
  other chart changes.

Today, `initContainers.udf.command` is the only override (#431), and there's no way to
inject credentials into this init container at all. That means anyone running in a
network-restricted environment with an *authenticated* internal mirror
(SigNoz/signoz#7047, SigNoz/signoz#8143) can't solve this with values alone today - they need a
full command override plus some way to get a credential in, and the chart provides neither the
env hook nor a documented alternative.

This keeps the default behavior byte-for-byte identical (all new values are opt-in / no-op by
default), and existing `command` overrides continue to work unchanged (`downloadUrl`/`version`
are only used when `command` is unset; `env`/`envFrom` render only when set).

Related: SigNoz/signoz#9256 proposes a longer-term native-function replacement that would remove
this dependency altogether - this PR doesn't block or duplicate that, just makes the interim
situation workable for restricted-network installs that need authenticated mirrors, not just
alternate unauthenticated URLs.