### PR TITLE
feat(signoz-operator): publish chart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,14 +33,6 @@ jobs:
           helm repo add signoz https://charts.signoz.io
           helm repo add redpanda https://charts.redpanda.com
 
-      # chart-releaser packages every directory under charts/ that has a
-      # Chart.yaml and offers no exclude list, so charts that are not ready to
-      # publish are dropped from the working tree first. signoz-operator ships
-      # no CRDs yet and signoz/signoz-operator has no image behind its
-      # appVersion. Remove the chart from this list to start publishing it.
-      - name: Hold unpublished charts
-        run: rm -rf charts/signoz-operator
-
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         env:

--- a/ct.yaml
+++ b/ct.yaml
@@ -7,6 +7,7 @@ charts:
   - charts/k8s-infra
   - charts/signoz
   - charts/postgresql
+  - charts/signoz-operator
 check-version-increment: false
 helm-extra-args: --timeout 5m
 chart-repos:


### PR DESCRIPTION
## Summary

The `signoz-operator` chart is ready to publish, so this drops the two things that were holding it back:

- **`.github/workflows/release.yaml`** — removes the `Hold unpublished charts` step that `rm -rf`'d `charts/signoz-operator` before chart-releaser ran. chart-releaser packages every directory under `charts/` with a `Chart.yaml` and offers no exclude list, so deleting it from the working tree was the only way to keep it unpublished.
- **`ct.yaml`** — adds `charts/signoz-operator` to the `charts` list so chart-testing lints and installs it in CI.

## Test plan

- CI `lint-test` job now covers `charts/signoz-operator`
- On merge, chart-releaser packages and publishes `signoz-operator-0.1.0`